### PR TITLE
feat(ui): export default emoji

### DIFF
--- a/packages/stream_core_flutter/CHANGELOG.md
+++ b/packages/stream_core_flutter/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `StreamRemoveControl` now meets the 48 dp minimum tap target by default while keeping its 20 dp visible badge anchored to the top-end corner. Exposes `tapTargetSize`, `visualDensity`, and `semanticLabel`, and announces itself as a button to screen readers.
 - Added `textAlignVertical` to `StreamTextInput` (and `StreamTextInputProps`) for controlling the vertical alignment of the text within the input.
 - Added `cursorColor`, `cursorErrorColor`, `cursorWidth`, `cursorHeight`, and `cursorRadius` to `StreamTextInputStyle` for customizing the text input cursor. `cursorErrorColor` is applied automatically when `helperState` is `StreamHelperState.error`. `StreamMessageComposerInputField` also honors these cursor properties from the theme.
+- Exported `DefaultStreamEmoji` so consumers can compose with or wrap the default emoji rendering when overriding via `StreamComponentFactory`.
 
 ### 🐞 Fixed
 
@@ -26,6 +27,7 @@
 - Changed `StreamTextInput` default `textCapitalization` to `TextCapitalization.sentences`.
 - Updated `StreamReactionPicker` spacing to match the Figma specification.
 - Updated `StreamStepper` button style to match the Figma specification.
+- `StreamEmoji` now pins its primary `fontFamily` to the platform's native emoji font (Apple Color Emoji on iOS/macOS, Segoe UI Emoji on Windows, Noto Color Emoji elsewhere) so the existing per-platform `fontSize` correction lines up with the font that actually renders the glyph. `fontFamilyFallback` is unchanged.
 
 ### 💥 Breaking Changes
 

--- a/packages/stream_core_flutter/lib/src/components.dart
+++ b/packages/stream_core_flutter/lib/src/components.dart
@@ -1,5 +1,5 @@
 export 'components/accessories/stream_audio_waveform.dart';
-export 'components/accessories/stream_emoji.dart' hide DefaultStreamEmoji;
+export 'components/accessories/stream_emoji.dart';
 export 'components/accessories/stream_file_type_icon.dart' hide DefaultStreamFileTypeIcon;
 export 'components/avatar/stream_avatar.dart' hide DefaultStreamAvatar;
 export 'components/avatar/stream_avatar_group.dart' hide DefaultStreamAvatarGroup;

--- a/packages/stream_core_flutter/lib/src/components/accessories/stream_emoji.dart
+++ b/packages/stream_core_flutter/lib/src/components/accessories/stream_emoji.dart
@@ -324,6 +324,16 @@ class _UnicodeEmojiWidget extends StatelessWidget {
       _ => size * _kNotoEmojiScale,
     };
 
+    // Pin the primary [fontFamily] to the platform's native emoji font so the
+    // [fontSize] correction above lines up with the font that actually renders
+    // the glyph. [fontFamilyFallback] still covers cases where the primary
+    // font is unavailable.
+    final fontFamily = switch (platform) {
+      .iOS || .macOS when !kIsWeb => 'Apple Color Emoji',
+      .windows => 'Segoe UI Emoji',
+      _ => 'Noto Color Emoji',
+    };
+
     // Both fonts produce a [Text] whose layout is larger than the visible glyph — Apple Color
     // Emoji adds whitespace above, below, and to the right; Noto has similar extra metrics.
     // See: <https://github.com/flutter/flutter/issues/119623>
@@ -351,6 +361,7 @@ class _UnicodeEmojiWidget extends StatelessWidget {
             ),
             style: TextStyle(
               fontSize: fontSize,
+              fontFamily: fontFamily,
               decoration: .none,
               // Commonly available fallback fonts for emoji rendering.
               fontFamilyFallback: const [

--- a/packages/stream_core_flutter/lib/src/components/accessories/stream_emoji.dart
+++ b/packages/stream_core_flutter/lib/src/components/accessories/stream_emoji.dart
@@ -328,8 +328,13 @@ class _UnicodeEmojiWidget extends StatelessWidget {
     // [fontSize] correction above lines up with the font that actually renders
     // the glyph. [fontFamilyFallback] still covers cases where the primary
     // font is unavailable.
+    //
+    // On web, leave [fontFamily] as null and let [fontFamilyFallback] resolve:
+    // CanvasKit bundles Noto Color Emoji and the HTML renderer defers to the
+    // browser, so a fixed primary name would lie about what actually renders.
     final fontFamily = switch (platform) {
-      .iOS || .macOS when !kIsWeb => 'Apple Color Emoji',
+      _ when kIsWeb => null,
+      .iOS || .macOS => 'Apple Color Emoji',
       .windows => 'Segoe UI Emoji',
       _ => 'Noto Color Emoji',
     };


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
This exports the default emoji, so it's easier to customize it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The default emoji component is now publicly available for use in apps.
* **Improvements**
  * Emoji rendering now uses the platform’s native emoji font to ensure consistent appearance and sizing across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->