### PR TITLE
feat(ui): add StreamSheet, StreamSheetRoute and StreamSheetTheme

### DIFF
--- a/apps/design_system_gallery/lib/app/gallery_app.directories.g.dart
+++ b/apps/design_system_gallery/lib/app/gallery_app.directories.g.dart
@@ -108,6 +108,8 @@ import 'package:design_system_gallery/components/reaction/stream_reaction_picker
     as _design_system_gallery_components_reaction_stream_reaction_picker;
 import 'package:design_system_gallery/components/reaction/stream_reactions.dart'
     as _design_system_gallery_components_reaction_stream_reactions;
+import 'package:design_system_gallery/components/sheet/stream_sheet.dart'
+    as _design_system_gallery_components_sheet_stream_sheet;
 import 'package:design_system_gallery/components/tiles/stream_list_tile.dart'
     as _design_system_gallery_components_tiles_stream_list_tile;
 import 'package:design_system_gallery/primitives/colors.dart'
@@ -1097,6 +1099,26 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _design_system_gallery_components_reaction_stream_reactions
                         .buildStreamReactionsShowcase,
+              ),
+            ],
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookFolder(
+        name: 'Sheet',
+        children: [
+          _widgetbook.WidgetbookComponent(
+            name: 'StreamSheetRoute',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Playground',
+                builder: _design_system_gallery_components_sheet_stream_sheet
+                    .buildStreamSheetPlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Showcase',
+                builder: _design_system_gallery_components_sheet_stream_sheet
+                    .buildStreamSheetShowcase,
               ),
             ],
           ),

--- a/apps/design_system_gallery/lib/components/header/stream_sheet_header.dart
+++ b/apps/design_system_gallery/lib/components/header/stream_sheet_header.dart
@@ -211,11 +211,11 @@ Widget buildStreamSheetHeaderShowcase(BuildContext context) {
   );
 }
 
