### PR TITLE
feat(llc): Add eagerError to uploadBatch

### DIFF
--- a/packages/stream_core/lib/src/utils/list_extensions.dart
+++ b/packages/stream_core/lib/src/utils/list_extensions.dart
@@ -222,7 +222,7 @@ extension SortedListExtensions<T extends Object> on List<T> {
   /// // Result: [Score(userId: '1', points: 150), Score(userId: '3', points: 120), Score(userId: '2', points: 80)]
   /// ```
   List<T> merge<K>(
-    List<T> other, {
+    Iterable<T> other, {
     required K Function(T item) key,
     T Function(T original, T updated)? update,
     Comparator<T>? compare,


### PR DESCRIPTION
This commit introduces an `eagerError` parameter to the `uploadBatch` method in `AttachmentUploader`.

When `eagerError` is true, the upload stream will throw an exception and close immediately upon the first failed upload. If `eagerError` is false (the default behavior), failed uploads will be emitted as `Result.failure` and the upload process will continue for the remaining attachments.

Additionally, the `attachments` parameter in `uploadBatch` has been changed from `List<StreamAttachment>` to `Iterable<StreamAttachment>` for better flexibility. A similar change was made to the `merge` extension method.