### PR TITLE
feat(llc): add teams to user

### DIFF
--- a/packages/stream_core/CHANGELOG.md
+++ b/packages/stream_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+### ✨ Features
+
+- Added `teams` field to `User` class.
+
 ## 0.4.0
 
 ### 💥 BREAKING CHANGES

--- a/packages/stream_core/lib/src/user/user.dart
+++ b/packages/stream_core/lib/src/user/user.dart
@@ -24,8 +24,7 @@ class User extends Equatable {
   /// - Parameter userId: the id of the user.
   /// - Parameter name: the display name of the user. Defaults to [userId] when not provided.
   /// - Returns: a guest `User`.
-  const User.guest(String userId, {String? name})
-      : this(id: userId, name: name, type: UserType.guest);
+  const User.guest(String userId, {String? name}) : this(id: userId, name: name, type: UserType.guest);
 
   /// Creates an anonymous user.
   /// - Returns: an anonymous `User`.

--- a/packages/stream_core/lib/src/user/user.dart
+++ b/packages/stream_core/lib/src/user/user.dart
@@ -16,6 +16,7 @@ class User extends Equatable {
     this.role = 'user',
     this.type = UserType.regular,
     Map<String, Object?>? custom,
+    this.teams = const [],
   }) : originalName = name,
        custom = custom ?? const {};
 
@@ -43,6 +44,9 @@ class User extends Equatable {
   /// The user's custom data.
   final Map<String, Object?> custom;
 
+  /// Teams this user belongs to.
+  final List<String> teams;
+
   /// User's name that was provided when the object was created. It will be used when communicating
   /// with the API and in cases where it doesn't make sense to override `null` values with the
   /// `non-null` id.
@@ -53,7 +57,7 @@ class User extends Equatable {
   String get name => originalName ?? id;
 
   @override
-  List<Object?> get props => [id, image, role, type, originalName, custom];
+  List<Object?> get props => [id, image, role, type, originalName, custom, teams];
 }
 
 /// The user authorization type.

--- a/packages/stream_core/lib/src/user/user.dart
+++ b/packages/stream_core/lib/src/user/user.dart
@@ -24,11 +24,8 @@ class User extends Equatable {
   /// - Parameter userId: the id of the user.
   /// - Parameter name: the display name of the user. Defaults to [userId] when not provided.
   /// - Returns: a guest `User`.
-  factory User.guest(String userId, {String? name}) => User(
-    id: userId,
-    name: name,
-    type: UserType.guest,
-  );
+  const User.guest(String userId, {String? name})
+      : this(id: userId, name: name, type: UserType.guest);
 
   /// Creates an anonymous user.
   /// - Returns: an anonymous `User`.

--- a/packages/stream_core/lib/src/user/user.dart
+++ b/packages/stream_core/lib/src/user/user.dart
@@ -20,10 +20,15 @@ class User extends Equatable {
   }) : originalName = name,
        custom = custom ?? const {};
 
-  /// Creates a guest user with the provided id.
+  /// Creates a guest user with the provided id and an optional display name.
   /// - Parameter userId: the id of the user.
+  /// - Parameter name: the display name of the user. Defaults to [userId] when not provided.
   /// - Returns: a guest `User`.
-  const User.guest(String userId) : this(id: userId, name: userId, type: UserType.guest);
+  factory User.guest(String userId, {String? name}) => User(
+    id: userId,
+    name: name,
+    type: UserType.guest,
+  );
 
   /// Creates an anonymous user.
   /// - Returns: an anonymous `User`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User profiles now include team membership via a `teams` field.
  * User record comparisons now include team membership to keep equality/hash behavior consistent.
* **API Changes**
  * `User.guest` now accepts an optional display name (`User.guest(userId, {name})`) instead of always using the `userId` as the name.
* **Documentation**
  * Added an “Upcoming” → “✨ Features” entry to the changelog for team membership support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->