### PR TITLE
refactor(llc)!: Enhance WebSocket connection management and lifecycle handling

### DIFF
--- a/packages/stream_core/CHANGELOG.md
+++ b/packages/stream_core/CHANGELOG.md
@@ -1,3 +1,20 @@
+## Unreleased
+
+### 💥 BREAKING CHANGES
+
+- Renamed `AppLifecycleStateProvider` to `LifecycleStateProvider` and `AppLifecycleState` to `LifecycleState`
+
+### ✨ Features
+
+- Added `keepConnectionAliveInBackground` option to `ConnectionRecoveryHandler`
+- Added `unknown` state to `NetworkState` and `LifecycleState` enums
+
+### 🐛 Bug Fixes
+
+- Fixed `onClose()` not being called when disconnecting during connecting state
+- Fixed unnecessary reconnection attempts when network is offline
+- Fixed existing connections not being closed before opening new ones
+
 ## 0.1.0
 
-* Initial release
+- Initial release

--- a/packages/stream_core/lib/src/utils.dart
+++ b/packages/stream_core/lib/src/utils.dart
@@ -1,6 +1,6 @@
-export 'utils/app_lifecycle_state_provider.dart';
 export 'utils/comparable_extensions.dart';
 export 'utils/disposable.dart';
+export 'utils/lifecycle_state_provider.dart';
 export 'utils/list_extensions.dart';
 export 'utils/network_state_provider.dart';
 export 'utils/result.dart';

--- a/packages/stream_core/lib/src/utils/lifecycle_state_provider.dart
+++ b/packages/stream_core/lib/src/utils/lifecycle_state_provider.dart
@@ -1,22 +1,28 @@
 import 'state_emitter.dart';
 
-typedef AppLifecycleStateEmitter = StateEmitter<AppLifecycleState>;
+/// A type alias for a state emitter that emits [LifecycleState] values.
+typedef LifecycleStateEmitter = StateEmitter<LifecycleState>;
 
 /// A utility class for monitoring application lifecycle state changes.
 ///
 /// This interface defines the contract for an application lifecycle state provider
 /// that can provide the current state of the application and a stream of state changes.
-abstract interface class AppLifecycleStateProvider {
+abstract interface class LifecycleStateProvider {
   /// A emitter that provides updates on the application lifecycle state.
-  AppLifecycleStateEmitter get state;
+  LifecycleStateEmitter get state;
 }
 
 /// Enum representing the lifecycle state of the application.
 ///
 /// This enum defines two possible states for the application:
 /// `foreground` and `background`.
-enum AppLifecycleState {
+enum LifecycleState {
+  /// The lifecycle state is not known, e.g., the initial state before any checks.
+  unknown,
+
+  /// The application is in the foreground and actively being used.
   foreground,
 
+  /// The application is in the background and not actively being used.
   background,
 }

--- a/packages/stream_core/lib/src/utils/network_state_provider.dart
+++ b/packages/stream_core/lib/src/utils/network_state_provider.dart
@@ -1,5 +1,6 @@
 import 'state_emitter.dart';
 
+/// A type alias for a state emitter that emits [NetworkState] values.
 typedef NetworkStateEmitter = StateEmitter<NetworkState>;
 
 /// A utility class for monitoring network connectivity changes.
@@ -16,6 +17,9 @@ abstract interface class NetworkStateProvider {
 /// This enum defines two possible values to represent the state of network
 /// connectivity: `connected` and `disconnected`.
 enum NetworkState {
+  /// The network state is unknown, e.g., the initial state before any checks.
+  unknown,
+
   /// Internet is available because at least one of the HEAD requests succeeded.
   connected,
 

--- a/packages/stream_core/lib/src/ws/client/reconnect/automatic_reconnection_policy.dart
+++ b/packages/stream_core/lib/src/ws/client/reconnect/automatic_reconnection_policy.dart
@@ -52,12 +52,12 @@ class BackgroundStateReconnectionPolicy implements AutomaticReconnectionPolicy {
   BackgroundStateReconnectionPolicy({required this.appLifecycleState});
 
   /// The provider that gives the current app lifecycle state.
-  final AppLifecycleStateEmitter appLifecycleState;
+  final LifecycleStateEmitter appLifecycleState;
 
   @override
   bool canBeReconnected() {
     final state = appLifecycleState.value;
-    return state == AppLifecycleState.foreground;
+    return state == LifecycleState.foreground;
   }
 }
 

--- a/packages/stream_core/lib/src/ws/client/stream_web_socket_client.dart
+++ b/packages/stream_core/lib/src/ws/client/stream_web_socket_client.dart
@@ -122,7 +122,7 @@ class StreamWebSocketClient
     final result = await _engine.open(options);
 
     // If some failure occurs, disconnect and rethrow the error.
-    return result.onFailure((_, __) => disconnect()).getOrThrow();
+    return result.recover((_, __) => onClose()).getOrThrow();
   }
 
   /// Closes the WebSocket connection.
@@ -213,8 +213,7 @@ class StreamWebSocketClient
       error: WebSocketEngineException(error: error),
     );
 
-    // Update the connection state to 'disconnecting'.
-    _connectionState = WebSocketConnectionState.disconnecting(source: source);
+    return unawaited(disconnect(source: source));
   }
 
   void _handleHealthCheckEvent(WsEvent event, HealthCheckInfo info) {


### PR DESCRIPTION
# Submit a pull request
<!--Internal tickets have to be added by Stream devs-->
Fixes: [FLU-279](https://linear.app/stream/issue/FLU-279/strm-015)

## Description of the pull request
This PR introduces several improvements to the WebSocket connection management and application lifecycle handling:

**WebSocket Engine:**
- Ensures that any existing WebSocket connection is closed before opening a new one.
- Improved handling of the `onDone` event for WebSocket streams, ensuring proper cleanup and notification.
- Refined the `close` method to handle cases where the WebSocket is not open and to notify listeners appropriately.

**WebSocket Client:**
- Updated error handling during the connection opening process to use `recover` instead of `onFailure` for better resilience.
- Simplified error handling in `onError` by directly calling `disconnect`.

**Network and Lifecycle State:**
- Renamed `AppLifecycleStateProvider` to `LifecycleStateProvider` and `AppLifecycleState` to `LifecycleState` for clarity and broader applicability.
- Added an `unknown` state to both `NetworkState` and `LifecycleState` to represent initial or indeterminate states.
- Introduced a `keepConnectionAliveInBackground` option in `ConnectionRecoveryHandler` to allow maintaining the WebSocket connection even when the app is in the background.
- `ConnectionRecoveryHandler` now considers the `unknown` state for both network and lifecycle, taking no action in these cases.
- `ConnectionRecoveryHandler` logic for `_onAppLifecycleStateChanged` updated to respect `keepConnectionAliveInBackground`.

**General Changes:**
- Updated imports and type aliases to reflect the renaming of lifecycle state components.