-// Opens a modal bottom sheet that fills the screen by default, with no snap
-// points — matching how the sheet header is presented in Figma. Drag the
-// handle or swipe down to dismiss; there's no intermediate resting height.
-// The sheet owns the drag handle via `showDragHandle: true`, so the header
-// keeps focus on title and actions.
+// Opens a `showStreamSheet` route that fills the screen by default, with no
+// snap points — matching how the sheet header is presented in Figma. Drag
+// the handle or swipe down to dismiss; there's no intermediate resting
+// height. The sheet owns the drag handle, so the header keeps focus on
+// title and actions.
 class _BottomSheetDemo extends StatelessWidget {
   const _BottomSheetDemo();
 
@@ -251,43 +251,39 @@ class _BottomSheetDemo extends StatelessWidget {
   }
 
   void _open(BuildContext context) {
-    showModalBottomSheet<void>(
+    showStreamSheet<void>(
       context: context,
-      isScrollControlled: true,
-      showDragHandle: true,
-      useSafeArea: true,
-      builder: (context) {
+      builder: (context, _) {
         final colorScheme = context.streamColorScheme;
         final textTheme = context.streamTextTheme;
         final spacing = context.streamSpacing;
 
-        return SizedBox.expand(
-          child: Column(
-            children: [
-              StreamSheetHeader(
-                title: const Text('Edit profile'),
-                subtitle: const Text('Changes are saved automatically'),
-                trailing: StreamButton.icon(
-                  icon: Icon(context.streamIcons.checkmark),
-                  onPressed: () => Navigator.pop(context),
-                ),
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            StreamSheetHeader(
+              title: const Text('Edit profile'),
+              subtitle: const Text('Changes are saved automatically'),
+              trailing: StreamButton.icon(
+                icon: Icon(context.streamIcons.checkmark),
+                onPressed: () => Navigator.pop(context),
               ),
-              Expanded(
-                child: Padding(
-                  padding: EdgeInsetsDirectional.fromSTEB(spacing.lg, 0, spacing.lg, spacing.lg),
-                  child: Center(
-                    child: Text(
-                      'The sheet opens full height with no snap points. '
-                      'Drag the handle down or swipe to dismiss — there is '
-                      'no intermediate resting height.',
-                      textAlign: TextAlign.center,
-                      style: textTheme.bodyDefault.copyWith(color: colorScheme.textSecondary),
-                    ),
+            ),
+            Expanded(
+              child: Padding(
+                padding: EdgeInsetsDirectional.fromSTEB(spacing.lg, 0, spacing.lg, spacing.lg),
+                child: Center(
+                  child: Text(
+                    'The sheet opens full height with no snap points. '
+                    'Drag the handle down or swipe to dismiss — there is '
+                    'no intermediate resting height.',
+                    textAlign: TextAlign.center,
+                    style: textTheme.bodyDefault.copyWith(color: colorScheme.textSecondary),
                   ),
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         );
       },
     );

--- a/apps/design_system_gallery/lib/components/sheet/stream_sheet.dart
+++ b/apps/design_system_gallery/lib/components/sheet/stream_sheet.dart
@@ -1,0 +1,503 @@
+import 'package:flutter/material.dart';
+import 'package:stream_core_flutter/stream_core_flutter.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+// =============================================================================
+// Playground
+// =============================================================================
+
+@widgetbook.UseCase(
+  name: 'Playground',
+  type: StreamSheetRoute,
+  path: '[Components]/Sheet',
+)
+Widget buildStreamSheetPlayground(BuildContext context) {
+  final showDragHandle = context.knobs.boolean(
+    label: 'Show drag handle',
+    initialValue: true,
+    description: 'Whether to display the drag handle at the top of the sheet.',
+  );
+
+  final enableDrag = context.knobs.boolean(
+    label: 'Enable drag',
+    initialValue: true,
+    description: 'Whether the sheet can be dismissed by dragging it down.',
+  );
+
+  final isDismissible = context.knobs.boolean(
+    label: 'Is dismissible',
+    description:
+        'Whether tapping the modal barrier dismisses the sheet. Pair with '
+        'a non-transparent barrier color to give users a visible target.',
+  );
+
+  final useNestedNavigation = context.knobs.boolean(
+    label: 'Use nested navigation',
+    description:
+        'When true, the sheet hosts its own Navigator so consumers can push '
+        'routes inside the sheet. The header auto-shows a back chevron on '
+        'deeper nested routes.',
+  );
+
+  final useScrollableBody = context.knobs.boolean(
+    label: 'Scrollable body',
+    initialValue: true,
+    description:
+        'When on, the sheet hosts a ListView attached to the provided '
+        'ScrollController so dragging at the top of the list dismisses '
+        'the sheet (scroll-aware drag-to-dismiss).',
+  );
+
+  return _SheetLauncher(
+    label: 'Open Stream sheet',
+    onPressed: (launchContext) => showStreamSheet<void>(
+      context: launchContext,
+      showDragHandle: showDragHandle,
+      enableDrag: enableDrag,
+      isDismissible: isDismissible,
+      useNestedNavigation: useNestedNavigation,
+      builder: (sheetContext, scrollController) {
+        return _PlaygroundSheetContent(
+          scrollController: scrollController,
+          useScrollableBody: useScrollableBody,
+          useNestedNavigation: useNestedNavigation,
+        );
+      },
+    ),
+  );
+}
+
+// =============================================================================
+// Showcase
+// =============================================================================
+
+@widgetbook.UseCase(
+  name: 'Showcase',
+  type: StreamSheetRoute,
+  path: '[Components]/Sheet',
+)
+Widget buildStreamSheetShowcase(BuildContext context) {
+  final colorScheme = context.streamColorScheme;
+  final textTheme = context.streamTextTheme;
+  final spacing = context.streamSpacing;
+
+  return DefaultTextStyle(
+    style: textTheme.bodyDefault.copyWith(color: colorScheme.textPrimary),
+    child: SingleChildScrollView(
+      padding: EdgeInsets.all(spacing.lg),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _Section(
+            label: 'Basic — full-height sheet with a drag handle',
+            description:
+                'The default Stream sheet covers the full screen, honours '
+                'the system top inset, and shows a drag handle at the top.',
+            launcher: _SheetLauncher(
+              label: 'Open basic sheet',
+              onPressed: (launchContext) => showStreamSheet<void>(
+                context: launchContext,
+                builder: (_, _) => const _SimpleBody(message: 'Basic sheet'),
+              ),
+            ),
+          ),
+          SizedBox(height: spacing.md),
+          _Section(
+            label: 'Scrollable — scroll-aware drag-to-dismiss',
+            description:
+                'When the list is at its top edge, dragging it further down '
+                'dismisses the sheet. Otherwise dragging just scrolls the list.',
+            launcher: _SheetLauncher(
+              label: 'Open scrollable sheet',
+              onPressed: (launchContext) => showStreamSheet<void>(
+                context: launchContext,
+                builder: (_, controller) {
+                  return ListView.builder(
+                    controller: controller,
+                    itemCount: 60,
+                    itemBuilder: (context, index) {
+                      return ListTile(
+                        title: Text('Item ${index + 1}'),
+                        subtitle: Text('Subtitle for item ${index + 1}'),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+          SizedBox(height: spacing.md),
+          _Section(
+            label: 'Stacked — open a sheet from inside a sheet',
+            description:
+                'Opening a Stream sheet from within another auto-applies a '
+                'stacked top gap so the parent peeks above. The header on '
+                'the stacked sheet shows a back chevron — popping returns '
+                'you to the previous sheet. Keep tapping the action to push '
+                'sheets indefinitely and watch the stack build up.',
+            launcher: _SheetLauncher(
+              label: 'Open infinitely stackable sheets',
+              onPressed: (launchContext) => showStreamSheet<void>(
+                context: launchContext,
+                builder: (_, _) => const _StackedSheetBody(depth: 1),
+              ),
+            ),
+          ),
+          SizedBox(height: spacing.md),
+          _Section(
+            label: 'Nested navigation — back button inside the sheet',
+            description:
+                'With useNestedNavigation: true the sheet hosts its own '
+                'Navigator. Pushing routes inside renders a back chevron on '
+                'the header, while the first route shows a close cross.',
+            launcher: _SheetLauncher(
+              label: 'Open sheet with nested navigation',
+              onPressed: (launchContext) => showStreamSheet<void>(
+                context: launchContext,
+                useNestedNavigation: true,
+                builder: (sheetContext, _) {
+                  return _NestedNavSheetBody(parentContext: sheetContext);
+                },
+              ),
+            ),
+          ),
+          SizedBox(height: spacing.md),
+          _Section(
+            label: 'Constrained — capped width on wide screens',
+            description:
+                'Pass BoxConstraints to limit width on tablet/desktop. The '
+                'sheet is bottom-aligned within the constraints.',
+            launcher: _SheetLauncher(
+              label: 'Open constrained sheet',
+              onPressed: (launchContext) => showStreamSheet<void>(
+                context: launchContext,
+                constraints: const BoxConstraints(maxWidth: 480),
+                builder: (_, _) => const _SimpleBody(message: 'Max width: 480'),
+              ),
+            ),
+          ),
+          SizedBox(height: spacing.md),
+          _Section(
+            label: 'Dismissible barrier — dim and tap-to-close',
+            description:
+                'Pair barrierColor with isDismissible: true to dim the '
+                'background and let users tap above the sheet to dismiss.',
+            launcher: _SheetLauncher(
+              label: 'Open dismissible sheet',
+              onPressed: (launchContext) => showStreamSheet<void>(
+                context: launchContext,
+                isDismissible: true,
+                barrierColor: const Color(0x99000000),
+                builder: (_, _) => const _SimpleBody(
+                  message: 'Tap above the sheet to dismiss',
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+class _SheetLauncher extends StatelessWidget {
+  const _SheetLauncher({required this.label, required this.onPressed});
+
+  final String label;
+  final void Function(BuildContext context) onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: StreamButton(
+        onPressed: () => onPressed(context),
+        child: Text(label),
+      ),
+    );
+  }
+}
+
+class _Section extends StatelessWidget {
+  const _Section({
+    required this.label,
+    required this.description,
+    required this.launcher,
+  });
+
+  final String label;
+  final String description;
+  final Widget launcher;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+    final textTheme = context.streamTextTheme;
+    final radius = context.streamRadius;
+    final spacing = context.streamSpacing;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: textTheme.captionEmphasis.copyWith(
+            color: colorScheme.textSecondary,
+          ),
+        ),
+        SizedBox(height: spacing.xs),
+        Container(
+          decoration: BoxDecoration(
+            color: colorScheme.backgroundSurface,
+            borderRadius: BorderRadius.all(radius.lg),
+            border: Border.all(color: colorScheme.borderSubtle),
+          ),
+          padding: EdgeInsets.all(spacing.md),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                description,
+                style: textTheme.bodyDefault.copyWith(color: colorScheme.textSecondary),
+              ),
+              SizedBox(height: spacing.md),
+              launcher,
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SimpleBody extends StatelessWidget {
+  const _SimpleBody({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+    final textTheme = context.streamTextTheme;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        StreamSheetHeader(title: const Text('Stream sheet')),
+        Expanded(
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Text(
+                message,
+                textAlign: TextAlign.center,
+                style: textTheme.bodyDefault.copyWith(
+                  color: colorScheme.textSecondary,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PlaygroundSheetContent extends StatelessWidget {
+  const _PlaygroundSheetContent({
+    required this.scrollController,
+    required this.useScrollableBody,
+    required this.useNestedNavigation,
+  });
+
+  final ScrollController scrollController;
+  final bool useScrollableBody;
+  final bool useNestedNavigation;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+    final textTheme = context.streamTextTheme;
+    final spacing = context.streamSpacing;
+
+    Widget body;
+    if (useScrollableBody) {
+      body = ListView.builder(
+        controller: scrollController,
+        itemCount: 60,
+        itemBuilder: (_, index) => ListTile(
+          title: Text('Item ${index + 1}'),
+        ),
+      );
+    } else {
+      body = Center(
+        child: Padding(
+          padding: EdgeInsets.all(spacing.lg),
+          child: Text(
+            'Sheet body',
+            style: textTheme.bodyDefault.copyWith(
+              color: colorScheme.textSecondary,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        StreamSheetHeader(
+          title: const Text('Stream sheet'),
+          subtitle: const Text('Playground'),
+          trailing: useNestedNavigation
+              ? StreamButton.icon(
+                  icon: Icon(context.streamIcons.chevronRight),
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (innerContext) => _NestedDetail(parentContext: innerContext),
+                      ),
+                    );
+                  },
+                )
+              : null,
+        ),
+        Expanded(child: body),
+      ],
+    );
+  }
+}
+
+class _StackedSheetBody extends StatelessWidget {
+  const _StackedSheetBody({required this.depth});
+
+  /// 1-based stacking depth shown in the header so it's easy to verify how
+  /// far down the stack you've gone.
+  final int depth;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+    final textTheme = context.streamTextTheme;
+    final spacing = context.streamSpacing;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        StreamSheetHeader(
+          title: Text('Sheet #$depth'),
+          subtitle: Text('Stacked depth: $depth'),
+        ),
+        Expanded(
+          child: Center(
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: spacing.lg),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Each new sheet shifts the previous stack up and scales '
+                    'it down. Pop a single sheet with the back chevron, or '
+                    'tap the action to push another one.',
+                    textAlign: TextAlign.center,
+                    style: textTheme.bodyDefault.copyWith(
+                      color: colorScheme.textSecondary,
+                    ),
+                  ),
+                  SizedBox(height: spacing.lg),
+                  StreamButton(
+                    onPressed: () => showStreamSheet<void>(
+                      context: context,
+                      builder: (_, _) => _StackedSheetBody(depth: depth + 1),
+                    ),
+                    child: const Text('Push another sheet'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _NestedNavSheetBody extends StatelessWidget {
+  const _NestedNavSheetBody({required this.parentContext});
+
+  final BuildContext parentContext;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        StreamSheetHeader(title: const Text('Sheet root')),
+        Expanded(
+          child: Center(
+            child: StreamButton(
+              onPressed: () {
+                Navigator.of(parentContext).push(
+                  MaterialPageRoute<void>(
+                    builder: (innerContext) => _NestedDetail(parentContext: innerContext),
+                  ),
+                );
+              },
+              child: const Text('Push detail page'),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _NestedDetail extends StatelessWidget {
+  const _NestedDetail({required this.parentContext});
+
+  final BuildContext parentContext;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.streamColorScheme;
+    final textTheme = context.streamTextTheme;
+
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: Column(
+        children: [
+          StreamSheetHeader(title: const Text('Detail')),
+          Expanded(
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'Pop the detail to return to the sheet root, or close '
+                      'the entire sheet via the action below.',
+                      textAlign: TextAlign.center,
+                      style: textTheme.bodyDefault.copyWith(color: colorScheme.textSecondary),
+                    ),
+                    const SizedBox(height: 24),
+                    StreamButton(
+                      style: StreamButtonStyle.secondary,
+                      type: StreamButtonType.outline,
+                      onPressed: () => StreamSheetRoute.popSheet(parentContext),
+                      child: const Text('Close entire sheet'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/stream_core_flutter/CHANGELOG.md
+++ b/packages/stream_core_flutter/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Added `trailing` slot to `StreamMessageAnnotation`, with matching `trailingTextStyle`/`trailingTextColor` on `StreamMessageAnnotationStyle`.
 - Added `StreamTapTargetPadding`, a reusable primitive that grows a child's layout and hit-test area to a configurable `minSize` without changing its visual size, with a directional `alignment` that controls which direction the extra tap area extends into.
 - Added `StreamSheetHeader` component and `StreamSheetHeaderTheme` for bottom-sheet and modal headers, with auto-implied dismissal based on the enclosing route.
+- Added `StreamSheet`, `StreamSheetDragHandle`, `StreamSheetRoute`, `StreamSheetTransition` and the `showStreamSheet` helper — Stream-styled modal bottom sheets with scroll-aware drag-to-dismiss and stacking support. `StreamSheet` can also be used standalone outside the modal route.
+- Added `StreamSheetTheme` and `StreamSheetThemeData` (`StreamTheme.sheetTheme`) for theming `StreamSheet` and modal sheets opened with `showStreamSheet`.
 - `StreamLoadingSpinner` now renders a completion checkmark when progress reaches 100%.
 - `StreamCommandChip` is now tappable across its whole surface, not just the × icon.
 - `StreamRemoveControl` now meets the 48 dp minimum tap target by default while keeping its 20 dp visible badge anchored to the top-end corner. Exposes `tapTargetSize`, `visualDensity`, and `semanticLabel`, and announces itself as a button to screen readers.

--- a/packages/stream_core_flutter/CHANGELOG.md
+++ b/packages/stream_core_flutter/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `StreamSheetHeader` component and `StreamSheetHeaderTheme` for bottom-sheet and modal headers, with auto-implied dismissal based on the enclosing route.
 - Added `StreamSheet`, `StreamSheetDragHandle`, `StreamSheetRoute`, `StreamSheetTransition` and the `showStreamSheet` helper — Stream-styled modal bottom sheets with scroll-aware drag-to-dismiss and stacking support. `StreamSheet` can also be used standalone outside the modal route.
 - Added `StreamSheetTheme` and `StreamSheetThemeData` (`StreamTheme.sheetTheme`) for theming `StreamSheet` and modal sheets opened with `showStreamSheet`.
+- `StreamEmojiPickerSheet.show` now resolves its background color and border radius from the ambient `StreamSheetTheme` so the picker visually matches other Stream-styled sheets by default.
 - `StreamLoadingSpinner` now renders a completion checkmark when progress reaches 100%.
 - `StreamCommandChip` is now tappable across its whole surface, not just the × icon.
 - `StreamRemoveControl` now meets the 48 dp minimum tap target by default while keeping its 20 dp visible badge anchored to the top-end corner. Exposes `tapTargetSize`, `visualDensity`, and `semanticLabel`, and announces itself as a button to screen readers.

--- a/packages/stream_core_flutter/lib/src/components.dart
+++ b/packages/stream_core_flutter/lib/src/components.dart
@@ -56,4 +56,5 @@ export 'components/message_layout/stream_message_list_kind.dart';
 export 'components/message_layout/stream_message_stack_position.dart';
 export 'components/reaction/stream_reaction_picker.dart' hide DefaultStreamReactionPicker;
 export 'components/reaction/stream_reactions.dart' hide DefaultStreamReactions;
+export 'components/sheet/stream_sheet.dart';
 export 'factory/stream_component_factory.dart';

--- a/packages/stream_core_flutter/lib/src/components/emoji/stream_emoji_picker_sheet.dart
+++ b/packages/stream_core_flutter/lib/src/components/emoji/stream_emoji_picker_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../components.dart';
 
 import '../../theme/components/stream_emoji_button_theme.dart';
+import '../../theme/components/stream_sheet_theme.dart';
 import '../../theme/stream_theme_extensions.dart';
 
 const _kGridCrossAxisCount = 7;
@@ -61,6 +62,10 @@ class StreamEmojiPickerSheet extends StatelessWidget {
   /// Shows the emoji picker as a modal bottom sheet.
   ///
   /// Returns the selected [StreamEmojiData], or `null` if dismissed.
+  ///
+  /// Visual defaults (background color, border radius) are pulled from
+  /// the ambient [StreamSheetTheme] so the picker matches the look of
+  /// other Stream-styled sheets.
   static Future<StreamEmojiData?> show({
     required BuildContext context,
     Iterable<StreamEmojiData>? emojis,
@@ -70,9 +75,11 @@ class StreamEmojiPickerSheet extends StatelessWidget {
   }) {
     final radius = context.streamRadius;
     final colorScheme = context.streamColorScheme;
+    final sheetTheme = StreamSheetTheme.of(context);
 
     final effectiveEmojis = emojis ?? streamSupportedEmojis.values;
-    final effectiveBackgroundColor = backgroundColor ?? colorScheme.backgroundElevation2;
+    final effectiveBackgroundColor = backgroundColor ?? sheetTheme.backgroundColor ?? colorScheme.backgroundElevation1;
+    final effectiveBorderRadius = sheetTheme.borderRadius ?? BorderRadius.vertical(top: radius.xxxxl);
 
     return showModalBottomSheet<StreamEmojiData>(
       context: context,
@@ -80,9 +87,7 @@ class StreamEmojiPickerSheet extends StatelessWidget {
       isScrollControlled: true,
       showDragHandle: true,
       backgroundColor: effectiveBackgroundColor,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadiusDirectional.only(topStart: radius.xl, topEnd: radius.xl),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: effectiveBorderRadius),
       builder: (context) => DraggableScrollableSheet(
         snap: true,
         expand: false,

--- a/packages/stream_core_flutter/lib/src/components/header/stream_sheet_header.dart
+++ b/packages/stream_core_flutter/lib/src/components/header/stream_sheet_header.dart
@@ -9,6 +9,7 @@ import '../../theme/semantics/stream_text_theme.dart';
 import '../../theme/stream_theme_extensions.dart';
 import '../buttons/stream_button.dart';
 import '../common/stream_visibility.dart';
+import '../sheet/stream_sheet.dart';
 
 /// A header for bottom sheets, modals, and dialogs in the Stream design
 /// system.
@@ -24,9 +25,19 @@ import '../common/stream_visibility.dart';
 ///
 /// When [leading] is null and [automaticallyImplyLeading] is true (the
 /// default), a dismissal button is inserted if the enclosing route can
-/// pop. The icon is a cross (`xmark`) on modal surfaces (bottom sheets,
-/// dialogs, fullscreen dialogs) and a back chevron on regular pushed
-/// pages.
+/// pop. The icon and behaviour depend on the surface:
+///
+///  * Inside a standalone [StreamSheetRoute] (or its nested navigator's
+///    first route), a cross (`xmark`) is shown — pressing it closes the
+///    entire sheet.
+///  * Inside a stacked [StreamSheetRoute] (one that covers another sheet),
+///    a back chevron is shown — pressing it pops back to the previous
+///    sheet.
+///  * Inside deeper nested routes within a [StreamSheetRoute], a back
+///    chevron is shown — pressing it pops one level inside the sheet.
+///  * On any other modal surface (bottom sheets, dialogs, fullscreen
+///    dialogs), a cross is shown.
+///  * On regular pushed pages, a back chevron is shown.
 ///
 /// The drag handle shown on iOS-style bottom sheets is intentionally *not*
 /// part of this widget — the sheet itself owns that affordance, which
@@ -35,21 +46,21 @@ import '../common/stream_visibility.dart';
 ///
 /// {@tool snippet}
 ///
-/// Use inside a bottom sheet with a confirm action — the leading close
-/// button is auto-implied since the sheet's route is a modal surface:
+/// Use inside a [StreamSheetRoute] with a confirm action — the leading
+/// close button is auto-implied (cross at the root of a sheet, back
+/// chevron when stacked over another sheet):
 ///
 /// ```dart
-/// showModalBottomSheet(
+/// showStreamSheet<ProfileEdits>(
 ///   context: context,
-///   showDragHandle: true,
-///   builder: (context) => Column(
+///   builder: (sheetContext, scrollController) => Column(
 ///     mainAxisSize: MainAxisSize.min,
 ///     children: [
 ///       StreamSheetHeader(
-///         title: Text('Edit profile'),
+///         title: const Text('Edit profile'),
 ///         trailing: StreamButton.icon(
 ///           icon: Icon(context.streamIcons.checkmark),
-///           onPressed: () => Navigator.pop(context, result),
+///           onPressed: () => Navigator.of(sheetContext).pop(edits),
 ///         ),
 ///       ),
 ///       // ... sheet contents
@@ -81,6 +92,7 @@ class StreamSheetHeader extends StatelessWidget {
     Widget? title,
     Widget? subtitle,
     Widget? trailing,
+    bool primary = true,
     StreamSheetHeaderStyle? style,
   }) : props = .new(
          leading: leading,
@@ -88,6 +100,7 @@ class StreamSheetHeader extends StatelessWidget {
          title: title,
          subtitle: subtitle,
          trailing: trailing,
+         primary: primary,
          style: style,
        );
 
@@ -119,6 +132,7 @@ class StreamSheetHeaderProps {
     this.title,
     this.subtitle,
     this.trailing,
+    this.primary = true,
     this.style,
   });
 
@@ -162,6 +176,17 @@ class StreamSheetHeaderProps {
   /// the widget's own hit area; the header only reserves a 48×48 slot for
   /// symmetry.
   final Widget? trailing;
+
+  /// Whether this header is the topmost chrome of its surface.
+  ///
+  /// When true (the default), the header wraps itself in a
+  /// `SafeArea(bottom: false)` so it clears the system top inset
+  /// (status bar / notch) and horizontal insets.
+  ///
+  /// Set to false when the header isn't at the top of its surface
+  /// (e.g. inside a sub-section of a page that has already consumed
+  /// the top inset) so it doesn't double-pad.
+  final bool primary;
 
   /// The visual style applied to this header.
   ///
@@ -208,19 +233,61 @@ class DefaultStreamSheetHeader extends StatelessWidget {
     final effectiveTrailingStyle = style?.trailingStyle ?? defaults.trailingStyle;
 
     // Leading: caller-provided, or an auto-implied dismissal button when
-    // the enclosing route implies one. A regular pushed page gets a back
-    // chevron; anything else that implies dismissal (popup routes, dialogs,
-    // fullscreen dialogs, custom modal routes) gets a cross.
+    // the enclosing route implies one.
+    //
+    // Inside a [StreamSheetRoute], the dismissal semantics shift:
+    //   * The sheet's root content (or the first route in its nested
+    //     navigator) shows a cross — pressing it closes the entire sheet.
+    //   * Subsequent routes pushed inside the sheet's nested navigator
+    //     show a back chevron — pressing it pops one level inside the
+    //     sheet.
+    //
+    // For non-sheet routes the legacy heuristic applies: a regular pushed
+    // page gets a back chevron, anything else that implies dismissal
+    // (popup routes, dialogs, fullscreen dialogs, custom modal routes)
+    // gets a cross.
     var leading = props.leading;
     if (leading == null && props.automaticallyImplyLeading) {
       final parentRoute = ModalRoute.of(context);
-      if (parentRoute != null && parentRoute.impliesAppBarDismissal) {
+      final sheetRoute = StreamSheetRoute.maybeOf(context);
+
+      IconData? icon;
+      VoidCallback? onPressed;
+
+      if (parentRoute is StreamSheetRoute) {
+        // Header sits directly on a [StreamSheetRoute] (no nested nav
+        // layer between us and the route). A stacked sheet's pop
+        // returns to the parent sheet — show a back chevron. A root
+        // sheet's pop dismisses it entirely — show a close cross.
+        icon = parentRoute.isStacked ? icons.chevronLeft : icons.xmark;
+        onPressed = Navigator.of(context).maybePop;
+      } else if (sheetRoute != null && parentRoute != null) {
+        // Header is inside the enclosing sheet's nested navigator
+        // (see [showStreamSheet]'s `useNestedNavigation`).
+        if (parentRoute.isFirst) {
+          // First nested route: tapping the icon dismisses the *whole*
+          // sheet via [popSheet]. Mirror the non-nested case for the
+          // icon — chevron when the enclosing sheet is stacked (pop
+          // reveals the parent), cross when it's a root sheet.
+          icon = sheetRoute.isStacked ? icons.chevronLeft : icons.xmark;
+          onPressed = () => StreamSheetRoute.popSheet(context);
+        } else {
+          // Deeper nested route: pop one level inside the sheet.
+          icon = icons.chevronLeft;
+          onPressed = Navigator.of(context).maybePop;
+        }
+      } else if (parentRoute != null && parentRoute.impliesAppBarDismissal) {
         final isRegularPage = parentRoute is PageRoute && !parentRoute.fullscreenDialog;
+        icon = isRegularPage ? icons.chevronLeft : icons.xmark;
+        onPressed = Navigator.of(context).maybePop;
+      }
+
+      if (icon != null && onPressed != null) {
         leading = StreamButton.icon(
           type: .outline,
           style: .secondary,
-          icon: Icon(isRegularPage ? icons.chevronLeft : icons.xmark),
-          onPressed: Navigator.of(context).maybePop,
+          icon: Icon(icon),
+          onPressed: onPressed,
         );
       }
     }
@@ -272,7 +339,7 @@ class DefaultStreamSheetHeader extends StatelessWidget {
       );
     }
 
-    return Padding(
+    Widget header = Padding(
       padding: effectivePadding,
       child: Row(
         spacing: effectiveSpacing,
@@ -289,6 +356,17 @@ class DefaultStreamSheetHeader extends StatelessWidget {
         ],
       ),
     );
+
+    // When [primary] is true, wrap in a `SafeArea(bottom: false)` so
+    // the header clears the system top + horizontal insets when used
+    // at the top of a screen. Inside a [StreamSheetRoute] the sheet
+    // already strips MediaQuery's top padding, so this is a no-op
+    // there.
+    if (props.primary) {
+      header = SafeArea(bottom: false, child: header);
+    }
+
+    return header;
   }
 }
 

--- a/packages/stream_core_flutter/lib/src/components/sheet/stream_sheet.dart
+++ b/packages/stream_core_flutter/lib/src/components/sheet/stream_sheet.dart
@@ -776,8 +776,12 @@ class StreamSheetRoute<T> extends PageRoute<T> {
     return context.streamSpacing.sm;
   }
 
+  /// Falls back to the standard modal-sheet [Colors.black54] scrim
+  /// when no `barrierColor` is provided. [showStreamSheet] instead
+  /// resolves [StreamSheetThemeData.barrierColor] (defaulting to
+  /// [StreamColorScheme.backgroundScrim]) from the calling context.
   @override
-  Color? get barrierColor => _barrierColor ?? Colors.transparent;
+  Color? get barrierColor => _barrierColor ?? Colors.black54;
 
   @override
   bool get barrierDismissible => isDismissible;
@@ -998,8 +1002,11 @@ class StreamSheetRoute<T> extends PageRoute<T> {
 ///
 /// A small pill-shaped indicator that signals the sheet can be
 /// dismissed by dragging. Wrapped in a [Semantics] node so assistive
-/// technology can dismiss the enclosing sheet by tapping the handle
-/// (`Navigator.maybePop`).
+/// technology can dismiss the enclosing sheet by tapping the handle —
+/// the tap targets the enclosing [StreamSheetRoute] (via
+/// [StreamSheetRoute.maybeOf]) so a nested navigator inside the sheet
+/// can't intercept it, and falls back to the nearest [Navigator] when
+/// the handle is composed outside a [StreamSheetRoute].
 ///
 /// The handle's color and size resolve from
 /// [StreamSheetThemeData.dragHandleColor] /
@@ -1026,7 +1033,16 @@ class StreamSheetDragHandle extends StatelessWidget {
       label: localizations.modalBarrierDismissLabel,
       container: true,
       button: true,
-      onTap: Navigator.of(context).maybePop,
+      onTap: () {
+        // Prefer dismissing the enclosing sheet route directly so a
+        // nested navigator inside the sheet (see `useNestedNavigation`
+        // on [showStreamSheet]) can't swallow the dismiss. Fall back to
+        // the nearest [Navigator] when the handle is composed outside
+        // a [StreamSheetRoute].
+        final route = StreamSheetRoute.maybeOf(context);
+        final navigator = route?.navigator ?? Navigator.maybeOf(context);
+        navigator?.maybePop();
+      },
       child: Container(
         height: size.height,
         width: size.width,

--- a/packages/stream_core_flutter/lib/src/components/sheet/stream_sheet.dart
+++ b/packages/stream_core_flutter/lib/src/components/sheet/stream_sheet.dart
@@ -1,0 +1,1526 @@
+import 'dart:math' as math;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+import '../../theme/components/stream_sheet_theme.dart';
+import '../../theme/primitives/stream_colors.dart';
+import '../../theme/primitives/stream_radius.dart';
+import '../../theme/semantics/stream_color_scheme.dart';
+import '../../theme/stream_theme_extensions.dart';
+
+// Minimum velocity (screen heights per second) for a downward fling
+// to dismiss the sheet.
+const _kMinFlingVelocity = 2.0;
+
+// Settle duration when the user releases the sheet mid-swipe.
+const _kSettleDuration = Duration(milliseconds: 300);
+
+// Relax-back duration for the upward rubber-band stretch when the
+// user releases after stretching.
+const _kStretchSettleDuration = Duration(milliseconds: 180);
+
+// Slide tween for a sheet entering the screen — fully below the
+// bottom edge to its natural rest position.
+final _kBottomUpTween = Tween<Offset>(
+  begin: const Offset(0, 1),
+  end: Offset.zero,
+);
+
+// Slide tween applied to a sheet that is becoming covered by another
+// sheet. Shifts it up by half a percent of the screen height so the
+// covered sheet feels like it's being tucked behind the foreground.
+const _kStackedSheetMidUpRatio = 0.005;
+final _kStackedSheetMidUpTween = Tween<Offset>(
+  begin: Offset.zero,
+  end: const Offset(0, -_kStackedSheetMidUpRatio),
+);
+
+// Scale tween applied to a sheet that is becoming covered by another
+// sheet. Shrinks it slightly so the foreground reads as the active
+// surface and the underlying sheet peeks at the lateral inset.
+const _kStackedSheetScaleFactor = 0.0835;
+final _kStackedSheetScaleTween = Tween<double>(
+  begin: 1,
+  end: 1 - _kStackedSheetScaleFactor,
+);
+
+/// Signature for a builder that takes a [BuildContext] and a [ScrollController]
+/// to build a scrollable widget inside a [StreamSheetRoute].
+typedef StreamSheetScrollableWidgetBuilder =
+    Widget Function(
+      BuildContext context,
+      ScrollController scrollController,
+    );
+
+/// Called when the user begins dragging a [StreamSheetRoute].
+typedef StreamSheetDragStartCallback = void Function(DragStartDetails details);
+
+/// Called when the user stops dragging a [StreamSheetRoute].
+///
+/// The sheet may pop in response to the gesture (in which case
+/// [isClosing] is `true`), or animate back to its open position.
+typedef StreamSheetDragEndCallback = void Function(DragEndDetails details, {required bool isClosing});
+
+/// Shows a Stream-styled modal sheet that slides up from the bottom of
+/// the screen.
+///
+/// The [builder] receives a [ScrollController] that should be attached to
+/// the topmost scrollable inside the sheet so dragging it past its top
+/// edge dismisses the sheet (scroll-aware drag-to-dismiss). Non-
+/// scrollable regions can also be dragged down to dismiss.
+///
+/// When [useNestedNavigation] is `true`, the sheet hosts its own
+/// [Navigator]. Routes pushed from inside the sheet stay within it, and a
+/// pop from the first nested route dismisses the entire sheet. The whole
+/// sheet can also be popped at once via [StreamSheetRoute.popSheet].
+///
+/// Pushing a sheet from within another sheet stacks it: the underlying
+/// sheet scales down slightly while the new one rests on top, and the
+/// auto-implied [StreamSheetHeader] leading icon flips from cross to
+/// back-chevron.
+///
+/// The sheet honours system insets — its top is clamped to a minimum of
+/// [MediaQueryData.viewPadding] top so the header / drag handle clear
+/// the status bar, and horizontal insets are honoured for landscape and
+/// notched displays. The bottom inset is never applied, so the sheet
+/// visually meets the bottom edge of the screen.
+///
+/// Style:
+///
+/// Each visual property follows the same resolution chain — the
+/// per-call argument wins, then the ambient [StreamSheetThemeData]
+/// (from [StreamTheme.sheetTheme] / [StreamSheetTheme]), then the
+/// built-in fallback below.
+///
+///  * [shape] takes precedence over [borderRadius] when provided. When
+///    both are null, the sheet's top corners are rounded with
+///    [StreamRadius.xxxxl] and the bottom corners are square.
+///  * [backgroundColor] defaults to
+///    [StreamColorScheme.backgroundElevation1].
+///  * [elevation] drives the shadow cast around the sheet. Defaults
+///    to `1`.
+///  * [clipBehavior] clips content against the border radius (defaults
+///    to [Clip.antiAlias]).
+///  * [constraints] caps the sheet's size — most useful on tablet /
+///    desktop. The sheet is bottom-aligned within the constraints.
+///
+/// Dismissal:
+///
+///  * [enableDrag] (defaults to `true`) lets users pop the sheet by
+///    dragging it down. The drag handle stays draggable even when
+///    [enableDrag] is `false`, so the affordance never lies.
+///  * [isDismissible] (defaults to `false`) lets users pop the sheet by
+///    tapping the modal barrier. Pair with a non-null [barrierColor] to
+///    give users a visible target.
+///  * [showDragHandle] (defaults to `true`) reserves a drag handle at
+///    the top of the sheet content.
+///  * [onDragStart] / [onDragEnd] fire when the user starts / stops a
+///    drag gesture; `isClosing` on [onDragEnd] indicates whether the
+///    gesture will pop the sheet.
+///
+/// Routing:
+///
+///  * [useRootNavigator] (defaults to `false`) selects which [Navigator]
+///    the sheet is pushed onto. Pass `true` to escape any nested
+///    navigators and push to the root.
+///  * [requestFocus] controls whether the sheet's first focusable
+///    descendant requests focus when the route activates.
+///  * [anchorPoint] is forwarded to a [DisplayFeatureSubScreen] so the
+///    sheet avoids display features like foldable hinges.
+///  * [settings] sets the [RouteSettings] of the underlying [PageRoute].
+///
+/// Returns a [Future] that resolves to the value (if any) passed to
+/// [Navigator.pop] when the sheet is closed.
+///
+/// {@tool snippet}
+///
+/// A simple sheet with a title and a confirm action:
+///
+/// ```dart
+/// final result = await showStreamSheet<String>(
+///   context: context,
+///   builder: (sheetContext, scrollController) => Column(
+///     mainAxisSize: MainAxisSize.min,
+///     children: [
+///       StreamSheetHeader(
+///         title: const Text('Edit profile'),
+///         trailing: StreamButton.icon(
+///           icon: Icon(context.streamIcons.checkmark),
+///           onPressed: () => Navigator.of(sheetContext).pop('saved'),
+///         ),
+///       ),
+///       // ... sheet contents
+///     ],
+///   ),
+/// );
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [StreamSheetRoute], the underlying route.
+///  * [StreamSheetHeader], the auto-aware header component.
+Future<T?> showStreamSheet<T>({
+  required BuildContext context,
+  required StreamSheetScrollableWidgetBuilder builder,
+  Color? backgroundColor,
+  Color? barrierColor,
+  String? barrierLabel,
+  ShapeBorder? shape,
+  BorderRadiusGeometry? borderRadius,
+  BoxConstraints? constraints,
+  double? elevation,
+  Clip? clipBehavior,
+  bool enableDrag = true,
+  bool isDismissible = false,
+  bool? showDragHandle,
+  bool useNestedNavigation = false,
+  bool useRootNavigator = false,
+  bool? requestFocus,
+  Offset? anchorPoint,
+  StreamSheetDragStartCallback? onDragStart,
+  StreamSheetDragEndCallback? onDragEnd,
+  RouteSettings? settings,
+}) {
+  assert(debugCheckHasMaterialLocalizations(context));
+
+  final localizations = MaterialLocalizations.of(context);
+  final sheetTheme = StreamSheetTheme.of(context);
+  final defaults = _StreamSheetDefaults(context);
+  final effectiveBuilder = useNestedNavigation ? _wrapWithNestedNavigator<T>(builder) : builder;
+
+  // The nearest StreamSheetRoute above the current context, if any. We keep
+  // the reference around so the new sheet can identify itself as a stacked
+  // sheet (used by the auto-imply leading icon in [StreamSheetHeader] and
+  // by [StreamSheetRoute.isStacked]).
+  final parentSheet = _StreamSheetScope.maybeOf(context)?.route;
+
+  final navigator = Navigator.of(context, rootNavigator: useRootNavigator);
+
+  // Capture the calling context's [InheritedTheme]s (StreamTheme, Theme,
+  // Directionality, MediaQuery overrides, etc.) and re-apply them inside
+  // the route. The sheet is pushed onto the navigator's overlay, which
+  // is typically *outside* any local theme overrides — without this
+  // wrap, sheets pushed from a sub-tree with a custom theme would render
+  // with the root theme.
+  final capturedThemes = InheritedTheme.capture(from: context, to: navigator.context);
+
+  return navigator.push<T>(
+    StreamSheetRoute<T>(
+      settings: settings,
+      requestFocus: requestFocus,
+      builder: effectiveBuilder,
+      backgroundColor: backgroundColor,
+      barrierColor: barrierColor ?? sheetTheme.barrierColor ?? defaults.barrierColor,
+      barrierLabel: barrierLabel ?? localizations.scrimLabel,
+      shape: shape,
+      borderRadius: borderRadius,
+      constraints: constraints,
+      elevation: elevation,
+      clipBehavior: clipBehavior,
+      enableDrag: enableDrag,
+      isDismissible: isDismissible,
+      showDragHandle: showDragHandle,
+      anchorPoint: anchorPoint,
+      onDragStart: onDragStart,
+      onDragEnd: onDragEnd,
+      parentSheet: parentSheet,
+      capturedThemes: capturedThemes,
+    ),
+  );
+}
+
+// Wraps [innerBuilder] in a nested [Navigator] so callers can push routes
+// within the sheet. A [PopScope] on the initial route intercepts pops and
+// dismisses the entire sheet via the root navigator.
+StreamSheetScrollableWidgetBuilder _wrapWithNestedNavigator<T>(
+  StreamSheetScrollableWidgetBuilder innerBuilder,
+) {
+  final nestedNavigatorKey = GlobalKey<NavigatorState>();
+  return (context, scrollController) {
+    return NavigatorPopHandler(
+      onPopWithResult: (T? _) {
+        nestedNavigatorKey.currentState!.maybePop();
+      },
+      child: Navigator(
+        key: nestedNavigatorKey,
+        initialRoute: '/',
+        onGenerateInitialRoutes: (navigator, _) {
+          return <Route<void>>[
+            MaterialPageRoute<void>(
+              builder: (context) {
+                return PopScope(
+                  canPop: false,
+                  onPopInvokedWithResult: (didPop, _) {
+                    if (didPop) return;
+                    StreamSheetRoute.popSheet(context);
+                  },
+                  child: innerBuilder(context, scrollController),
+                );
+              },
+            ),
+          ];
+        },
+      ),
+    );
+  };
+}
+
+/// Slide-up transition used by [StreamSheetRoute].
+///
+/// Drives three animations:
+///
+///  * Primary — slides the sheet up from below the screen on push and
+///    reverses on pop.
+///  * Secondary — when another sheet is pushed on top, slides this sheet
+///    slightly upward and scales it down so the foreground reads as the
+///    active surface and the underlying sheet peeks at the lateral inset.
+///  * Stretch — while the sheet is fully open, additional upward drag
+///    extends the top edge a few pixels as a rubber-band effect that
+///    relaxes back on release.
+///
+/// See also:
+///
+///  * [StreamSheetRoute], which uses this transition.
+class StreamSheetTransition extends StatefulWidget {
+  /// Creates a Stream-styled sheet transition.
+  const StreamSheetTransition({
+    super.key,
+    required this.primaryRouteAnimation,
+    required this.secondaryRouteAnimation,
+    required this.child,
+    required this.topPadding,
+    this.linearTransition = false,
+    this.isStacked = false,
+  });
+
+  /// Linear route animation from `0.0` to `1.0` when this sheet is being
+  /// pushed (and the reverse when it is being popped).
+  final Animation<double> primaryRouteAnimation;
+
+  /// Linear route animation from `0.0` to `1.0` when another sheet is being
+  /// pushed on top of this one (and the reverse when it is being popped).
+  final Animation<double> secondaryRouteAnimation;
+
+  /// The widget below this widget in the tree.
+  final Widget child;
+
+  /// The y-offset (in logical pixels) of this sheet's top edge,
+  /// measured from the bottom of the system top inset (e.g. just below
+  /// the status bar / notch — system insets are already consumed by
+  /// the route's `SafeArea` wrap).
+  ///
+  /// Applied as a top padding wrapping the transforms — shrinks
+  /// dynamically while the upward-stretch animation is active so the
+  /// sheet's *bottom* stays at the screen edge while the top extends
+  /// upward (rubber-band feel without leaving a gap at the bottom).
+  final double topPadding;
+
+  /// Whether to animate the sheet linearly. Set to `true` while a pop drag is
+  /// in progress so the sheet tracks the finger.
+  final bool linearTransition;
+
+  /// Whether this sheet was pushed on top of another [StreamSheetRoute].
+  ///
+  /// Currently informational — both root and stacked sheets share the
+  /// same primary slide-up tween (ending at rest, no bottom gap).
+  /// Reserved for future per-depth transition tweaks if Stream's
+  /// stacking design diverges from the root. Mirrors
+  /// [StreamSheetRoute.isStacked].
+  final bool isStacked;
+
+  @override
+  State<StreamSheetTransition> createState() => _StreamSheetTransitionState();
+}
+
+class _StreamSheetTransitionState extends State<StreamSheetTransition> with SingleTickerProviderStateMixin {
+  // Drives the upward-stretch rubber band when the user keeps dragging up
+  // past the sheet's open position. `0.0` is at rest, `1.0` is fully
+  // stretched.
+  late final AnimationController _stretchController;
+
+  CurvedAnimation? _primaryCurve;
+  CurvedAnimation? _secondaryCurve;
+
+  late Animation<Offset> _primaryPositionAnimation;
+  late Animation<Offset> _secondaryPositionAnimation;
+  late Animation<double> _secondaryScaleAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _stretchController = AnimationController(
+      duration: const Duration(microseconds: 1),
+      vsync: this,
+    );
+    _setupAnimations();
+  }
+
+  @override
+  void didUpdateWidget(covariant StreamSheetTransition oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.primaryRouteAnimation != widget.primaryRouteAnimation ||
+        oldWidget.secondaryRouteAnimation != widget.secondaryRouteAnimation ||
+        oldWidget.linearTransition != widget.linearTransition ||
+        oldWidget.isStacked != widget.isStacked) {
+      _disposeCurves();
+      _setupAnimations();
+    }
+  }
+
+  @override
+  void dispose() {
+    _stretchController.dispose();
+    _disposeCurves();
+    super.dispose();
+  }
+
+  void _setupAnimations() {
+    _primaryCurve = CurvedAnimation(
+      parent: widget.primaryRouteAnimation,
+      curve: widget.linearTransition ? Curves.linear : Curves.fastEaseInToSlowEaseOut,
+      reverseCurve: widget.linearTransition ? Curves.linear : Curves.fastEaseInToSlowEaseOut.flipped,
+    );
+    _primaryPositionAnimation = _primaryCurve!.drive(_kBottomUpTween);
+
+    // Secondary transition (scale + slide-up) applies to every covered
+    // sheet — produces the deck-of-cards effect when sheets stack. The
+    // covered sheet scales down by 0.0835 around its top center and
+    // slides up by 0.005 of its slot height.
+    _secondaryCurve = CurvedAnimation(
+      parent: widget.secondaryRouteAnimation,
+      curve: Curves.linearToEaseOut,
+      reverseCurve: Curves.easeInToLinear,
+    );
+    _secondaryPositionAnimation = _secondaryCurve!.drive(_kStackedSheetMidUpTween);
+    _secondaryScaleAnimation = _secondaryCurve!.drive(_kStackedSheetScaleTween);
+  }
+
+  void _disposeCurves() {
+    _primaryCurve?.dispose();
+    _secondaryCurve?.dispose();
+    _primaryCurve = null;
+    _secondaryCurve = null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _StreamSheetTransitionScope(
+      stretchController: _stretchController,
+      child: AnimatedBuilder(
+        animation: _stretchController,
+        builder: (context, child) {
+          // Effective top padding wrapping the transforms — shrinks
+          // when the user stretches up, growing the sheet's slot
+          // height. The Padding sits *outside* the ScaleTransition so
+          // the gap stays constant when the sheet is covered.
+          //
+          // The system top inset is already consumed by the route's
+          // `SafeArea(bottom: false)` wrap (see `buildPage`), so this
+          // padding is purely the design-system peek (`topPadding`)
+          // minus the active rubber-band stretch.
+          final stretchAmount = context.streamSpacing.xs;
+          final stretchedTop = widget.topPadding - _stretchController.value * stretchAmount;
+          return Padding(
+            padding: EdgeInsets.only(top: math.max(0, stretchedTop)),
+            child: child,
+          );
+        },
+        child: SlideTransition(
+          position: _secondaryPositionAnimation,
+          transformHitTests: false,
+          child: ScaleTransition(
+            scale: _secondaryScaleAnimation,
+            filterQuality: FilterQuality.medium,
+            alignment: Alignment.topCenter,
+            child: SlideTransition(
+              position: _primaryPositionAnimation,
+              child: widget.child,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// InheritedWidget hosting the transition's per-instance state (stretch
+// controller + drag handle WidgetState notifier) so descendants — drag
+// gesture detectors, scroll position — can reach it without threading
+// the reference through every widget.
+class _StreamSheetTransitionScope extends InheritedWidget {
+  const _StreamSheetTransitionScope({
+    required this.stretchController,
+    required super.child,
+  });
+
+  final AnimationController stretchController;
+
+  static _StreamSheetTransitionScope? maybeOf(BuildContext context) {
+    return context.getInheritedWidgetOfExactType<_StreamSheetTransitionScope>();
+  }
+
+  @override
+  bool updateShouldNotify(_StreamSheetTransitionScope oldWidget) {
+    return stretchController != oldWidget.stretchController;
+  }
+}
+
+/// The visual chrome of a Stream-styled sheet.
+///
+/// Renders [child] on the design system's sheet surface — rounded top
+/// corners, [StreamColorScheme.backgroundElevation1] background,
+/// elevation `1`, and anti-aliased clipping. Each visual property
+/// follows the same resolution chain — the per-instance argument wins,
+/// then [StreamSheetThemeData] (from [StreamTheme.sheetTheme] or a
+/// nearer [StreamSheetTheme]), then the built-in fallback.
+///
+/// Used by [StreamSheetRoute] to render the sheet's surface; can also
+/// be used standalone when a sheet-like surface is needed outside a
+/// modal route. The widget is purely visual — it does *not* implement
+/// drag-to-dismiss (that's the route's job) and does *not* render a
+/// drag handle (compose [StreamSheetDragHandle] over [child] when
+/// needed).
+///
+/// {@tool snippet}
+///
+/// A standalone sheet surface:
+///
+/// ```dart
+/// StreamSheet(
+///   constraints: BoxConstraints(maxWidth: 480),
+///   child: Column(
+///     mainAxisSize: MainAxisSize.min,
+///     children: [
+///       StreamSheetHeader(title: Text('Details')),
+///       // ... contents
+///     ],
+///   ),
+/// )
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [StreamSheetThemeData], which describes the configurable properties
+///    and their defaults.
+///  * [StreamSheetRoute] / [showStreamSheet], the modal route that uses
+///    this widget.
+///  * [StreamSheetDragHandle], the visual handle drawn at the top of a
+///    modal sheet.
+class StreamSheet extends StatelessWidget {
+  /// Creates a Stream-styled sheet surface.
+  const StreamSheet({
+    super.key,
+    required this.child,
+    this.backgroundColor,
+    this.surfaceTintColor,
+    this.shadowColor,
+    this.elevation,
+    this.shape,
+    this.borderRadius,
+    this.clipBehavior,
+    this.constraints,
+  });
+
+  /// The widget below this widget in the tree — typically the body of
+  /// the sheet.
+  final Widget child;
+
+  /// The background color of the sheet.
+  ///
+  /// When `null`, falls back to [StreamSheetThemeData.backgroundColor]
+  /// and finally to [StreamColorScheme.backgroundElevation1].
+  final Color? backgroundColor;
+
+  /// The surface tint color used as an overlay on the sheet's
+  /// background.
+  ///
+  /// When `null`, falls back to [StreamSheetThemeData.surfaceTintColor].
+  /// If still `null`, no overlay color is drawn.
+  final Color? surfaceTintColor;
+
+  /// The shadow color cast around the sheet.
+  ///
+  /// When `null`, falls back to [StreamSheetThemeData.shadowColor].
+  final Color? shadowColor;
+
+  /// The elevation of the sheet.
+  ///
+  /// When `null`, falls back to [StreamSheetThemeData.elevation] and
+  /// finally to `1`.
+  final double? elevation;
+
+  /// The shape applied to the sheet.
+  ///
+  /// Takes precedence over [borderRadius] when non-null. When `null`,
+  /// falls back to [StreamSheetThemeData.shape].
+  final ShapeBorder? shape;
+
+  /// The border radius applied to the sheet.
+  ///
+  /// Ignored when an effective [shape] is in effect. When `null`, falls
+  /// back to [StreamSheetThemeData.borderRadius] and finally to a
+  /// top-corner [StreamRadius.xxxxl] radius and square bottom corners.
+  final BorderRadiusGeometry? borderRadius;
+
+  /// How to clip the sheet's content against its [shape] / [borderRadius].
+  ///
+  /// When `null`, falls back to [StreamSheetThemeData.clipBehavior] and
+  /// finally to [Clip.antiAlias].
+  final Clip? clipBehavior;
+
+  /// Optional [BoxConstraints] applied around the sheet.
+  ///
+  /// Most useful on tablet/desktop to cap the sheet's width. The sheet
+  /// is bottom-aligned within the constraints. When `null`, falls back
+  /// to [StreamSheetThemeData.constraints]; if still `null`, the sheet
+  /// is unconstrained.
+  final BoxConstraints? constraints;
+
+  @override
+  Widget build(BuildContext context) {
+    final sheetTheme = StreamSheetTheme.of(context);
+    final defaults = _StreamSheetDefaults(context);
+
+    final effectiveElevation = elevation ?? sheetTheme.elevation ?? defaults.elevation;
+    final effectiveBackgroundColor = backgroundColor ?? sheetTheme.backgroundColor ?? defaults.backgroundColor;
+    final effectiveSurfaceTintColor = surfaceTintColor ?? sheetTheme.surfaceTintColor ?? defaults.surfaceTintColor;
+    final effectiveShadowColor = shadowColor ?? sheetTheme.shadowColor ?? defaults.shadowColor;
+    final effectiveShape = shape ?? sheetTheme.shape ?? defaults.shape;
+    // [borderRadius] is ignored when an explicit shape is in effect.
+    final effectiveBorderRadius = borderRadius ?? sheetTheme.borderRadius ?? defaults.borderRadius;
+    final effectiveClipBehavior = clipBehavior ?? sheetTheme.clipBehavior ?? defaults.clipBehavior;
+    final effectiveConstraints = constraints ?? sheetTheme.constraints ?? defaults.constraints;
+
+    return Align(
+      heightFactor: 1,
+      alignment: .bottomCenter,
+      child: ConstrainedBox(
+        constraints: effectiveConstraints,
+        child: Material(
+          shape: effectiveShape,
+          clipBehavior: effectiveClipBehavior,
+          elevation: effectiveElevation,
+          color: effectiveBackgroundColor,
+          surfaceTintColor: effectiveSurfaceTintColor,
+          shadowColor: effectiveShadowColor,
+          borderRadius: effectiveBorderRadius,
+          child: child,
+        ),
+      ),
+    );
+  }
+}
+
+/// Modal route for a Stream-styled sheet.
+///
+/// The sheet slides up from the bottom of the screen and rests just
+/// below the top with a small fixed peek of [StreamSpacing.sm]. Users
+/// can dismiss it by dragging downwards or via [popSheet].
+///
+/// Typically created by [showStreamSheet].
+///
+/// See also:
+///
+///  * [showStreamSheet], the convenience entry point.
+///  * [StreamSheet], the widget rendering the sheet's visual chrome.
+///  * [StreamSheetTransition], the slide-up transition the route uses.
+///  * [StreamSheetHeader], the auto-aware header component.
+class StreamSheetRoute<T> extends PageRoute<T> {
+  /// Creates a [StreamSheetRoute].
+  StreamSheetRoute({
+    super.settings,
+    super.requestFocus,
+    required this.builder,
+    this.backgroundColor,
+    Color? barrierColor,
+    this.barrierLabel,
+    this.shape,
+    this.borderRadius,
+    this.constraints,
+    this.elevation,
+    this.clipBehavior,
+    this.enableDrag = true,
+    this.isDismissible = false,
+    this.showDragHandle,
+    this.anchorPoint,
+    this.onDragStart,
+    this.onDragEnd,
+    this.parentSheet,
+    this.capturedThemes,
+  }) : _barrierColor = barrierColor;
+
+  /// Builds the primary contents of the sheet. The provided [ScrollController]
+  /// should be attached to the topmost scrollable widget inside the sheet.
+  final StreamSheetScrollableWidgetBuilder builder;
+
+  /// The background color of the sheet.
+  ///
+  /// When `null`, defaults to [StreamColorScheme.backgroundElevation1].
+  final Color? backgroundColor;
+
+  // Private storage so we can override [ModalRoute.barrierColor] while still
+  // accepting a constructor argument with the same name.
+  final Color? _barrierColor;
+
+  /// The shape applied to the sheet.
+  ///
+  /// Takes precedence over [borderRadius] when non-null. Useful for
+  /// non-rectangular sheets (e.g. with a clipped notch) where a plain
+  /// [BorderRadiusGeometry] isn't expressive enough.
+  final ShapeBorder? shape;
+
+  /// The border radius applied to the sheet.
+  ///
+  /// Ignored when [shape] is non-null. When both are `null`, defaults to
+  /// a top-corner [StreamRadius.xxxxl] radius and square bottom corners.
+  final BorderRadiusGeometry? borderRadius;
+
+  /// Optional [BoxConstraints] applied around the sheet.
+  ///
+  /// Most useful on tablet/desktop to cap the sheet's width. The sheet is
+  /// bottom-aligned within the constraints.
+  final BoxConstraints? constraints;
+
+  /// The elevation of the sheet.
+  ///
+  /// Drives the shadow cast around the sheet — most visible at the top
+  /// edge, where the sheet meets the content behind it.
+  final double? elevation;
+
+  /// How to clip the sheet's content against its [shape] / [borderRadius].
+  ///
+  /// When `null`, falls back to [StreamSheetThemeData.clipBehavior] and
+  /// finally to [Clip.antiAlias] for smooth rounded corners.
+  final Clip? clipBehavior;
+
+  /// Whether the sheet body can be dismissed by dragging it down.
+  ///
+  /// Even when this is `false`, the drag handle (if [showDragHandle] is
+  /// `true`) remains draggable so the visible affordance never lies.
+  final bool enableDrag;
+
+  /// Whether tapping the modal barrier dismisses the sheet.
+  ///
+  /// Defaults to `false`. Pair with a non-`null` [barrierColor] to give
+  /// users a visible target to tap.
+  final bool isDismissible;
+
+  /// Whether to display a drag handle at the top of the sheet content.
+  ///
+  /// When `true`, the handle is overlaid at the top of the sheet's body
+  /// just under the rounded top corners. The body should leave space
+  /// for it (e.g. by starting with [StreamSheetHeader]) — the handle
+  /// itself doesn't reserve layout room.
+  ///
+  /// When `null`, falls back to [StreamSheetThemeData.showDragHandle]
+  /// and finally to `true`.
+  final bool? showDragHandle;
+
+  /// {@macro flutter.widgets.DisplayFeatureSubScreen.anchorPoint}
+  final Offset? anchorPoint;
+
+  /// Called when the user begins dragging the sheet vertically.
+  final StreamSheetDragStartCallback? onDragStart;
+
+  /// Called when the user stops dragging the sheet vertically.
+  ///
+  /// The `isClosing` flag indicates whether the sheet will pop in
+  /// response to the gesture (either because of a downward fling or
+  /// because the drag passed the close threshold).
+  final StreamSheetDragEndCallback? onDragEnd;
+
+  /// The [StreamSheetRoute] this sheet was pushed on top of, if any.
+  ///
+  /// Used to compute the foreground sheet's top padding so it sits exactly
+  /// `spacing.sm` below the parent sheet's transformed top edge — and to
+  /// drive the auto-imply leading icon in [StreamSheetHeader] (a stacked
+  /// sheet shows a back chevron instead of a close icon).
+  ///
+  /// Set automatically by [showStreamSheet] using the nearest enclosing
+  /// [StreamSheetRoute].
+  final StreamSheetRoute<dynamic>? parentSheet;
+
+  /// [InheritedTheme]s captured from the calling context, re-applied
+  /// inside the sheet via [CapturedThemes.wrap] in [buildPage].
+  ///
+  /// The sheet is pushed onto the navigator's overlay, which is
+  /// typically *outside* any local theme overrides (a `StreamTheme`
+  /// or `Theme` set in a sub-tree, a `Directionality.rtl`, etc.).
+  /// Capturing the calling context's inherited widgets and re-wrapping
+  /// the sheet ensures it renders with the same theme as the caller.
+  ///
+  /// Set automatically by [showStreamSheet]. Pass `null` to disable.
+  final CapturedThemes? capturedThemes;
+
+  /// Whether this sheet was pushed on top of another [StreamSheetRoute].
+  ///
+  /// Stacked sheets render a back-chevron in their auto-implied
+  /// [StreamSheetHeader] leading slot (popping reveals the parent
+  /// sheet); root sheets render a close-cross (popping dismisses the
+  /// sheet entirely).
+  bool get isStacked => parentSheet != null;
+
+  /// The y-offset (in logical pixels) of this sheet's top edge at
+  /// rest, measured from the bottom of the system top inset.
+  ///
+  /// Resolves to a fixed [StreamSpacing.sm] for both root and stacked
+  /// sheets — the design-system peek between the sheet and the system
+  /// top inset (status bar / notch). The system inset itself is
+  /// consumed by the route's `SafeArea` wrap, so the sheet visually
+  /// rests at `viewPadding.top + topPaddingFor(context)`.
+  double topPaddingFor(BuildContext context) {
+    return context.streamSpacing.sm;
+  }
+
+  @override
+  Color? get barrierColor => _barrierColor ?? Colors.transparent;
+
+  @override
+  bool get barrierDismissible => isDismissible;
+
+  @override
+  final String? barrierLabel;
+
+  @override
+  bool get maintainState => true;
+
+  @override
+  bool get opaque => false;
+
+  @override
+  Duration get transitionDuration => const Duration(milliseconds: 500);
+
+  // We only forward the secondaryAnimation (and therefore animate the
+  // stacked-sheet scale + slide on the previous sheet) when another
+  // [StreamSheetRoute] is being pushed on top of this one. Pushing a
+  // regular [PageRoute] over a sheet leaves the sheet untouched.
+  //
+  // For non-sheet previous routes, [delegatedTransition] takes over and
+  // animates them out of the way as this sheet rises.
+  // Sheet-over-sheet stacking goes through the previous sheet's
+  // `buildTransitions` (via `secondaryAnimation`) rather than the
+  // delegated transition — that's how the deck-of-cards effect lands on
+  // every covered sheet. The non-sheet route below the first sheet
+  // intentionally stays still: we don't override `delegatedTransition`,
+  // so a regular page underneath isn't transformed when the sheet rises
+  // over it.
+  @override
+  bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
+    return nextRoute is StreamSheetRoute;
+  }
+
+  @override
+  Widget buildPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
+    final content = _StreamDraggableScrollableSheet(
+      enableDrag: () => enableDrag,
+      popDragController: controller!,
+      navigator: navigator!,
+      getIsCurrent: () => isCurrent,
+      getIsActive: () => isActive,
+      builder: _buildBodyWithDragHandle,
+    );
+
+    Widget sheet = StreamSheet(
+      backgroundColor: backgroundColor,
+      elevation: elevation,
+      shape: shape,
+      borderRadius: borderRadius,
+      clipBehavior: clipBehavior,
+      constraints: constraints,
+      child: _StreamSheetScope(route: this, child: content),
+    );
+
+    // System-inset handling. A single `SafeArea(bottom: false)`
+    // consumes the top, left, and right system insets *and* strips
+    // them from `MediaQuery` for descendants — so any inner
+    // `SafeArea` / `StreamSheetHeader` inside the sheet does not
+    // re-pad the status bar / notch.
+    //
+    // Bottom is intentionally retained so descendants can opt-in to
+    // the home-indicator / keyboard inset via their own
+    // `SafeArea(bottom: true)`.
+    //
+    // On top of this, the transition's animated `Padding` adds the
+    // design-system peek (`topPadding`) plus the rubber-band stretch.
+    sheet = SafeArea(bottom: false, child: sheet);
+
+    sheet = DisplayFeatureSubScreen(
+      anchorPoint: anchorPoint,
+      child: sheet,
+    );
+
+    // Re-apply captured InheritedThemes (StreamTheme, Theme,
+    // Directionality, etc.) so the sheet renders with the same
+    // ambient theme as the calling context, even though it's pushed
+    // onto the navigator's overlay above any local theme overrides.
+    return capturedThemes?.wrap(sheet) ?? sheet;
+  }
+
+  /// The nearest enclosing [StreamSheetRoute] for [context], or `null`
+  /// if [context] isn't inside any sheet.
+  ///
+  /// Walks the widget tree via the InheritedWidget set up in
+  /// [buildPage]. Use this from anything inside a sheet that needs to
+  /// react to the sheet's identity (auto-implied headers, drag
+  /// handles, body content, etc.) — e.g.:
+  ///
+  /// ```dart
+  /// final sheet = StreamSheetRoute.maybeOf(context);
+  /// if (sheet != null && sheet.isStacked) {
+  ///   // Render a back chevron etc.
+  /// }
+  /// ```
+  ///
+  /// Continues to find the enclosing sheet even when [context] is
+  /// inside a sheet's nested navigator (see `useNestedNavigation` on
+  /// [showStreamSheet]).
+  static StreamSheetRoute<dynamic>? maybeOf(BuildContext context) {
+    return _StreamSheetScope.maybeOf(context)?.route;
+  }
+
+  /// Whether [context] is currently inside a [StreamSheetRoute].
+  ///
+  /// Convenience wrapper over [maybeOf]. Equivalent to
+  /// `maybeOf(context) != null`.
+  static bool hasParentSheet(BuildContext context) {
+    return maybeOf(context) != null;
+  }
+
+  /// Whether the enclosing [StreamSheetRoute] for [context] is itself
+  /// stacked over another sheet.
+  ///
+  /// Convenience wrapper over [maybeOf]. Equivalent to
+  /// `maybeOf(context)?.isStacked ?? false`.
+  static bool inStackedSheet(BuildContext context) {
+    return maybeOf(context)?.isStacked ?? false;
+  }
+
+  /// Pops the entire enclosing [StreamSheetRoute], if one is in the stack.
+  ///
+  /// Useful when the sheet uses nested navigation (see the
+  /// `useNestedNavigation` parameter on [showStreamSheet]) and you want to
+  /// dismiss the whole sheet at once instead of just the current nested
+  /// route.
+  static void popSheet(BuildContext context) {
+    final scope = _StreamSheetScope.maybeOf(context);
+    final route = scope?.route;
+    if (route == null) return;
+    final navigator = route.navigator;
+    if (navigator == null) return;
+    if (navigator.canPop()) navigator.pop();
+  }
+
+  Widget _buildBodyWithDragHandle(
+    BuildContext context,
+    ScrollController scrollController,
+  ) {
+    final body = builder(context, scrollController);
+    final sheetTheme = StreamSheetTheme.of(context);
+    final defaults = _StreamSheetDefaults(context);
+    final effectiveShowDragHandle = showDragHandle ?? sheetTheme.showDragHandle ?? defaults.showDragHandle;
+    if (!effectiveShowDragHandle) return body;
+
+    final spacing = context.streamSpacing;
+
+    Widget handle = Padding(
+      padding: EdgeInsets.only(top: spacing.xxs),
+      child: const StreamSheetDragHandle(),
+    );
+
+    // When the body isn't draggable, the visible drag handle still must
+    // be — otherwise the affordance lies. Wrap just the handle in its
+    // own gesture detector so it pops the sheet via the route's drag
+    // controller.
+    if (!enableDrag) {
+      handle = _StreamDragGestureDetector(
+        enabledCallback: () => true,
+        onStartPopGesture: _startPopGesture,
+        onDragStart: onDragStart,
+        onDragEnd: onDragEnd,
+        child: handle,
+      );
+    }
+
+    // The body fills the sheet; the drag handle floats over the top
+    // with a tiny offset. Stream's chrome (sheet header, etc.) is
+    // expected to leave space at the top for the handle.
+    return Stack(
+      fit: StackFit.expand,
+      children: <Widget>[
+        body,
+        Align(alignment: Alignment.topCenter, child: handle),
+      ],
+    );
+  }
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return StreamSheetTransition(
+      primaryRouteAnimation: animation,
+      secondaryRouteAnimation: secondaryAnimation,
+      linearTransition: popGestureInProgress,
+      isStacked: isStacked,
+      topPadding: topPaddingFor(context),
+      child: _StreamDragGestureDetector(
+        enabledCallback: () => enableDrag,
+        onStartPopGesture: _startPopGesture,
+        onDragStart: onDragStart,
+        onDragEnd: onDragEnd,
+        child: child,
+      ),
+    );
+  }
+
+  _StreamDragGestureController _startPopGesture() {
+    return _StreamDragGestureController(
+      navigator: navigator!,
+      popDragController: controller!,
+      getIsCurrent: () => isCurrent,
+      getIsActive: () => isActive,
+    );
+  }
+}
+
+/// The visual drag handle drawn at the top of a Stream-styled sheet.
+///
+/// A small pill-shaped indicator that signals the sheet can be
+/// dismissed by dragging. Wrapped in a [Semantics] node so assistive
+/// technology can dismiss the enclosing sheet by tapping the handle
+/// (`Navigator.maybePop`).
+///
+/// The handle's color and size resolve from
+/// [StreamSheetThemeData.dragHandleColor] /
+/// [StreamSheetThemeData.dragHandleSize], with built-in fallbacks of
+/// [StreamColorScheme.accentNeutral] and a `36 × 5` pill.
+///
+/// Used by [StreamSheetRoute] internally; can also be composed by
+/// callers when building custom sheet content.
+class StreamSheetDragHandle extends StatelessWidget {
+  /// Creates a Stream-styled sheet drag handle.
+  const StreamSheetDragHandle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final radius = context.streamRadius;
+    final sheetTheme = StreamSheetTheme.of(context);
+    final defaults = _StreamSheetDefaults(context);
+    final localizations = MaterialLocalizations.of(context);
+
+    final size = sheetTheme.dragHandleSize ?? defaults.dragHandleSize;
+    final color = sheetTheme.dragHandleColor ?? defaults.dragHandleColor;
+
+    return Semantics(
+      label: localizations.modalBarrierDismissLabel,
+      container: true,
+      button: true,
+      onTap: Navigator.of(context).maybePop,
+      child: Container(
+        height: size.height,
+        width: size.width,
+        decoration: ShapeDecoration(
+          color: color,
+          shape: RoundedSuperellipseBorder(
+            borderRadius: .all(radius.max),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StreamDragGestureDetector extends StatefulWidget {
+  const _StreamDragGestureDetector({
+    required this.enabledCallback,
+    required this.onStartPopGesture,
+    required this.child,
+    this.onDragStart,
+    this.onDragEnd,
+  });
+
+  final Widget child;
+  final ValueGetter<bool> enabledCallback;
+  final ValueGetter<_StreamDragGestureController> onStartPopGesture;
+  final StreamSheetDragStartCallback? onDragStart;
+  final StreamSheetDragEndCallback? onDragEnd;
+
+  @override
+  State<_StreamDragGestureDetector> createState() => _StreamDragGestureDetectorState();
+}
+
+class _StreamDragGestureDetectorState extends State<_StreamDragGestureDetector> {
+  _StreamDragGestureController? _dragGestureController;
+  late final VerticalDragGestureRecognizer _recognizer;
+
+  _StreamSheetTransitionScope? _transitionScope;
+
+  @override
+  void initState() {
+    super.initState();
+    _recognizer = VerticalDragGestureRecognizer(debugOwner: this)
+      // Use the fling-aware velocity tracker so end-of-drag velocities
+      // are weighted toward the most recent samples, matching the feel
+      // of a flick gesture closing the sheet.
+      ..velocityTrackerBuilder = _flingVelocityBuilder
+      ..onStart = _handleDragStart
+      ..onUpdate = _handleDragUpdate
+      ..onEnd = _handleDragEnd
+      ..onCancel = _handleDragCancel;
+  }
+
+  static VelocityTracker _flingVelocityBuilder(PointerEvent event) => IOSScrollViewFlingVelocityTracker(event.kind);
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _transitionScope = _StreamSheetTransitionScope.maybeOf(context);
+  }
+
+  @override
+  void dispose() {
+    _recognizer.dispose();
+    if (_dragGestureController != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (_dragGestureController?.navigator.mounted ?? false) {
+          _dragGestureController?.navigator.didStopUserGesture();
+        }
+        _dragGestureController = null;
+      });
+    }
+    super.dispose();
+  }
+
+  void _handleDragStart(DragStartDetails details) {
+    _dragGestureController = widget.onStartPopGesture();
+    widget.onDragStart?.call(details);
+  }
+
+  void _handleDragUpdate(DragUpdateDetails details) {
+    final size = context.size;
+    if (size == null || size.height <= 0) return;
+    _dragGestureController?.dragUpdate(
+      details.primaryDelta!,
+      sheetHeight: size.height,
+      stretchPixels: context.streamSpacing.xs,
+      stretchController: _transitionScope?.stretchController,
+    );
+  }
+
+  void _handleDragEnd(DragEndDetails details) {
+    final size = context.size;
+    final velocity = size != null && size.height > 0 ? details.velocity.pixelsPerSecond.dy / size.height : 0.0;
+    final isClosing =
+        _dragGestureController?.dragEnd(
+          velocity,
+          _transitionScope?.stretchController,
+        ) ??
+        false;
+    _dragGestureController = null;
+    widget.onDragEnd?.call(details, isClosing: isClosing);
+  }
+
+  void _handleDragCancel() {
+    _dragGestureController?.dragEnd(0, _transitionScope?.stretchController);
+    _dragGestureController = null;
+  }
+
+  void _handlePointerDown(PointerDownEvent event) {
+    if (widget.enabledCallback()) {
+      _recognizer.addPointer(event);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerDown: _handlePointerDown,
+      behavior: HitTestBehavior.translucent,
+      child: widget.child,
+    );
+  }
+}
+
+class _StreamDragGestureController {
+  _StreamDragGestureController({
+    required this.navigator,
+    required this.popDragController,
+    required this.getIsCurrent,
+    required this.getIsActive,
+  }) {
+    navigator.didStartUserGesture();
+  }
+
+  final NavigatorState navigator;
+  final AnimationController popDragController;
+  final ValueGetter<bool> getIsCurrent;
+  final ValueGetter<bool> getIsActive;
+
+  /// Applies a vertical pixel drag delta (`+y` is downward).
+  /// [sheetHeight] is the sheet content's rendered height (used to
+  /// normalise the pop animation), and [stretchPixels] is the rubber-
+  /// band's full-stretch range (typically `spacing.sm`).
+  ///
+  /// When the sheet is fully open and the finger keeps moving up,
+  /// drives [stretchController] (if provided) to produce the rubber-band
+  /// stretch effect. Otherwise updates the sheet's pop animation as
+  /// usual.
+  void dragUpdate(
+    double pixelsDelta, {
+    required double sheetHeight,
+    required double stretchPixels,
+    AnimationController? stretchController,
+  }) {
+    if (sheetHeight <= 0) return;
+    var remaining = pixelsDelta;
+
+    // Rubber-band: only kicks in once the sheet is fully open and the
+    // user is still dragging up.
+    if (popDragController.value >= 1.0 && remaining < 0 && stretchController != null) {
+      if (stretchPixels > 0) {
+        stretchController.value = (stretchController.value - remaining / stretchPixels).clamp(0.0, 1.0);
+      }
+      return;
+    }
+
+    // If the user is now dragging back down out of a stretched state,
+    // unwind the stretch first before touching the pop controller.
+    if (stretchController != null && stretchController.value > 0 && remaining > 0 && stretchPixels > 0) {
+      final prev = stretchController.value;
+      final next = (prev - remaining / stretchPixels).clamp(0.0, 1.0);
+      stretchController.value = next;
+      if (next > 0) return;
+      // Carry over any leftover delta after unwinding the stretch.
+      remaining -= prev * stretchPixels;
+    }
+
+    popDragController.value -= remaining / sheetHeight;
+  }
+
+  /// Ends the drag with a vertical velocity (in fractions of screen height
+  /// per second). Either pops the route or animates it back to fully open.
+  ///
+  /// Returns whether the gesture caused the sheet to close.
+  bool dragEnd(double velocity, [AnimationController? stretchController]) {
+    // Relax the rubber-band stretch back to 0 before deciding pop/keep.
+    if (stretchController != null && stretchController.value > 0) {
+      stretchController.animateTo(
+        0,
+        duration: _kStretchSettleDuration,
+        curve: Curves.easeOut,
+      );
+      navigator.didStopUserGesture();
+      return false;
+    }
+
+    const animationCurve = Curves.easeOut;
+    final isCurrent = getIsCurrent();
+    final bool animateForward;
+
+    if (!isCurrent) {
+      animateForward = getIsActive();
+    } else if (velocity.abs() >= _kMinFlingVelocity) {
+      animateForward = velocity <= 0;
+    } else {
+      animateForward = popDragController.value > 0.52;
+    }
+
+    if (animateForward) {
+      popDragController.animateTo(
+        1,
+        duration: _kSettleDuration,
+        curve: animationCurve,
+      );
+    } else {
+      if (isCurrent) navigator.pop();
+      if (popDragController.isAnimating) {
+        popDragController.animateBack(
+          0,
+          duration: _kSettleDuration,
+          curve: animationCurve,
+        );
+      }
+    }
+
+    if (popDragController.isAnimating) {
+      void animationStatusCallback(AnimationStatus status) {
+        navigator.didStopUserGesture();
+        popDragController.removeStatusListener(animationStatusCallback);
+      }
+
+      popDragController.addStatusListener(animationStatusCallback);
+    } else {
+      navigator.didStopUserGesture();
+    }
+
+    return !animateForward;
+  }
+}
+
+// Wires the [ScrollController] forwarded to the sheet's body to the route's
+// drag-to-dismiss controller, so dragging a scroll view past its top edge
+// dismisses the sheet.
+class _StreamDraggableScrollableSheet extends StatefulWidget {
+  const _StreamDraggableScrollableSheet({
+    required this.enableDrag,
+    required this.popDragController,
+    required this.navigator,
+    required this.getIsCurrent,
+    required this.getIsActive,
+    required this.builder,
+  });
+
+  final ValueGetter<bool> enableDrag;
+  final AnimationController popDragController;
+  final NavigatorState navigator;
+  final ValueGetter<bool> getIsCurrent;
+  final ValueGetter<bool> getIsActive;
+  final StreamSheetScrollableWidgetBuilder builder;
+
+  @override
+  State<_StreamDraggableScrollableSheet> createState() => _StreamDraggableScrollableSheetState();
+}
+
+class _StreamDraggableScrollableSheetState extends State<_StreamDraggableScrollableSheet> {
+  late final _StreamSheetScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = _StreamSheetScrollController(
+      enableDrag: widget.enableDrag,
+      popDragController: widget.popDragController,
+      navigator: widget.navigator,
+      getIsCurrent: widget.getIsCurrent,
+      getIsActive: widget.getIsActive,
+    );
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(context, _scrollController);
+  }
+}
+
+/// A [ScrollController] used by [StreamSheetRoute]'s body that, when the
+/// scrollable is at its top edge, hands additional drag-down deltas to the
+/// route's pop-drag controller so the user's gesture seamlessly transitions
+/// from scrolling to dismissing the sheet.
+class _StreamSheetScrollController extends ScrollController {
+  _StreamSheetScrollController({
+    required this.enableDrag,
+    required this.popDragController,
+    required this.navigator,
+    required this.getIsCurrent,
+    required this.getIsActive,
+  });
+
+  final ValueGetter<bool> enableDrag;
+  final AnimationController popDragController;
+  final NavigatorState navigator;
+  final ValueGetter<bool> getIsCurrent;
+  final ValueGetter<bool> getIsActive;
+
+  @override
+  _StreamSheetScrollPosition createScrollPosition(
+    ScrollPhysics physics,
+    ScrollContext context,
+    ScrollPosition? oldPosition,
+  ) {
+    return _StreamSheetScrollPosition(
+      physics: physics,
+      context: context,
+      oldPosition: oldPosition,
+      controller: this,
+    );
+  }
+
+  @override
+  _StreamSheetScrollPosition get position => super.position as _StreamSheetScrollPosition;
+}
+
+/// A [ScrollPosition] that forwards over-scroll-down at the top of the
+/// scrollable to the enclosing [StreamSheetRoute]'s drag controller, and
+/// finalises the drag (pop or animate back) when the scroll drag ends.
+class _StreamSheetScrollPosition extends ScrollPositionWithSingleContext {
+  _StreamSheetScrollPosition({
+    required super.physics,
+    required super.context,
+    super.oldPosition,
+    required this.controller,
+  });
+
+  final _StreamSheetScrollController controller;
+
+  _StreamDragGestureController? _dragGestureController;
+
+  AnimationController get _routeController => controller.popDragController;
+
+  bool get _isSheetPartiallyDismissed => _routeController.value < 1.0;
+
+  // The viewport's height is the closest stand-in we have for the sheet
+  // body's height: the scrollable fills the rest of the sheet under the
+  // header. Used to normalise pixel deltas to fractions of sheet height
+  // for [_StreamDragGestureController].
+  double get _sheetHeight => viewportDimension > 0 ? viewportDimension : 1;
+
+  @override
+  void applyUserOffset(double delta) {
+    if (!controller.enableDrag()) {
+      super.applyUserOffset(delta);
+      return;
+    }
+
+    // `delta` mirrors `DragUpdateDetails.primaryDelta`: positive = finger
+    // moved down, negative = finger moved up.
+    final atTop = pixels <= minScrollExtent;
+    final draggingDown = delta > 0;
+    final draggingUp = delta < 0;
+    final sheetHeight = _sheetHeight;
+    final stretchPixels = controller.navigator.context.streamSpacing.xs;
+
+    // Drag down past the top of the scrollable: redirect the delta to the
+    // route's drag controller to dismiss the sheet.
+    if (atTop && draggingDown) {
+      _dragGestureController ??= _StreamDragGestureController(
+        navigator: controller.navigator,
+        popDragController: _routeController,
+        getIsCurrent: controller.getIsCurrent,
+        getIsActive: controller.getIsActive,
+      );
+      _dragGestureController!.dragUpdate(
+        delta,
+        sheetHeight: sheetHeight,
+        stretchPixels: stretchPixels,
+      );
+      return;
+    }
+
+    // If a sheet drag is in progress, allow upward finger movement to undo
+    // the dismissal before resuming normal scroll.
+    if (_dragGestureController != null && _isSheetPartiallyDismissed && draggingUp) {
+      final remainingPixels = (1.0 - _routeController.value) * sheetHeight;
+      final fingerPixels = -delta;
+      if (fingerPixels <= remainingPixels) {
+        _dragGestureController!.dragUpdate(
+          delta,
+          sheetHeight: sheetHeight,
+          stretchPixels: stretchPixels,
+        );
+        return;
+      }
+      _dragGestureController!.dragUpdate(
+        -remainingPixels,
+        sheetHeight: sheetHeight,
+        stretchPixels: stretchPixels,
+      );
+      super.applyUserOffset(-(fingerPixels - remainingPixels));
+      return;
+    }
+
+    super.applyUserOffset(delta);
+  }
+
+  @override
+  void goBallistic(double velocity) {
+    final dragController = _dragGestureController;
+    if (dragController != null) {
+      _dragGestureController = null;
+      final fracVelocity = velocity / _sheetHeight;
+      dragController.dragEnd(fracVelocity);
+      super.goBallistic(0);
+      return;
+    }
+    super.goBallistic(velocity);
+  }
+
+  @override
+  void dispose() {
+    _dragGestureController = null;
+    super.dispose();
+  }
+}
+
+// Inherited widget injected into every [StreamSheetRoute]'s content.
+// Lets descendants — including widgets pushed onto a nested [Navigator]
+// inside the sheet — discover that they are inside a sheet and pop the
+// whole sheet via the navigator the route was pushed onto (which may not
+// be the root navigator).
+class _StreamSheetScope extends InheritedWidget {
+  const _StreamSheetScope({required this.route, required super.child});
+
+  final StreamSheetRoute<dynamic> route;
+
+  static _StreamSheetScope? maybeOf(BuildContext context) {
+    return context.getInheritedWidgetOfExactType<_StreamSheetScope>();
+  }
+
+  @override
+  bool updateShouldNotify(_StreamSheetScope oldWidget) => route != oldWidget.route;
+}
+
+// Built-in defaults for [StreamSheet] (and modal sheets opened via
+// [showStreamSheet] / [StreamSheetRoute]).
+//
+// Used as the last step of the resolution chain — per-instance argument
+// → ambient [StreamSheetThemeData] → these defaults — so every visual
+// property has a concrete value at build time.
+//
+// Resolves context-aware values (colors, radii) from the surrounding
+// [StreamTheme]; constants come from the design system spec.
+class _StreamSheetDefaults extends StreamSheetThemeData {
+  _StreamSheetDefaults(this.context) : _colorScheme = context.streamColorScheme, _radius = context.streamRadius;
+
+  final BuildContext context;
+  final StreamColorScheme _colorScheme;
+  final StreamRadius _radius;
+
+  @override
+  double get elevation => 1;
+
+  @override
+  Color get backgroundColor => _colorScheme.backgroundElevation1;
+
+  @override
+  Color get barrierColor => _colorScheme.backgroundScrim;
+
+  @override
+  BorderRadiusGeometry get borderRadius => .vertical(top: _radius.xxxxl);
+
+  @override
+  Clip get clipBehavior => Clip.none;
+
+  @override
+  bool get showDragHandle => true;
+
+  @override
+  Color get dragHandleColor => _colorScheme.accentNeutral;
+
+  @override
+  Size get dragHandleSize => const Size(36, 5);
+
+  @override
+  Color get surfaceTintColor => StreamColors.transparent;
+
+  @override
+  Color get shadowColor => StreamColors.transparent;
+
+  @override
+  BoxConstraints get constraints => const BoxConstraints(maxWidth: 640);
+}

--- a/packages/stream_core_flutter/lib/src/components/sheet/stream_sheet.dart
+++ b/packages/stream_core_flutter/lib/src/components/sheet/stream_sheet.dart
@@ -101,9 +101,10 @@ typedef StreamSheetDragEndCallback = void Function(DragEndDetails details, {requ
 ///  * [elevation] drives the shadow cast around the sheet. Defaults
 ///    to `1`.
 ///  * [clipBehavior] clips content against the border radius (defaults
-///    to [Clip.antiAlias]).
+///    to [Clip.none]).
 ///  * [constraints] caps the sheet's size — most useful on tablet /
 ///    desktop. The sheet is bottom-aligned within the constraints.
+///    Defaults to `BoxConstraints(maxWidth: 640)`.
 ///
 /// Dismissal:
 ///
@@ -568,15 +569,15 @@ class StreamSheet extends StatelessWidget {
   /// How to clip the sheet's content against its [shape] / [borderRadius].
   ///
   /// When `null`, falls back to [StreamSheetThemeData.clipBehavior] and
-  /// finally to [Clip.antiAlias].
+  /// finally to [Clip.none].
   final Clip? clipBehavior;
 
   /// Optional [BoxConstraints] applied around the sheet.
   ///
   /// Most useful on tablet/desktop to cap the sheet's width. The sheet
   /// is bottom-aligned within the constraints. When `null`, falls back
-  /// to [StreamSheetThemeData.constraints]; if still `null`, the sheet
-  /// is unconstrained.
+  /// to [StreamSheetThemeData.constraints] and finally to
+  /// `BoxConstraints(maxWidth: 640)`.
   final BoxConstraints? constraints;
 
   @override
@@ -1102,11 +1103,15 @@ class _StreamDragGestureDetectorState extends State<_StreamDragGestureDetector> 
   }
 
   void _handleDragStart(DragStartDetails details) {
+    assert(mounted);
+    assert(_dragGestureController == null);
     _dragGestureController = widget.onStartPopGesture();
     widget.onDragStart?.call(details);
   }
 
   void _handleDragUpdate(DragUpdateDetails details) {
+    assert(mounted);
+    assert(_dragGestureController != null);
     final size = context.size;
     if (size == null || size.height <= 0) return;
     _dragGestureController?.dragUpdate(
@@ -1118,6 +1123,8 @@ class _StreamDragGestureDetectorState extends State<_StreamDragGestureDetector> 
   }
 
   void _handleDragEnd(DragEndDetails details) {
+    assert(mounted);
+    assert(_dragGestureController != null);
     final size = context.size;
     final velocity = size != null && size.height > 0 ? details.velocity.pixelsPerSecond.dy / size.height : 0.0;
     final isClosing =
@@ -1131,6 +1138,10 @@ class _StreamDragGestureDetectorState extends State<_StreamDragGestureDetector> 
   }
 
   void _handleDragCancel() {
+    assert(mounted);
+    // [VerticalDragGestureRecognizer] can fire `onCancel` even when no
+    // `onStart` preceded it (paired with the initial "down" event); the
+    // null-aware call below tolerates that case.
     _dragGestureController?.dragEnd(0, _transitionScope?.stretchController);
     _dragGestureController = null;
   }
@@ -1207,6 +1218,10 @@ class _StreamDragGestureController {
     popDragController.value -= remaining / sheetHeight;
   }
 
+  /// Whether the sheet is currently dragged below its fully-open position
+  /// (i.e. partially dismissed).
+  bool isDragged() => popDragController.value != 1.0;
+
   /// Ends the drag with a vertical velocity (in fractions of screen height
   /// per second). Either pops the route or animates it back to fully open.
   ///
@@ -1267,9 +1282,11 @@ class _StreamDragGestureController {
   }
 }
 
-// Wires the [ScrollController] forwarded to the sheet's body to the route's
-// drag-to-dismiss controller, so dragging a scroll view past its top edge
-// dismisses the sheet.
+// Wires the [ScrollController] forwarded to the sheet's body to the
+// route's drag-to-dismiss controller, so dragging a scroll view past
+// its top edge dismisses the sheet. Owns the lifecycle of a
+// [_StreamDragGestureController] for the scroll-driven path; the
+// gesture-detector path on the sheet's chrome owns its own.
 class _StreamDraggableScrollableSheet extends StatefulWidget {
   const _StreamDraggableScrollableSheet({
     required this.enableDrag,
@@ -1293,23 +1310,68 @@ class _StreamDraggableScrollableSheet extends StatefulWidget {
 
 class _StreamDraggableScrollableSheetState extends State<_StreamDraggableScrollableSheet> {
   late final _StreamSheetScrollController _scrollController;
+  _StreamDragGestureController? _dragGestureController;
 
   @override
   void initState() {
     super.initState();
     _scrollController = _StreamSheetScrollController(
-      enableDrag: widget.enableDrag,
-      popDragController: widget.popDragController,
-      navigator: widget.navigator,
-      getIsCurrent: widget.getIsCurrent,
-      getIsActive: widget.getIsActive,
+      onDragStart: _handleDragStart,
+      onDragUpdate: _handleDragUpdate,
+      onDragEnd: _handleDragEnd,
+      sheetIsDraggedDown: () => _dragGestureController?.isDragged() ?? false,
     );
   }
 
   @override
   void dispose() {
+    // If we're still mid-drag, balance the navigator's user-gesture
+    // counter post-frame so we don't leave it dangling.
+    if (_dragGestureController != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (widget.navigator.mounted) widget.navigator.didStopUserGesture();
+        _dragGestureController = null;
+      });
+    }
     _scrollController.dispose();
     super.dispose();
+  }
+
+  void _handleDragStart() {
+    assert(mounted);
+    if (!widget.enableDrag()) return;
+    _dragGestureController ??= _StreamDragGestureController(
+      navigator: widget.navigator,
+      popDragController: widget.popDragController,
+      getIsCurrent: widget.getIsCurrent,
+      getIsActive: widget.getIsActive,
+    );
+  }
+
+  void _handleDragUpdate(double delta) {
+    assert(mounted);
+    final dragController = _dragGestureController;
+    if (dragController == null) return;
+    final size = context.size;
+    if (size == null || size.height <= 0) return;
+    dragController.dragUpdate(
+      delta,
+      sheetHeight: size.height,
+      stretchPixels: context.streamSpacing.xs,
+    );
+  }
+
+  void _handleDragEnd(double velocity) {
+    assert(mounted);
+    final dragController = _dragGestureController;
+    if (dragController == null) return;
+    _dragGestureController = null;
+    final size = context.size;
+    final sheetHeight = size != null && size.height > 0 ? size.height : 1.0;
+    // Convert scroll-position velocity (negative = finger moved down,
+    // pixels/sec) to the sheet-fraction finger-down velocity that
+    // [_StreamDragGestureController.dragEnd] expects.
+    dragController.dragEnd(-velocity / sheetHeight);
   }
 
   @override
@@ -1318,24 +1380,23 @@ class _StreamDraggableScrollableSheetState extends State<_StreamDraggableScrolla
   }
 }
 
-/// A [ScrollController] used by [StreamSheetRoute]'s body that, when the
-/// scrollable is at its top edge, hands additional drag-down deltas to the
-/// route's pop-drag controller so the user's gesture seamlessly transitions
-/// from scrolling to dismissing the sheet.
+/// A [ScrollController] used by [StreamSheetRoute]'s body that bridges
+/// the scrollable's gestures to the enclosing route's pop-drag
+/// controller. The actual drag controller lives on the parent
+/// [_StreamDraggableScrollableSheetState]; this controller forwards
+/// drag lifecycle events via callbacks.
 class _StreamSheetScrollController extends ScrollController {
   _StreamSheetScrollController({
-    required this.enableDrag,
-    required this.popDragController,
-    required this.navigator,
-    required this.getIsCurrent,
-    required this.getIsActive,
+    required this.onDragStart,
+    required this.onDragUpdate,
+    required this.onDragEnd,
+    required this.sheetIsDraggedDown,
   });
 
-  final ValueGetter<bool> enableDrag;
-  final AnimationController popDragController;
-  final NavigatorState navigator;
-  final ValueGetter<bool> getIsCurrent;
-  final ValueGetter<bool> getIsActive;
+  final VoidCallback onDragStart;
+  final ValueChanged<double> onDragUpdate;
+  final ValueChanged<double> onDragEnd;
+  final ValueGetter<bool> sheetIsDraggedDown;
 
   @override
   _StreamSheetScrollPosition createScrollPosition(
@@ -1344,10 +1405,18 @@ class _StreamSheetScrollController extends ScrollController {
     ScrollPosition? oldPosition,
   ) {
     return _StreamSheetScrollPosition(
-      physics: physics,
+      // Wrap with [AlwaysScrollableScrollPhysics] so the drag-to-dismiss
+      // gesture works even when the scrollable's content fits inside
+      // the viewport (e.g. a short body inside a tall sheet) — without
+      // this, the scrollable would reject the gesture before it reaches
+      // [applyUserOffset].
+      physics: physics.applyTo(const AlwaysScrollableScrollPhysics()),
       context: context,
       oldPosition: oldPosition,
-      controller: this,
+      onDragStart: onDragStart,
+      onDragUpdate: onDragUpdate,
+      onDragEnd: onDragEnd,
+      sheetIsDraggedDown: sheetIsDraggedDown,
     );
   }
 
@@ -1355,104 +1424,112 @@ class _StreamSheetScrollController extends ScrollController {
   _StreamSheetScrollPosition get position => super.position as _StreamSheetScrollPosition;
 }
 
-/// A [ScrollPosition] that forwards over-scroll-down at the top of the
-/// scrollable to the enclosing [StreamSheetRoute]'s drag controller, and
-/// finalises the drag (pop or animate back) when the scroll drag ends.
+/// A [ScrollPosition] that decides — based on the *release state*
+/// (current [pixels] and current [velocity]) — whether each gesture
+/// belongs to the list or to the enclosing sheet's drag-to-dismiss.
+///
+/// It emits [onDragStart] / [onDragUpdate] / [onDragEnd] callbacks; the
+/// drag controller itself lives on the parent state, keeping this
+/// class free of any animation logic.
 class _StreamSheetScrollPosition extends ScrollPositionWithSingleContext {
   _StreamSheetScrollPosition({
     required super.physics,
     required super.context,
     super.oldPosition,
-    required this.controller,
+    required this.onDragStart,
+    required this.onDragUpdate,
+    required this.onDragEnd,
+    required this.sheetIsDraggedDown,
   });
 
-  final _StreamSheetScrollController controller;
+  final VoidCallback onDragStart;
+  final ValueChanged<double> onDragUpdate;
+  final ValueChanged<double> onDragEnd;
+  final ValueGetter<bool> sheetIsDraggedDown;
 
-  _StreamDragGestureController? _dragGestureController;
+  // Captured from [drag] so we can call it before stealing the
+  // ballistic. Tells the parent [Scrollable] that we've taken over the
+  // gesture and that it should release any drag book-keeping it was
+  // holding (held pointer, current [DragScrollActivity], etc.).
+  VoidCallback? _dragCancelCallback;
 
-  AnimationController get _routeController => controller.popDragController;
-
-  bool get _isSheetPartiallyDismissed => _routeController.value < 1.0;
-
-  // The viewport's height is the closest stand-in we have for the sheet
-  // body's height: the scrollable fills the rest of the sheet under the
-  // header. Used to normalise pixel deltas to fractions of sheet height
-  // for [_StreamDragGestureController].
-  double get _sheetHeight => viewportDimension > 0 ? viewportDimension : 1;
+  bool get listShouldScroll => pixels > 0.0;
 
   @override
   void applyUserOffset(double delta) {
-    if (!controller.enableDrag()) {
+    onDragStart();
+    // While the sheet is partially dismissed, every delta belongs to
+    // the sheet (so reversing direction undoes the dismiss). At rest
+    // (sheet fully open + list at top), only downward deltas redirect;
+    // upward deltas start scrolling the list normally.
+    if (!listShouldScroll && (delta > 0 || sheetIsDraggedDown())) {
+      onDragUpdate(delta);
+    } else {
       super.applyUserOffset(delta);
-      return;
     }
-
-    // `delta` mirrors `DragUpdateDetails.primaryDelta`: positive = finger
-    // moved down, negative = finger moved up.
-    final atTop = pixels <= minScrollExtent;
-    final draggingDown = delta > 0;
-    final draggingUp = delta < 0;
-    final sheetHeight = _sheetHeight;
-    final stretchPixels = controller.navigator.context.streamSpacing.xs;
-
-    // Drag down past the top of the scrollable: redirect the delta to the
-    // route's drag controller to dismiss the sheet.
-    if (atTop && draggingDown) {
-      _dragGestureController ??= _StreamDragGestureController(
-        navigator: controller.navigator,
-        popDragController: _routeController,
-        getIsCurrent: controller.getIsCurrent,
-        getIsActive: controller.getIsActive,
-      );
-      _dragGestureController!.dragUpdate(
-        delta,
-        sheetHeight: sheetHeight,
-        stretchPixels: stretchPixels,
-      );
-      return;
-    }
-
-    // If a sheet drag is in progress, allow upward finger movement to undo
-    // the dismissal before resuming normal scroll.
-    if (_dragGestureController != null && _isSheetPartiallyDismissed && draggingUp) {
-      final remainingPixels = (1.0 - _routeController.value) * sheetHeight;
-      final fingerPixels = -delta;
-      if (fingerPixels <= remainingPixels) {
-        _dragGestureController!.dragUpdate(
-          delta,
-          sheetHeight: sheetHeight,
-          stretchPixels: stretchPixels,
-        );
-        return;
-      }
-      _dragGestureController!.dragUpdate(
-        -remainingPixels,
-        sheetHeight: sheetHeight,
-        stretchPixels: stretchPixels,
-      );
-      super.applyUserOffset(-(fingerPixels - remainingPixels));
-      return;
-    }
-
-    super.applyUserOffset(delta);
   }
 
   @override
   void goBallistic(double velocity) {
-    final dragController = _dragGestureController;
-    if (dragController != null) {
-      _dragGestureController = null;
-      final fracVelocity = velocity / _sheetHeight;
-      dragController.dragEnd(fracVelocity);
+    // [ScrollDragController.end] forwards `-finger.primaryVelocity`
+    // here, so:
+    //   negative velocity = finger moved down (dismiss direction)
+    //   positive velocity = finger moved up   (scroll-forward direction)
+    //
+    // The list owns this fling — settle the sheet by its position
+    // threshold (no fling on the sheet) and run the normal scroll
+    // ballistic. Covers:
+    //   * no velocity at all
+    //   * finger down but the list isn't at the top (it scrolls back up)
+    //   * finger up but the list isn't at its bottom (it keeps scrolling)
+    if (velocity == 0.0 || (velocity < 0.0 && listShouldScroll) || (velocity > 0.0 && pixels != maxScrollExtent)) {
+      onDragEnd(0);
+      super.goBallistic(velocity);
+      return;
+    }
+
+    // Tell the parent [Scrollable] we're handling the rest of the
+    // gesture so it doesn't keep tracking the drag underneath us.
+    _dragCancelCallback?.call();
+    _dragCancelCallback = null;
+
+    // Finger flung down at the top of the list — dismiss the sheet
+    // (the parent state converts velocity to a sheet-fraction).
+    if (velocity < 0.0 && !listShouldScroll) {
+      onDragEnd(velocity);
       super.goBallistic(0);
       return;
     }
+
+    // Else: finger flung up at the bottom of the list — sheet settles
+    // by position; list runs its ballistic with the fling velocity.
+    onDragEnd(0);
     super.goBallistic(velocity);
   }
 
   @override
+  Drag drag(DragStartDetails details, VoidCallback dragCancelCallback) {
+    _dragCancelCallback = dragCancelCallback;
+    return super.drag(details, dragCancelCallback);
+  }
+
+  @override
+  void absorb(ScrollPosition other) {
+    super.absorb(other);
+    // Migrate the cancel callback across position swaps (viewport
+    // metric changes, scroll physics swaps, etc.) so an in-flight
+    // gesture isn't dropped on the floor.
+    assert(_dragCancelCallback == null);
+    if (other is! _StreamSheetScrollPosition) return;
+    if (other._dragCancelCallback != null) {
+      _dragCancelCallback = other._dragCancelCallback;
+      other._dragCancelCallback = null;
+    }
+  }
+
+  @override
   void dispose() {
-    _dragGestureController = null;
+    _dragCancelCallback = null;
     super.dispose();
   }
 }

--- a/packages/stream_core_flutter/lib/src/theme.dart
+++ b/packages/stream_core_flutter/lib/src/theme.dart
@@ -28,6 +28,7 @@ export 'theme/components/stream_progress_bar_theme.dart';
 export 'theme/components/stream_reaction_picker_theme.dart';
 export 'theme/components/stream_reactions_theme.dart';
 export 'theme/components/stream_sheet_header_theme.dart';
+export 'theme/components/stream_sheet_theme.dart';
 export 'theme/components/stream_stepper_theme.dart';
 export 'theme/components/stream_switch_theme.dart';
 export 'theme/components/stream_text_input_theme.dart';

--- a/packages/stream_core_flutter/lib/src/theme/components/stream_sheet_theme.dart
+++ b/packages/stream_core_flutter/lib/src/theme/components/stream_sheet_theme.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/widgets.dart';
+import 'package:theme_extensions_builder_annotation/theme_extensions_builder_annotation.dart';
+
+import '../stream_theme.dart';
+
+part 'stream_sheet_theme.g.theme.dart';
+
+/// Applies a sheet theme to descendant [StreamSheet] widgets and
+/// [StreamSheetDragHandle]s.
+///
+/// Wrap a subtree with [StreamSheetTheme] to override the look of any
+/// sheet rendered inside it (including modal sheets opened via
+/// `showStreamSheet`). Access the merged theme using
+/// [BuildContext.streamSheetTheme].
+///
+/// {@tool snippet}
+///
+/// Override the sheet background and elevation for a specific subtree:
+///
+/// ```dart
+/// StreamSheetTheme(
+///   data: StreamSheetThemeData(
+///     backgroundColor: Colors.white,
+///     elevation: 4,
+///   ),
+///   child: child,
+/// )
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [StreamSheetThemeData], which describes the sheet theme.
+///  * [StreamSheet], the widget affected by this theme.
+///  * [StreamSheetDragHandle], which reads its color and size from this
+///    theme.
+class StreamSheetTheme extends InheritedTheme {
+  /// Creates a sheet theme that controls descendant sheets.
+  const StreamSheetTheme({
+    super.key,
+    required this.data,
+    required super.child,
+  });
+
+  /// The sheet theme data for descendant widgets.
+  final StreamSheetThemeData data;
+
+  /// Returns the [StreamSheetThemeData] merged from local and global
+  /// themes.
+  ///
+  /// Local values from the nearest [StreamSheetTheme] ancestor take
+  /// precedence over global values from [StreamTheme.of].
+  ///
+  /// This allows partial overrides — for example, overriding only
+  /// [StreamSheetThemeData.backgroundColor] while inheriting the rest
+  /// from the global theme.
+  static StreamSheetThemeData of(BuildContext context) {
+    final localTheme = context.dependOnInheritedWidgetOfExactType<StreamSheetTheme>();
+    return StreamTheme.of(context).sheetTheme.merge(localTheme?.data);
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return StreamSheetTheme(data: data, child: child);
+  }
+
+  @override
+  bool updateShouldNotify(StreamSheetTheme oldWidget) => data != oldWidget.data;
+}
+
+/// Defines default property values for [StreamSheet] (and modal sheets
+/// opened via `showStreamSheet`).
+///
+/// Every field is `null` by default; when null, the sheet falls back
+/// to its built-in defaults (which themselves resolve from
+/// [StreamColorScheme] / [StreamRadius] / [StreamSpacing]).
+///
+/// Per-instance constructor arguments on [StreamSheet] (and
+/// [showStreamSheet]) take precedence over this theme.
+///
+/// {@tool snippet}
+///
+/// Customize sheet appearance globally via [StreamTheme]:
+///
+/// ```dart
+/// StreamTheme(
+///   sheetTheme: StreamSheetThemeData(
+///     elevation: 4,
+///     dragHandleSize: const Size(40, 4),
+///   ),
+/// )
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [StreamSheetTheme], for overriding the theme in a widget subtree.
+///  * [StreamSheet], the widget that uses this theme.
+///  * [StreamSheetDragHandle], which reads its color and size from
+///    this theme.
+@themeGen
+@immutable
+class StreamSheetThemeData with _$StreamSheetThemeData {
+  /// Creates sheet theme data.
+  const StreamSheetThemeData({
+    this.backgroundColor,
+    this.surfaceTintColor,
+    this.shadowColor,
+    this.barrierColor,
+    this.elevation,
+    this.shape,
+    this.borderRadius,
+    this.clipBehavior,
+    this.constraints,
+    this.showDragHandle,
+    this.dragHandleColor,
+    this.dragHandleSize,
+  });
+
+  /// Overrides the default value of `StreamSheetRoute.backgroundColor`.
+  ///
+  /// If null, the sheet falls back to
+  /// [StreamColorScheme.backgroundElevation1].
+  final Color? backgroundColor;
+
+  /// Overrides the default surface tint color used as an overlay on
+  /// the sheet's background.
+  ///
+  /// If null, no overlay color is drawn.
+  final Color? surfaceTintColor;
+
+  /// Overrides the default shadow color cast around the sheet.
+  ///
+  /// If null, the platform default is used.
+  final Color? shadowColor;
+
+  /// Overrides the default value of `StreamSheetRoute.barrierColor`.
+  ///
+  /// If null, the sheet falls back to
+  /// [StreamColorScheme.backgroundScrim].
+  final Color? barrierColor;
+
+  /// Overrides the default value of `StreamSheetRoute.elevation`.
+  ///
+  /// Drives the shadow cast around the sheet — most visible at the top
+  /// edge, where the sheet meets the content behind it. If null, the
+  /// sheet defaults to `1`.
+  final double? elevation;
+
+  /// Overrides the default value of `StreamSheetRoute.shape`.
+  ///
+  /// Takes precedence over [borderRadius] when non-null. Useful for
+  /// non-rectangular sheets (e.g. with a clipped notch).
+  final ShapeBorder? shape;
+
+  /// Overrides the default value of `StreamSheetRoute.borderRadius`.
+  ///
+  /// Ignored when [shape] is non-null. If both are null, the sheet's
+  /// top corners are rounded with [StreamRadius.xxxxl] and the bottom
+  /// corners are square.
+  final BorderRadiusGeometry? borderRadius;
+
+  /// Overrides how the sheet's content is clipped against its [shape]
+  /// / [borderRadius].
+  ///
+  /// If null, the sheet defaults to [Clip.antiAlias].
+  final Clip? clipBehavior;
+
+  /// Constrains the size of the sheet.
+  ///
+  /// Most useful on tablet/desktop to cap the sheet's width. When null,
+  /// the sheet's size is unconstrained.
+  final BoxConstraints? constraints;
+
+  /// Overrides the default value of `StreamSheetRoute.showDragHandle`.
+  ///
+  /// If null, the sheet defaults to `true` (a drag handle is shown).
+  final bool? showDragHandle;
+
+  /// Overrides the default color of the sheet's drag handle.
+  ///
+  /// If null, the handle falls back to
+  /// [StreamColorScheme.accentNeutral].
+  final Color? dragHandleColor;
+
+  /// Overrides the default size of the sheet's drag handle.
+  ///
+  /// If null, the handle defaults to a `36 × 5` pill.
+  final Size? dragHandleSize;
+
+  /// Linearly interpolate between two [StreamSheetThemeData] objects.
+  static StreamSheetThemeData? lerp(
+    StreamSheetThemeData? a,
+    StreamSheetThemeData? b,
+    double t,
+  ) => _$StreamSheetThemeData.lerp(a, b, t);
+}

--- a/packages/stream_core_flutter/lib/src/theme/components/stream_sheet_theme.dart
+++ b/packages/stream_core_flutter/lib/src/theme/components/stream_sheet_theme.dart
@@ -163,13 +163,13 @@ class StreamSheetThemeData with _$StreamSheetThemeData {
   /// Overrides how the sheet's content is clipped against its [shape]
   /// / [borderRadius].
   ///
-  /// If null, the sheet defaults to [Clip.antiAlias].
+  /// If null, the sheet defaults to [Clip.none].
   final Clip? clipBehavior;
 
   /// Constrains the size of the sheet.
   ///
-  /// Most useful on tablet/desktop to cap the sheet's width. When null,
-  /// the sheet's size is unconstrained.
+  /// Most useful on tablet/desktop to cap the sheet's width. If null,
+  /// the sheet defaults to `BoxConstraints(maxWidth: 640)`.
   final BoxConstraints? constraints;
 
   /// Overrides the default value of `StreamSheetRoute.showDragHandle`.

--- a/packages/stream_core_flutter/lib/src/theme/components/stream_sheet_theme.g.theme.dart
+++ b/packages/stream_core_flutter/lib/src/theme/components/stream_sheet_theme.g.theme.dart
@@ -1,0 +1,158 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_element
+
+part of 'stream_sheet_theme.dart';
+
+// **************************************************************************
+// ThemeGenGenerator
+// **************************************************************************
+
+mixin _$StreamSheetThemeData {
+  bool get canMerge => true;
+
+  static StreamSheetThemeData? lerp(
+    StreamSheetThemeData? a,
+    StreamSheetThemeData? b,
+    double t,
+  ) {
+    if (identical(a, b)) {
+      return a;
+    }
+
+    if (a == null) {
+      return t == 1.0 ? b : null;
+    }
+
+    if (b == null) {
+      return t == 0.0 ? a : null;
+    }
+
+    return StreamSheetThemeData(
+      backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
+      surfaceTintColor: Color.lerp(a.surfaceTintColor, b.surfaceTintColor, t),
+      shadowColor: Color.lerp(a.shadowColor, b.shadowColor, t),
+      barrierColor: Color.lerp(a.barrierColor, b.barrierColor, t),
+      elevation: lerpDouble$(a.elevation, b.elevation, t),
+      shape: ShapeBorder.lerp(a.shape, b.shape, t),
+      borderRadius: BorderRadiusGeometry.lerp(
+        a.borderRadius,
+        b.borderRadius,
+        t,
+      ),
+      clipBehavior: t < 0.5 ? a.clipBehavior : b.clipBehavior,
+      constraints: BoxConstraints.lerp(a.constraints, b.constraints, t),
+      showDragHandle: t < 0.5 ? a.showDragHandle : b.showDragHandle,
+      dragHandleColor: Color.lerp(a.dragHandleColor, b.dragHandleColor, t),
+      dragHandleSize: Size.lerp(a.dragHandleSize, b.dragHandleSize, t),
+    );
+  }
+
+  StreamSheetThemeData copyWith({
+    Color? backgroundColor,
+    Color? surfaceTintColor,
+    Color? shadowColor,
+    Color? barrierColor,
+    double? elevation,
+    ShapeBorder? shape,
+    BorderRadiusGeometry? borderRadius,
+    Clip? clipBehavior,
+    BoxConstraints? constraints,
+    bool? showDragHandle,
+    Color? dragHandleColor,
+    Size? dragHandleSize,
+  }) {
+    final _this = (this as StreamSheetThemeData);
+
+    return StreamSheetThemeData(
+      backgroundColor: backgroundColor ?? _this.backgroundColor,
+      surfaceTintColor: surfaceTintColor ?? _this.surfaceTintColor,
+      shadowColor: shadowColor ?? _this.shadowColor,
+      barrierColor: barrierColor ?? _this.barrierColor,
+      elevation: elevation ?? _this.elevation,
+      shape: shape ?? _this.shape,
+      borderRadius: borderRadius ?? _this.borderRadius,
+      clipBehavior: clipBehavior ?? _this.clipBehavior,
+      constraints: constraints ?? _this.constraints,
+      showDragHandle: showDragHandle ?? _this.showDragHandle,
+      dragHandleColor: dragHandleColor ?? _this.dragHandleColor,
+      dragHandleSize: dragHandleSize ?? _this.dragHandleSize,
+    );
+  }
+
+  StreamSheetThemeData merge(StreamSheetThemeData? other) {
+    final _this = (this as StreamSheetThemeData);
+
+    if (other == null || identical(_this, other)) {
+      return _this;
+    }
+
+    if (!other.canMerge) {
+      return other;
+    }
+
+    return copyWith(
+      backgroundColor: other.backgroundColor,
+      surfaceTintColor: other.surfaceTintColor,
+      shadowColor: other.shadowColor,
+      barrierColor: other.barrierColor,
+      elevation: other.elevation,
+      shape: other.shape,
+      borderRadius: other.borderRadius,
+      clipBehavior: other.clipBehavior,
+      constraints: other.constraints,
+      showDragHandle: other.showDragHandle,
+      dragHandleColor: other.dragHandleColor,
+      dragHandleSize: other.dragHandleSize,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+
+    final _this = (this as StreamSheetThemeData);
+    final _other = (other as StreamSheetThemeData);
+
+    return _other.backgroundColor == _this.backgroundColor &&
+        _other.surfaceTintColor == _this.surfaceTintColor &&
+        _other.shadowColor == _this.shadowColor &&
+        _other.barrierColor == _this.barrierColor &&
+        _other.elevation == _this.elevation &&
+        _other.shape == _this.shape &&
+        _other.borderRadius == _this.borderRadius &&
+        _other.clipBehavior == _this.clipBehavior &&
+        _other.constraints == _this.constraints &&
+        _other.showDragHandle == _this.showDragHandle &&
+        _other.dragHandleColor == _this.dragHandleColor &&
+        _other.dragHandleSize == _this.dragHandleSize;
+  }
+
+  @override
+  int get hashCode {
+    final _this = (this as StreamSheetThemeData);
+
+    return Object.hash(
+      runtimeType,
+      _this.backgroundColor,
+      _this.surfaceTintColor,
+      _this.shadowColor,
+      _this.barrierColor,
+      _this.elevation,
+      _this.shape,
+      _this.borderRadius,
+      _this.clipBehavior,
+      _this.constraints,
+      _this.showDragHandle,
+      _this.dragHandleColor,
+      _this.dragHandleSize,
+    );
+  }
+}

--- a/packages/stream_core_flutter/lib/src/theme/stream_theme.dart
+++ b/packages/stream_core_flutter/lib/src/theme/stream_theme.dart
@@ -25,6 +25,7 @@ import 'components/stream_progress_bar_theme.dart';
 import 'components/stream_reaction_picker_theme.dart';
 import 'components/stream_reactions_theme.dart';
 import 'components/stream_sheet_header_theme.dart';
+import 'components/stream_sheet_theme.dart';
 import 'components/stream_skeleton_loading_theme.dart';
 import 'components/stream_stepper_theme.dart';
 import 'components/stream_switch_theme.dart';
@@ -125,6 +126,7 @@ class StreamTheme extends ThemeExtension<StreamTheme> with _$StreamTheme {
     StreamReactionPickerThemeData? reactionPickerTheme,
     StreamReactionsThemeData? reactionsTheme,
     StreamSheetHeaderThemeData? sheetHeaderTheme,
+    StreamSheetThemeData? sheetTheme,
     StreamSkeletonLoadingThemeData? skeletonLoadingTheme,
     StreamStepperThemeData? stepperTheme,
     StreamSwitchThemeData? switchTheme,
@@ -166,6 +168,7 @@ class StreamTheme extends ThemeExtension<StreamTheme> with _$StreamTheme {
     reactionPickerTheme ??= const StreamReactionPickerThemeData();
     reactionsTheme ??= const StreamReactionsThemeData();
     sheetHeaderTheme ??= const StreamSheetHeaderThemeData();
+    sheetTheme ??= const StreamSheetThemeData();
     skeletonLoadingTheme ??= const StreamSkeletonLoadingThemeData();
     stepperTheme ??= const StreamStepperThemeData();
     switchTheme ??= const StreamSwitchThemeData();
@@ -201,6 +204,7 @@ class StreamTheme extends ThemeExtension<StreamTheme> with _$StreamTheme {
       reactionPickerTheme: reactionPickerTheme,
       reactionsTheme: reactionsTheme,
       sheetHeaderTheme: sheetHeaderTheme,
+      sheetTheme: sheetTheme,
       skeletonLoadingTheme: skeletonLoadingTheme,
       stepperTheme: stepperTheme,
       switchTheme: switchTheme,
@@ -250,6 +254,7 @@ class StreamTheme extends ThemeExtension<StreamTheme> with _$StreamTheme {
     required this.reactionPickerTheme,
     required this.reactionsTheme,
     required this.sheetHeaderTheme,
+    required this.sheetTheme,
     required this.skeletonLoadingTheme,
     required this.stepperTheme,
     required this.switchTheme,
@@ -381,6 +386,9 @@ class StreamTheme extends ThemeExtension<StreamTheme> with _$StreamTheme {
   /// The sheet header theme for this theme.
   final StreamSheetHeaderThemeData sheetHeaderTheme;
 
+  /// The sheet theme for this theme.
+  final StreamSheetThemeData sheetTheme;
+
   /// The skeleton theme for this theme.
   final StreamSkeletonLoadingThemeData skeletonLoadingTheme;
 
@@ -440,6 +448,7 @@ class StreamTheme extends ThemeExtension<StreamTheme> with _$StreamTheme {
       reactionPickerTheme: reactionPickerTheme,
       reactionsTheme: reactionsTheme,
       sheetHeaderTheme: sheetHeaderTheme,
+      sheetTheme: sheetTheme,
       skeletonLoadingTheme: skeletonLoadingTheme,
       stepperTheme: stepperTheme,
       switchTheme: switchTheme,

--- a/packages/stream_core_flutter/lib/src/theme/stream_theme.g.theme.dart
+++ b/packages/stream_core_flutter/lib/src/theme/stream_theme.g.theme.dart
@@ -42,6 +42,7 @@ mixin _$StreamTheme on ThemeExtension<StreamTheme> {
     StreamReactionPickerThemeData? reactionPickerTheme,
     StreamReactionsThemeData? reactionsTheme,
     StreamSheetHeaderThemeData? sheetHeaderTheme,
+    StreamSheetThemeData? sheetTheme,
     StreamSkeletonLoadingThemeData? skeletonLoadingTheme,
     StreamStepperThemeData? stepperTheme,
     StreamSwitchThemeData? switchTheme,
@@ -83,6 +84,7 @@ mixin _$StreamTheme on ThemeExtension<StreamTheme> {
       reactionPickerTheme: reactionPickerTheme ?? _this.reactionPickerTheme,
       reactionsTheme: reactionsTheme ?? _this.reactionsTheme,
       sheetHeaderTheme: sheetHeaderTheme ?? _this.sheetHeaderTheme,
+      sheetTheme: sheetTheme ?? _this.sheetTheme,
       skeletonLoadingTheme: skeletonLoadingTheme ?? _this.skeletonLoadingTheme,
       stepperTheme: stepperTheme ?? _this.stepperTheme,
       switchTheme: switchTheme ?? _this.switchTheme,
@@ -216,6 +218,11 @@ mixin _$StreamTheme on ThemeExtension<StreamTheme> {
         other.sheetHeaderTheme,
         t,
       )!,
+      sheetTheme: StreamSheetThemeData.lerp(
+        _this.sheetTheme,
+        other.sheetTheme,
+        t,
+      )!,
       skeletonLoadingTheme: StreamSkeletonLoadingThemeData.lerp(
         _this.skeletonLoadingTheme,
         other.skeletonLoadingTheme,
@@ -277,6 +284,7 @@ mixin _$StreamTheme on ThemeExtension<StreamTheme> {
         _other.reactionPickerTheme == _this.reactionPickerTheme &&
         _other.reactionsTheme == _this.reactionsTheme &&
         _other.sheetHeaderTheme == _this.sheetHeaderTheme &&
+        _other.sheetTheme == _this.sheetTheme &&
         _other.skeletonLoadingTheme == _this.skeletonLoadingTheme &&
         _other.stepperTheme == _this.stepperTheme &&
         _other.switchTheme == _this.switchTheme;
@@ -318,6 +326,7 @@ mixin _$StreamTheme on ThemeExtension<StreamTheme> {
       _this.reactionPickerTheme,
       _this.reactionsTheme,
       _this.sheetHeaderTheme,
+      _this.sheetTheme,
       _this.skeletonLoadingTheme,
       _this.stepperTheme,
       _this.switchTheme,

--- a/packages/stream_core_flutter/lib/src/theme/stream_theme_extensions.dart
+++ b/packages/stream_core_flutter/lib/src/theme/stream_theme_extensions.dart
@@ -21,6 +21,7 @@ import 'components/stream_progress_bar_theme.dart';
 import 'components/stream_reaction_picker_theme.dart';
 import 'components/stream_reactions_theme.dart';
 import 'components/stream_sheet_header_theme.dart';
+import 'components/stream_sheet_theme.dart';
 import 'components/stream_skeleton_loading_theme.dart';
 import 'components/stream_stepper_theme.dart';
 import 'components/stream_switch_theme.dart';
@@ -144,6 +145,9 @@ extension StreamThemeExtension on BuildContext {
 
   /// Returns the [StreamSheetHeaderThemeData] from the nearest ancestor.
   StreamSheetHeaderThemeData get streamSheetHeaderTheme => StreamSheetHeaderTheme.of(this);
+
+  /// Returns the [StreamSheetThemeData] from the nearest ancestor.
+  StreamSheetThemeData get streamSheetTheme => StreamSheetTheme.of(this);
 
   /// Returns the [StreamSkeletonLoadingThemeData] from the nearest ancestor.
   StreamSkeletonLoadingThemeData get streamSkeletonLoadingTheme => StreamSkeletonLoadingTheme.of(this);

--- a/packages/stream_core_flutter/test/components/header/stream_sheet_header_test.dart
+++ b/packages/stream_core_flutter/test/components/header/stream_sheet_header_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_core_flutter/stream_core_flutter.dart';
@@ -69,7 +71,383 @@ void main() {
 
       expect(find.byType(StreamButton), findsNothing);
     });
+
+    testWidgets(
+      'inserts cross icon at the root of a StreamSheetRoute',
+      (tester) async {
+        await tester.pumpWidget(_withStreamTheme(const _StreamSheetLauncher()));
+        await tester.tap(find.text('Open stream sheet'));
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(StreamIconData.xmark), findsOneWidget);
+        expect(find.byIcon(StreamIconData.chevronLeft), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'inserts back chevron when a StreamSheetRoute covers another sheet',
+      (tester) async {
+        await tester.pumpWidget(_withStreamTheme(const _StreamSheetLauncher()));
+        await tester.tap(find.text('Open stream sheet'));
+        await tester.pumpAndSettle();
+
+        // Open a second sheet from inside the first.
+        final firstHeaderContext = tester.element(find.text('Sheet'));
+        unawaited(
+          showStreamSheet<void>(
+            context: firstHeaderContext,
+            builder: (_, _) => Scaffold(
+              body: StreamSheetHeader(title: const Text('Stacked')),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Both sheets are mounted; scope assertions to the stacked sheet.
+        expect(find.text('Stacked'), findsOneWidget);
+        final stackedHeader = find.ancestor(
+          of: find.text('Stacked'),
+          matching: find.byType(StreamSheetHeader),
+        );
+        expect(
+          find.descendant(
+            of: stackedHeader,
+            matching: find.byIcon(StreamIconData.chevronLeft),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: stackedHeader,
+            matching: find.byIcon(StreamIconData.xmark),
+          ),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'inserts cross at first nested route inside a StreamSheetRoute and '
+      'back chevron at deeper nested routes',
+      (tester) async {
+        await tester.pumpWidget(
+          _withStreamTheme(const _StreamSheetLauncher(useNestedNavigation: true)),
+        );
+        await tester.tap(find.text('Open stream sheet'));
+        await tester.pumpAndSettle();
+
+        // First nested route: cross (closes whole sheet).
+        expect(find.byIcon(StreamIconData.xmark), findsOneWidget);
+        expect(find.byIcon(StreamIconData.chevronLeft), findsNothing);
+
+        await tester.tap(find.text('Push deeper'));
+        await tester.pumpAndSettle();
+
+        // Deeper nested route: back chevron.
+        expect(find.byIcon(StreamIconData.chevronLeft), findsOneWidget);
+        expect(find.byIcon(StreamIconData.xmark), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'inserts back chevron on the first nested route of a stacked sheet '
+      '(stacked + nested combo)',
+      (tester) async {
+        await tester.pumpWidget(
+          _withStreamTheme(const _StreamSheetLauncher()),
+        );
+        await tester.tap(find.text('Open stream sheet'));
+        await tester.pumpAndSettle();
+
+        // From inside the first sheet, push a stacked sheet that itself
+        // uses nested navigation. The stacked sheet's first nested
+        // route should show a back chevron (popping reveals the parent
+        // sheet) — *not* a cross.
+        final firstHeaderContext = tester.element(find.text('Sheet'));
+        unawaited(
+          showStreamSheet<void>(
+            context: firstHeaderContext,
+            useNestedNavigation: true,
+            builder: (_, _) => Scaffold(
+              body: StreamSheetHeader(title: const Text('Stacked')),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Stacked'), findsOneWidget);
+        final stackedHeader = find.ancestor(
+          of: find.text('Stacked'),
+          matching: find.byType(StreamSheetHeader),
+        );
+        expect(
+          find.descendant(
+            of: stackedHeader,
+            matching: find.byIcon(StreamIconData.chevronLeft),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: stackedHeader,
+            matching: find.byIcon(StreamIconData.xmark),
+          ),
+          findsNothing,
+        );
+      },
+    );
   });
+
+  group('StreamSheetHeader tap actions', () {
+    testWidgets(
+      'tapping the cross on a standalone StreamSheetRoute pops the sheet',
+      (tester) async {
+        await tester.pumpWidget(_withStreamTheme(const _StreamSheetLauncher()));
+        await tester.tap(find.text('Open stream sheet'));
+        await tester.pumpAndSettle();
+        expect(find.text('Sheet'), findsOneWidget);
+
+        await tester.tap(find.byIcon(StreamIconData.xmark));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Sheet'), findsNothing);
+        expect(find.text('Open stream sheet'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tapping the chevron on a stacked StreamSheetRoute pops only itself; '
+      'parent sheet stays mounted',
+      (tester) async {
+        await tester.pumpWidget(_withStreamTheme(const _StreamSheetLauncher()));
+        await tester.tap(find.text('Open stream sheet'));
+        await tester.pumpAndSettle();
+
+        final firstHeaderContext = tester.element(find.text('Sheet'));
+        unawaited(
+          showStreamSheet<void>(
+            context: firstHeaderContext,
+            builder: (_, _) => Scaffold(
+              body: StreamSheetHeader(title: const Text('Stacked')),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.text('Stacked'), findsOneWidget);
+        expect(find.text('Sheet'), findsOneWidget);
+
+        // Tap the chevron on the stacked sheet's header.
+        final stackedHeader = find.ancestor(
+          of: find.text('Stacked'),
+          matching: find.byType(StreamSheetHeader),
+        );
+        await tester.tap(
+          find.descendant(
+            of: stackedHeader,
+            matching: find.byIcon(StreamIconData.chevronLeft),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Only the stacked sheet popped — the parent sheet is still mounted.
+        expect(find.text('Stacked'), findsNothing);
+        expect(find.text('Sheet'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tapping the chevron on a deeper nested route pops only that '
+      'nested level; the sheet stays mounted',
+      (tester) async {
+        await tester.pumpWidget(
+          _withStreamTheme(const _StreamSheetLauncher(useNestedNavigation: true)),
+        );
+        await tester.tap(find.text('Open stream sheet'));
+        await tester.pumpAndSettle();
+        expect(find.text('Sheet'), findsOneWidget);
+
+        await tester.tap(find.text('Push deeper'));
+        await tester.pumpAndSettle();
+        expect(find.text('Deeper'), findsOneWidget);
+
+        // Tap chevron on the deeper route's header.
+        await tester.tap(find.byIcon(StreamIconData.chevronLeft));
+        await tester.pumpAndSettle();
+
+        // Only the deeper route popped — the sheet's first nested route
+        // (with the cross) is back. The cross icon is now the only one
+        // showing; the chevron from the deeper route is gone.
+        expect(find.text('Deeper'), findsNothing);
+        expect(find.text('Sheet'), findsOneWidget);
+        expect(find.byIcon(StreamIconData.xmark), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tapping the chevron on the first nested route of a stacked sheet '
+      'pops the entire stacked sheet (not just the nested route)',
+      (tester) async {
+        await tester.pumpWidget(_withStreamTheme(const _StreamSheetLauncher()));
+        await tester.tap(find.text('Open stream sheet'));
+        await tester.pumpAndSettle();
+
+        final firstHeaderContext = tester.element(find.text('Sheet'));
+        unawaited(
+          showStreamSheet<void>(
+            context: firstHeaderContext,
+            useNestedNavigation: true,
+            builder: (_, _) => Scaffold(
+              body: StreamSheetHeader(title: const Text('Stacked')),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(find.text('Stacked'), findsOneWidget);
+
+        final stackedHeader = find.ancestor(
+          of: find.text('Stacked'),
+          matching: find.byType(StreamSheetHeader),
+        );
+        await tester.tap(
+          find.descendant(
+            of: stackedHeader,
+            matching: find.byIcon(StreamIconData.chevronLeft),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // The whole stacked sheet popped — parent sheet still mounted.
+        expect(find.text('Stacked'), findsNothing);
+        expect(find.text('Sheet'), findsOneWidget);
+      },
+    );
+  });
+
+  group('StreamSheetHeader style precedence', () {
+    testWidgets(
+      'props.style > theme.style > token defaults (three-level merge)',
+      (tester) async {
+        const propsPadding = EdgeInsets.all(7);
+        const themeTitleStyle = TextStyle(fontSize: 99, color: Color(0xFF112233));
+
+        // Theme provides only `titleTextStyle`. Props provide only
+        // `padding`. Other fields must fall through to token defaults.
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(extensions: [StreamTheme()]),
+            home: StreamSheetHeaderTheme(
+              data: const StreamSheetHeaderThemeData(
+                style: StreamSheetHeaderStyle(titleTextStyle: themeTitleStyle),
+              ),
+              child: Scaffold(
+                body: StreamSheetHeader(
+                  // Skip the SafeArea wrap so the inner Padding is the
+                  // first one under the header — makes the assertion
+                  // below straightforward.
+                  primary: false,
+                  automaticallyImplyLeading: false,
+                  title: const Text('Title'),
+                  subtitle: const Text('Subtitle'),
+                  style: const StreamSheetHeaderStyle(padding: propsPadding),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        // Props win for padding.
+        final padding = tester.widget<Padding>(
+          find
+              .descendant(
+                of: find.byType(StreamSheetHeader),
+                matching: find.byType(Padding),
+              )
+              .first,
+        );
+        expect(padding.padding, equals(propsPadding));
+
+        // Theme wins for titleTextStyle (props didn't set it).
+        final titleStyle = tester
+            .widget<DefaultTextStyle>(
+              find
+                  .ancestor(
+                    of: find.text('Title'),
+                    matching: find.byType(DefaultTextStyle),
+                  )
+                  .first,
+            )
+            .style;
+        expect(titleStyle.fontSize, equals(themeTitleStyle.fontSize));
+        expect(titleStyle.color, equals(themeTitleStyle.color));
+
+        // Subtitle falls through to defaults (neither props nor theme set it).
+        // Default subtitleTextStyle uses StreamTextTheme's captionDefault and
+        // colorScheme.textTertiary — non-null, non-zero font size.
+        final subtitleStyle = tester
+            .widget<DefaultTextStyle>(
+              find
+                  .ancestor(
+                    of: find.text('Subtitle'),
+                    matching: find.byType(DefaultTextStyle),
+                  )
+                  .first,
+            )
+            .style;
+        expect(subtitleStyle.fontSize, isNotNull);
+        expect(subtitleStyle.fontSize, greaterThan(0));
+      },
+    );
+  });
+}
+
+class _StreamSheetLauncher extends StatelessWidget {
+  const _StreamSheetLauncher({this.useNestedNavigation = false});
+
+  final bool useNestedNavigation;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Builder(
+          builder: (context) => TextButton(
+            onPressed: () {
+              showStreamSheet<void>(
+                context: context,
+                useNestedNavigation: useNestedNavigation,
+                builder: (sheetContext, _) => Scaffold(
+                  body: Column(
+                    children: [
+                      StreamSheetHeader(title: const Text('Sheet')),
+                      Expanded(
+                        child: Center(
+                          child: TextButton(
+                            onPressed: () {
+                              Navigator.of(sheetContext).push(
+                                MaterialPageRoute<void>(
+                                  builder: (_) => Scaffold(
+                                    body: StreamSheetHeader(
+                                      title: const Text('Deeper'),
+                                    ),
+                                  ),
+                                ),
+                              );
+                            },
+                            child: const Text('Push deeper'),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+            child: const Text('Open stream sheet'),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class _SheetLauncher extends StatelessWidget {

--- a/packages/stream_core_flutter/test/components/sheet/stream_sheet_test.dart
+++ b/packages/stream_core_flutter/test/components/sheet/stream_sheet_test.dart
@@ -137,12 +137,11 @@ void main() {
         expect(find.text('Item 0'), findsNothing);
         expect(find.byType(ListView), findsOneWidget);
 
-        // Scroll back to the top.
-        await tester.fling(
-          find.byType(ListView),
-          const Offset(0, 1500),
-          2000,
-        );
+        // Programmatically scroll back to the top so we can test the
+        // "drag down at top dismisses" path without coupling the test to
+        // over-scroll behaviour at the end of a scroll-back fling.
+        final scrollable = tester.widget<Scrollable>(find.byType(Scrollable));
+        scrollable.controller!.jumpTo(0);
         await tester.pumpAndSettle();
         expect(find.text('Item 0'), findsOneWidget);
 
@@ -150,6 +149,51 @@ void main() {
         await tester.dragFrom(
           tester.getCenter(find.text('Item 0')),
           const Offset(0, 600),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ListView), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'flinging the scroll view downward past the top dismisses the sheet',
+      (tester) async {
+        await tester.pumpWidget(
+          _withStreamTheme(
+            _SheetLauncher(
+              onPushed: (context) {
+                return showStreamSheet<void>(
+                  context: context,
+                  builder: (_, scrollController) {
+                    return ListView.builder(
+                      controller: scrollController,
+                      itemCount: 100,
+                      itemBuilder: (_, index) => SizedBox(
+                        height: 64,
+                        child: Center(child: Text('Item $index')),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Item 0'), findsOneWidget);
+
+        // A strong downward fling at the top of the scrollable should
+        // dismiss the sheet — the velocity is in the finger's
+        // downward-equals-dismiss direction and exceeds the fling
+        // threshold.
+        await tester.fling(
+          find.byType(ListView),
+          const Offset(0, 600),
+          2000,
         );
         await tester.pumpAndSettle();
 
@@ -408,7 +452,7 @@ void main() {
         await tester.pumpWidget(
           _withStreamTheme(
             _SheetLauncher(
-              onPushed: (context) => pushOnce(context),
+              onPushed: pushOnce,
             ),
           ),
         );

--- a/packages/stream_core_flutter/test/components/sheet/stream_sheet_test.dart
+++ b/packages/stream_core_flutter/test/components/sheet/stream_sheet_test.dart
@@ -1,0 +1,555 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/stream_core_flutter.dart';
+
+Widget _withStreamTheme(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [StreamTheme()]),
+    home: child,
+  );
+}
+
+class _SheetLauncher extends StatelessWidget {
+  const _SheetLauncher({required this.onPushed});
+
+  final Future<Object?> Function(BuildContext context) onPushed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Builder(
+        builder: (context) => TextButton(
+          onPressed: () => onPushed(context),
+          child: const Text('Open'),
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  group('showStreamSheet', () {
+    testWidgets('completes future with the popped value', (tester) async {
+      Object? result;
+      await tester.pumpWidget(
+        _withStreamTheme(
+          _SheetLauncher(
+            onPushed: (context) async {
+              return result = await showStreamSheet<String>(
+                context: context,
+                builder: (sheetContext, scrollController) {
+                  return Center(
+                    child: TextButton(
+                      onPressed: () => Navigator.of(sheetContext).pop('done'),
+                      child: const Text('Close'),
+                    ),
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Close'), findsOneWidget);
+
+      await tester.tap(find.text('Close'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Close'), findsNothing);
+      expect(result, equals('done'));
+    });
+
+    testWidgets('drags the body down to dismiss the sheet', (tester) async {
+      await tester.pumpWidget(
+        _withStreamTheme(
+          _SheetLauncher(
+            onPushed: (context) {
+              return showStreamSheet<void>(
+                context: context,
+                builder: (_, _) => const SizedBox.expand(
+                  child: ColoredBox(
+                    color: Color(0xFFFFC107),
+                    child: Center(child: Text('Body')),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      expect(find.text('Body'), findsOneWidget);
+
+      // Drag the body downwards far enough to trigger dismissal.
+      final start = tester.getCenter(find.text('Body'));
+      await tester.dragFrom(start, const Offset(0, 600));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Body'), findsNothing);
+    });
+
+    testWidgets(
+      'scrolling within scrollable does not dismiss until at top',
+      (tester) async {
+        await tester.pumpWidget(
+          _withStreamTheme(
+            _SheetLauncher(
+              onPushed: (context) {
+                return showStreamSheet<void>(
+                  context: context,
+                  builder: (_, scrollController) {
+                    return ListView.builder(
+                      controller: scrollController,
+                      itemCount: 100,
+                      itemBuilder: (_, index) => SizedBox(
+                        height: 64,
+                        child: Center(child: Text('Item $index')),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Item 0'), findsOneWidget);
+
+        // Scroll the list upward (drag finger up): the sheet should NOT
+        // dismiss; the list should scroll instead.
+        await tester.fling(
+          find.text('Item 5'),
+          const Offset(0, -300),
+          1000,
+        );
+        await tester.pumpAndSettle();
+
+        // Sheet still on screen — find a now-visible item further down.
+        expect(find.text('Item 0'), findsNothing);
+        expect(find.byType(ListView), findsOneWidget);
+
+        // Scroll back to the top.
+        await tester.fling(
+          find.byType(ListView),
+          const Offset(0, 1500),
+          2000,
+        );
+        await tester.pumpAndSettle();
+        expect(find.text('Item 0'), findsOneWidget);
+
+        // Now drag down at the top — should dismiss the sheet.
+        await tester.dragFrom(
+          tester.getCenter(find.text('Item 0')),
+          const Offset(0, 600),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ListView), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'applies custom backgroundColor, borderRadius and elevation',
+      (tester) async {
+        const customColor = Color(0xFF112233);
+        final customRadius = BorderRadius.circular(40);
+        const customElevation = 4.0;
+
+        await tester.pumpWidget(
+          _withStreamTheme(
+            _SheetLauncher(
+              onPushed: (context) {
+                return showStreamSheet<void>(
+                  context: context,
+                  backgroundColor: customColor,
+                  borderRadius: customRadius,
+                  elevation: customElevation,
+                  builder: (_, _) => const SizedBox.expand(
+                    child: Center(child: Text('Body')),
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        final materialFinder = find
+            .descendant(
+              of: find.byType(StreamSheetTransition),
+              matching: find.byType(Material),
+            )
+            .first;
+        final material = tester.widget<Material>(materialFinder);
+        expect(material.color, equals(customColor));
+        expect(material.borderRadius, equals(customRadius));
+        expect(material.elevation, equals(customElevation));
+      },
+    );
+
+    testWidgets(
+      'isDismissible + barrierColor allow tap-to-dismiss',
+      (tester) async {
+        await tester.pumpWidget(
+          _withStreamTheme(
+            _SheetLauncher(
+              onPushed: (context) {
+                return showStreamSheet<void>(
+                  context: context,
+                  isDismissible: true,
+                  barrierColor: const Color(0x80000000),
+                  builder: (_, _) => const SizedBox.expand(
+                    child: Center(child: Text('Body')),
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+        expect(find.text('Body'), findsOneWidget);
+
+        // Tap above the sheet (in the barrier area). The sheet's top
+        // sits at `spacing.sm = 12`, so a tap at y=4 is above it.
+        await tester.tapAt(const Offset(20, 4));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Body'), findsNothing);
+      },
+    );
+
+    testWidgets('applies BoxConstraints to the sheet', (tester) async {
+      await tester.pumpWidget(
+        _withStreamTheme(
+          _SheetLauncher(
+            onPushed: (context) {
+              return showStreamSheet<void>(
+                context: context,
+                constraints: const BoxConstraints(maxWidth: 320),
+                builder: (_, _) => const SizedBox.expand(
+                  child: Center(child: Text('Body')),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final sheetSize = tester.getSize(
+        find
+            .descendant(
+              of: find.byType(StreamSheetTransition),
+              matching: find.byType(Material),
+            )
+            .first,
+      );
+      expect(sheetSize.width, lessThanOrEqualTo(320));
+    });
+
+    testWidgets(
+      'stacked sheets share the root sheet topPadding',
+      (tester) async {
+        await tester.pumpWidget(
+          _withStreamTheme(
+            _SheetLauncher(
+              onPushed: (context) {
+                return showStreamSheet<void>(
+                  context: context,
+                  builder: (sheetContext, _) {
+                    return Center(
+                      child: TextButton(
+                        onPressed: () {
+                          showStreamSheet<void>(
+                            context: sheetContext,
+                            builder: (_, _) => const SizedBox.expand(
+                              child: Center(child: Text('Inner')),
+                            ),
+                          );
+                        },
+                        child: const Text('Push inner'),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Push inner'));
+        await tester.pumpAndSettle();
+        expect(find.text('Inner'), findsOneWidget);
+
+        // Stream's stacked sheets resolve their topPadding the same way
+        // as the root (`screenHeight * topGap`) — there's no per-depth
+        // bump. The inner (stacked) sheet's Material should therefore
+        // have the same layout height as the root sheet's Material.
+        final materials = tester
+            .widgetList<Material>(
+              find.descendant(
+                of: find.byType(StreamSheetTransition),
+                matching: find.byType(Material),
+              ),
+            )
+            .toList();
+        final outerHeight = tester.renderObject<RenderBox>(find.byWidget(materials.first)).size.height;
+        final innerHeight = tester.renderObject<RenderBox>(find.byWidget(materials.last)).size.height;
+        expect(innerHeight, closeTo(outerHeight, 0.5));
+      },
+    );
+
+    testWidgets(
+      'foreground stacked sheet sits at spacing.sm and reaches the '
+      'screen bottom',
+      (tester) async {
+        tester.view.physicalSize = const Size(390, 844);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+
+        await tester.pumpWidget(
+          _withStreamTheme(
+            _SheetLauncher(
+              onPushed: (context) {
+                return showStreamSheet<void>(
+                  context: context,
+                  builder: (sheetContext, _) {
+                    return Center(
+                      child: TextButton(
+                        onPressed: () {
+                          showStreamSheet<void>(
+                            context: sheetContext,
+                            builder: (_, _) => const SizedBox.expand(child: Text('Inner')),
+                          );
+                        },
+                        child: const Text('Push inner'),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Push inner'));
+        await tester.pumpAndSettle();
+
+        final innerMaterial = tester
+            .widgetList<Material>(
+              find.descendant(
+                of: find.byType(StreamSheetTransition).last,
+                matching: find.byType(Material),
+              ),
+            )
+            .first;
+        final box = tester.renderObject<RenderBox>(
+          find.byWidget(innerMaterial),
+        );
+        final topLeft = box.localToGlobal(Offset.zero);
+        final size = box.size;
+        final screenHeight = tester.view.physicalSize.height;
+
+        // The sheet sits at a fixed `spacing.sm` (= 12) from the screen
+        // top — a fixed peek rather than a screen-relative gap, since
+        // we don't shrink the underlying route. The foreground extends
+        // all the way to the screen bottom (no primary lift, no bottom
+        // gap).
+        const spacingSm = 12.0;
+        expect(topLeft.dy, closeTo(spacingSm, 0.5));
+        expect(topLeft.dy + size.height, closeTo(screenHeight, 0.5));
+      },
+    );
+
+    testWidgets(
+      'covered sheets apply the secondary scale + slide-up while the '
+      'topmost stays flush at its topPadding',
+      (tester) async {
+        tester.view.physicalSize = const Size(390, 844);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.reset);
+
+        Future<void> pushOnce(BuildContext context) {
+          return showStreamSheet<void>(
+            context: context,
+            builder: (innerContext, _) {
+              return Builder(
+                builder: (buttonContext) => Center(
+                  child: TextButton(
+                    onPressed: () => pushOnce(buttonContext),
+                    child: const Text('Push more'),
+                  ),
+                ),
+              );
+            },
+          );
+        }
+
+        await tester.pumpWidget(
+          _withStreamTheme(
+            _SheetLauncher(
+              onPushed: (context) => pushOnce(context),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+
+        // Stack: depth 1 (just the original push from `Open`).
+        // Push two more so we end up at depth 3. Use `.last` so we always
+        // tap the topmost sheet's button.
+        await tester.tap(find.text('Push more').last);
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Push more').last);
+        await tester.pumpAndSettle();
+
+        const midUpShift = 0.005;
+        const spacingSm = 12.0;
+        const totalDepth = 3;
+        final screenHeight = tester.view.physicalSize.height;
+
+        // Per the design — every sheet shares the same `topPadding`
+        // (= `spacing.sm = 12`), and the primary slide-up tween always
+        // ends at `(0, 0)`. The foreground stays flush with the screen
+        // edges; covered sheets apply only the secondary transform
+        // (scale by 0.9165 around topCenter + slide-up by `midUpShift *
+        // childHeight`, where `childHeight = screenHeight - topPadding
+        // = screenHeight - 12`).
+        //
+        // For 3 stacked sheets the rendered tops are:
+        //   depth 0 (root, covered):   12 - midUpShift * (h - 12)
+        //   depth 1 (middle, covered): same as depth 0
+        //   depth 2 (foreground, top): 12
+        double renderedTopAt(int depth) {
+          if (depth == totalDepth - 1) return spacingSm;
+          final childHeight = screenHeight - spacingSm;
+          return spacingSm - midUpShift * childHeight;
+        }
+
+        final transitions = tester.widgetList<StreamSheetTransition>(
+          find.byType(StreamSheetTransition),
+        );
+        expect(transitions, hasLength(totalDepth));
+
+        for (var depth = 0; depth < totalDepth; depth++) {
+          final material = tester
+              .widgetList<Material>(
+                find.descendant(
+                  of: find.byType(StreamSheetTransition).at(depth),
+                  matching: find.byType(Material),
+                ),
+              )
+              .first;
+          final box = tester.renderObject<RenderBox>(find.byWidget(material));
+          final actualTop = box.localToGlobal(Offset.zero).dy;
+          expect(
+            actualTop,
+            closeTo(renderedTopAt(depth), 0.5),
+            reason: 'depth $depth rendered top mismatch',
+          );
+        }
+
+        // The foreground sits at exactly its `topPadding` and every
+        // covered sheet sits slightly above (by `midUpShift *
+        // childHeight`), giving the rounded top corners of the
+        // underlying stack a small peek above the foreground.
+        final foregroundTop = renderedTopAt(totalDepth - 1);
+        for (var depth = 0; depth < totalDepth - 1; depth++) {
+          expect(
+            renderedTopAt(depth),
+            lessThan(foregroundTop),
+            reason: 'covered depth $depth should peek above the foreground',
+          );
+        }
+      },
+    );
+
+    testWidgets(
+      'useNestedNavigation pushes routes inside the sheet and popSheet '
+      'dismisses the whole sheet',
+      (tester) async {
+        await tester.pumpWidget(
+          _withStreamTheme(
+            _SheetLauncher(
+              onPushed: (context) {
+                return showStreamSheet<void>(
+                  context: context,
+                  useNestedNavigation: true,
+                  builder: (sheetContext, _) {
+                    return Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Text('First'),
+                          TextButton(
+                            onPressed: () {
+                              Navigator.of(sheetContext).push(
+                                MaterialPageRoute<void>(
+                                  builder: (innerContext) => Center(
+                                    child: Column(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        const Text('Second'),
+                                        TextButton(
+                                          onPressed: () => StreamSheetRoute.popSheet(
+                                            innerContext,
+                                          ),
+                                          child: const Text('Close All'),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              );
+                            },
+                            child: const Text('Push'),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+        expect(find.text('First'), findsOneWidget);
+
+        await tester.tap(find.text('Push'));
+        await tester.pumpAndSettle();
+        expect(find.text('Second'), findsOneWidget);
+
+        await tester.tap(find.text('Close All'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('First'), findsNothing);
+        expect(find.text('Second'), findsNothing);
+        expect(find.text('Open'), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description of the pull request
Adds a Stream-styled modal bottom sheet primitive with scroll-aware
drag-to-dismiss and stacking support, plus its theme:

- `StreamSheet` and `StreamSheetDragHandle` widgets
- `StreamSheetRoute` and `StreamSheetTransition` for the modal route
  and its transition (including stacked-sheet behaviour)
- `showStreamSheet` helper for opening the sheet
- `StreamSheetTheme`/`StreamSheetThemeData` exposed via
  `StreamTheme.sheetTheme` and `BuildContext.streamSheetTheme`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Stream-styled modal sheet with drag-to-dismiss, barrier dismissal, stacked/nested navigation, and display/size constraints.
  * Added sheet theming (StreamSheetTheme) and a context getter for accessing sheet theme defaults.
  * Emoji picker sheet now inherits sheet theme for consistent visuals.
  * Gallery/demo updated with playground and showcase examples for the new sheet.

* **Tests**
  * Added comprehensive tests for sheet interactions and header dismissal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->