### PR TITLE
docs(repo): add STYLE_GUIDE.md and TESTING.md adapted from Flutter's guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+> **Before writing or reviewing code, read [`STYLE_GUIDE.md`](STYLE_GUIDE.md).** It is the source of truth for coding conventions, the barrel contract, theming, testing, and changelog policy. See [`TESTING.md`](TESTING.md) for guidance on writing effective tests. This file is a repo overview; the style guide is the rulebook.
+
 ## Project Overview
 
 A Flutter monorepo managed with **Melos** containing:

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -651,13 +651,22 @@ trade-offs before reaching for one:
 
 Rules:
 
-- Don't declare an extension method when a regular method or a helper function will
-  do.
-- Extensions on domain-typed collections (`Iterable<Message>`, `List<Attachment>`)
-  are fine — they only apply when the caller is already working with those types.
-- Avoid public extensions on unconstrained common types (`Object`, `Object?`,
-  `List<T>`, `Map<K, V>`, `Future<T>`, `String`, `int`) — those show up on every
-  value in every file that imports the package.
+- Don't declare an extension method when a regular method or a helper function
+  will do.
+- Extensions on domain types are fine — they only apply when the caller is already
+  working with those types. Examples in the repo: `AttachmentFile`,
+  `DioException`, `RetryStrategy`, `SystemEnvironment`.
+- Extensions on `BuildContext` for scoped lookups are an accepted Flutter idiom.
+  Examples: `StreamThemeExtension on BuildContext` exposing `context.streamTheme`;
+  `StreamComponentFactoryExtension on BuildContext` exposing the factory.
+- Units-of-measure extensions on primitives are acceptable when the extension is
+  small, unambiguous, and lives next to the value type. Example:
+  `DistanceExtension on num` exposing `5.kilometers` next to `Distance`.
+- Avoid public extensions on common types (`Object`, `Object?`, `List<T>`,
+  `Map<K, V>`, `Future<T>`, `String`, `int`, `num`) outside the two patterns above
+  — they show up on every value of that type in every file that imports the
+  package, causing IDE-completion noise and potential collisions with other
+  packages.
 
 ### Avoid `FutureOr<T>` in public APIs
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -818,39 +818,34 @@ Widget build(BuildContext context) {
 
 ### Reactive state
 
-The choice of primitive depends on the layer:
+This repo is transport + design system, not a product SDK — it doesn't own a
+state-management layer. The primitives here are:
 
-- **Pure-Dart product SDKs** — `StateNotifier<S>` from `package:state_notifier`.
-  `S` is an immutable `@freezed` state class. The notifier is internal; the
-  public API is a high-level object that wraps it. See
-  [Product-SDK architecture](#product-sdk-architecture) for the shape.
-  `StateNotifier` is functionally a pure-Dart equivalent of `ValueNotifier` —
-  used here because `Listenable` lives in `package:flutter/foundation.dart` and
-  isn't available in pure-Dart LLCs.
-- **Flutter widget code** — `ValueNotifier` / `ChangeNotifier` for widget-owned
-  state (animations, toggles, controller-adjacent state) and for controllers
-  exposed to the widget tree. Matches Flutter's own conventions.
-- **Transport internals** — `SharedEmitter<T>` / `StateEmitter<T>` in
-  `stream_core/lib/src/utils/` for WS events, connection lifecycle, and other
-  stream-based state that predates `StateNotifier` here. Kotlin
-  `SharedFlow`/`StateFlow` equivalents; both implement `Stream<T>`. Don't build
-  new product-facing state on emitters.
+- **`SharedEmitter<T>` / `StateEmitter<T>`** (in `stream_core/lib/src/utils/`)
+  — internal transport-layer state: WS events, connection lifecycle, network
+  state. Kotlin `SharedFlow`/`StateFlow` equivalents; both implement `Stream<T>`.
+- **`ValueNotifier` / `ChangeNotifier`** — widget-owned state in
+  `stream_core_flutter`: animations, toggles, controller-adjacent state, and
+  controllers exposed to the widget tree. Matches Flutter's own conventions.
 
 Cancel `StreamSubscription`s in `dispose()`. `MutableSharedEmitter` /
-`MutableStateEmitter` have `close()`; `StateNotifier`, `ValueNotifier`, and
-`ChangeNotifier` all have `dispose()`. Prefer RxDart operators over hand-rolled
-`.listen()` + `Controller` plumbing.
+`MutableStateEmitter` have `close()`; `ValueNotifier` / `ChangeNotifier` have
+`dispose()`. Prefer RxDart operators over hand-rolled `.listen()` + `Controller`
+plumbing.
+
+Product SDKs built on top of `stream_core` (pure-Dart LLCs, Flutter UI wrappers)
+choose their own state primitives — each defines them in its own style guide.
 
 ### Error handling with `Result<T>`
 
-Public methods on repositories, clients, and CDN wrappers return
-`Future<Result<T>>` (from `stream_core/lib/src/utils/result.dart`) rather than
-throwing. Existing examples: `StreamAttachmentUploader.upload`, `CdnClient.uploadImage`.
+Public methods that can fail return `Future<Result<T>>` (from
+`stream_core/lib/src/utils/result.dart`) rather than throwing. Existing examples:
+`StreamAttachmentUploader.upload`, `CdnClient.uploadImage`/`uploadFile`.
 
 ```dart
-Future<Result<UserData>> getUser(String id) async {
+Future<Result<UploadedFile>> uploadImage(File image) async {
   try {
-    final response = await _api.getUser(id: id);
+    final response = await _api.uploadImage(image);
     return Result.success(response.toModel());
   } on DioException catch (e) {
     return Result.failure(_mapException(e));
@@ -858,9 +853,8 @@ Future<Result<UserData>> getUser(String id) async {
 }
 
 // Consumer.
-final result = await client.getUser('123');
-switch (result) {
-  case Success(:final data): render(data);
+switch (await cdn.uploadImage(file)) {
+  case Success(:final data): attach(data);
   case Failure(:final error): showError(error);
 }
 ```
@@ -870,83 +864,12 @@ violation, programming error) — convert to `Result.failure` at the boundary.
 `Result` is a `sealed class` — prefer exhaustive `switch` over
 `isSuccess`/`isFailure`.
 
-### Product-SDK architecture
-
-New **pure-Dart** product SDKs built on top of `stream_core` (Chat LLC, Feeds
-LLC, …) use this layering. Flutter UI packages built on top of an LLC follow
-Flutter conventions — see [Reactive state](#reactive-state) for the primitive
-per layer.
-
-```text
-Client                    # public entry point (thin factory)
-  └── Repository          # data access, returns Future<Result<T>>
-      └── StateNotifier   # internal; wraps state, reacts to WS events
-          └── State       # public @freezed value the UI renders
-```
-
-Skeleton:
-
-```dart
-// State — @freezed with Freezed 3.0 mixed-mode syntax + @override on fields.
-@freezed
-class FeatureState with _$FeatureState {
-  const FeatureState({required this.id, required this.items});
-
-  @override
-  final String id;
-  @override
-  final List<ItemData> items;
-}
-
-// StateNotifier — internal, under lib/src/state/.
-class FeatureStateNotifier extends StateNotifier<FeatureState> {
-  FeatureStateNotifier(this._repo, FeatureState initial) : super(initial);
-
-  final FeatureRepository _repo;
-
-  Future<void> refresh() async {
-    switch (await _repo.fetch(id: state.id)) {
-      case Success(:final data): state = state.copyWith(items: data);
-      case Failure(): break;
-    }
-  }
-}
-
-// Public wrapper — lives at the top of lib/.
-class Feature {
-  Feature._(this._notifier);
-  final FeatureStateNotifier _notifier;
-  FeatureState get state => _notifier.state;
-  Stream<FeatureState> get stateChanges => _notifier.stream;
-}
-```
-
-- Public: `Client` + high-level wrappers (like `Feature` above). Both at top of `lib/`.
-- Internal: `Repository`, `*StateNotifier`. Under `lib/src/`.
-- Models under `src/models/`: `*Data` (domain), `*Query` (query descriptor),
-  `*Request` (HTTP payload). All `@freezed`.
-- Tests exercise the public API only — see [Testing](#testing).
-
 
 ## Testing
 
 This section covers repo-level testing conventions. For guidance on **how to write
 good tests** — naming, factoring, one behavior per test — see
 [`TESTING.md`](TESTING.md).
-
-**For product-SDK tests built on top of `stream_core`**, test exclusively through
-the public API:
-
-- **Never test internal implementation directly** — no `.toModel()` mapper
-  invocations, no `*Repository` instantiations, no `*StateNotifier` instantiations
-  in tests. If a consuming app cannot call it, the test cannot either.
-- **Prefer typed test helpers** (`<Product>ClientTest`, `<Product>Test`) that
-  wire up a real client against a mocked HTTP API and expose `mockApi(...)` /
-  `verifyApi(...)` / `emitEvent(...)`. Each product SDK ships its own such
-  helper package alongside its tests.
-- **Mock exact requests, not `any()`** — passing the concrete expected request
-  object simultaneously stubs the response and validates what the SDK sent. Using
-  `any()` matchers hides bugs where the SDK sends the wrong payload.
 
 ### Make each test entirely self-contained
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -192,15 +192,17 @@ pulls higher-level concepts into places they don't belong.
 (cross-product primitives) and `chat.dart` (chat-domain widgets). See
 [Public barrel contract](#public-barrel-contract).
 
-### Avoid interleaving multiple concepts together
+### Prefer immutable data
 
-Each API should be self-contained and should not know about other features.
-Interleaving concepts leads to complexity.
+Themes, `@freezed` models, and other value classes are immutable — callers get a
+new instance from `copyWith`, never mutation. Widgets that take a `child` should
+be agnostic about the type of that child; don't `is`-check to act differently on
+the child's runtime type.
 
-- Widgets that take a `child` should be entirely agnostic about the type of that
-  child. Don't use `is` checks to act differently based on the type of the child.
-- Prefer immutable data models. `Message`, `User`, and friends are immutable. Themes
-  are immutable. Callers get a new instance from `copyWith`, never mutation.
+Note that "immutable" applies to values and configuration, not to the design
+system as a whole: components compose deliberately here (component factory,
+theme hierarchy, related message-layer widgets referencing each other). Coupling
+between design-system pieces is part of the point, not a smell.
 
 ### Avoid secret (or global) state
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -643,24 +643,20 @@ groups (`directives_ordering`).
 
 ### Guidelines for `extension`s
 
-New utility extensions on common types (`on T extends Object`, `on Iterable`,
-`on List`, `on Comparable`, `on num`) belong in `stream_core/lib/src/utils/`.
-That layer is exported from `stream_core.dart` and used in 100+ call sites:
-`Standard` (Kotlin scope funcs `let`/`also`/`apply`/`takeIf`),
-`ComparableExtension`, `IterableExtensions`, `ListExtensions`,
-`SortedListExtensions`. Add to it rather than scattering new extensions across
-feature code.
+New utility extensions on common types belong in `stream_core/lib/src/utils/`
+alongside the existing helpers. Add to that layer rather than scattering
+new extensions across feature code.
 
 Extensions outside `utils/` are fine on:
 
-- Domain types — `AttachmentFile`, `DioException`, `RetryStrategy`, etc.
-- `BuildContext`, for scoped lookups (`context.streamTheme`).
-- Primitives, for units-of-measure — `5.kilometers` via `DistanceExtension on num`.
-  Keep them small and colocated with the value type.
+- Domain types the caller is already working with.
+- `BuildContext`, for scoped lookups.
+- Primitives, for units-of-measure — small, unambiguous, and colocated with
+  the value type.
 
-Avoid public extensions on `Object`, `Object?`, `Future<T>`, `String`,
-`Map<K, V>` outside these patterns — they land on every value of that type in
-every file that imports the package.
+Avoid public extensions on unconstrained common types (`Object`, `Object?`,
+`Future<T>`, `String`, `Map<K, V>`) outside these patterns — they land on
+every value of that type in every file that imports the package.
 
 Extension methods are resolved statically and can't be overridden; if a caller
 might want to substitute the behaviour, expose an instance method or callback

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -190,6 +190,12 @@ pulls higher-level concepts into places they don't belong.
 (cross-product primitives) and `chat.dart` (chat-domain widgets). See
 [Public barrel contract](#public-barrel-contract).
 
+### Prefer immutable data
+
+Themes, `@freezed` models, and other value classes are immutable — callers get
+a new instance via `copyWith`, not mutation. Widgets that take a `child` are
+agnostic about its runtime type; don't `is`-check the child.
+
 ### Avoid secret (or global) state
 
 A function should operate only on its arguments and, if it is an instance method,
@@ -200,12 +206,30 @@ Theme values are threaded through `StreamTheme.of(context)` — an
 `ThemeExtension` lookup that resolves to a concrete `StreamTheme`. We do
 not have singletons for theme, colors, or design tokens.
 
+### Prefer general APIs, but use dedicated APIs where there is a reason
+
+Having dedicated APIs for performance reasons is fine. If one specific operation
+is expensive using the general API but could be implemented more efficiently
+using a dedicated API, that is where a dedicated API belongs.
+
 ### Avoid APIs that encourage bad practices
 
 Don't provide APIs that walk entire trees, or that encourage O(N²) algorithms, or
 that encourage sequential long-lived operations where the operations could be run
 concurrently. Similarly, if an operation is expensive, that expense should be
 represented in the API (e.g. by returning a `Future` or a `Stream`).
+
+### Avoid heuristics and magic
+
+Predictable APIs that give the developer control are generally preferred over
+APIs that mostly do the right thing but don't give the developer any way to
+adjust the results. Predictability is reassuring.
+
+### Solve real problems by literally solving a real problem
+
+Where possible, partner with a real customer who wants the feature and is
+willing to help you test it. Only by actually using a feature in the real world
+can we be confident it is ready.
 
 ### Start designing APIs from the closest point to the developer
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -643,11 +643,11 @@ groups (`directives_ordering`).
 
 ### Guidelines for `extension`s
 
-New utility extensions on common types belong in `stream_core/lib/src/utils/`
-alongside the existing helpers. Add to that layer rather than scattering
-new extensions across feature code.
+New utility extensions on common types belong in the shared utils layer,
+alongside the existing helpers. Add to that layer rather than scattering new
+extensions across feature code.
 
-Extensions outside `utils/` are fine on:
+Extensions outside the utils layer are fine on:
 
 - Domain types the caller is already working with.
 - `BuildContext`, for scoped lookups.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -808,21 +808,27 @@ Widget build(BuildContext context) {
 }
 ```
 
-### Reactive primitives
+### Use of `Stream`s
 
-Two primitives cover reactive state in this repo:
+In general we avoid direct use of `Stream` classes in this repo. Streams in
+general are fine — we encourage people to use them — but they have some
+disadvantages that make them awkward as a public reactive primitive, and we
+prefer to wrap them in our own emitter types for this reason. For example:
 
-- **`SharedEmitter` / `StateEmitter`** — for stream-like reactive data (WS
-  events, connection changes, transport-layer state). `SharedEmitter`
-  broadcasts events with optional replay for late subscribers; `StateEmitter`
-  adds a current-value accessor and conflates duplicate emissions. Both
-  implement `Stream<T>`, so `StreamBuilder` can consume them directly.
-- **`Listenable` subclasses** (`ValueNotifier`, `ChangeNotifier`) — for
-  widget-owned state at the Flutter layer: animations, toggles,
-  controller-adjacent state, and controllers exposed to the widget tree.
-  Matches Flutter's own convention.
+- Streams have a heavy API. For example, they can be synchronous or asynchronous,
+  broadcast or single-client, and they can be paused and resumed. It is
+  non-trivial to determine the right semantics for a particular stream when it
+  will be used in all the ways SDK code could be used, and it is non-trivial to
+  fully implement the semantics correctly.
 
-Don't use raw `Stream` directly — reach for the emitters instead.
+- The APIs for manipulating streams are non-trivial (e.g. transformers).
+
+We generally prefer `SharedEmitter` for broadcast events and `StateEmitter` for
+state with a definite "current value". Both implement `Stream<T>`, so consumers
+can still use `StreamBuilder`.
+
+At the Flutter widget layer, we prefer `Listenable` subclasses (e.g.
+`ValueNotifier` or `ChangeNotifier`) for widget-owned state.
 
 ## Testing
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -643,24 +643,19 @@ groups (`directives_ordering`).
 
 ### Guidelines for `extension`s
 
-New utility extensions on common types belong in the shared utils layer,
-alongside the existing helpers. Add to that layer rather than scattering new
-extensions across feature code.
+Extension methods let you add additional functionality to an existing type.
+When choosing between declaring a regular instance method and an extension
+method, consider the trade-offs. Extension methods are resolved statically and
+cannot be overridden. Furthermore, misusing extension methods can pollute IDE
+suggestions and cause naming collisions.
 
-Extensions outside the utils layer are fine on:
+Don't declare an extension method when declaring a regular method will do.
 
-- Domain types the caller is already working with.
-- `BuildContext`, for scoped lookups.
-- Primitives, for units-of-measure — small, unambiguous, and colocated with
-  the value type.
+Don't use extension methods if the end developer might want to override the
+extension method's implementation. Extension methods cannot be overridden.
 
-Avoid public extensions on unconstrained common types (`Object`, `Object?`,
-`Future<T>`, `String`, `Map<K, V>`) outside these patterns — they land on
-every value of that type in every file that imports the package.
-
-Extension methods are resolved statically and can't be overridden; if a caller
-might want to substitute the behaviour, expose an instance method or callback
-instead.
+Don't create extension methods with the same name on the same type in separate
+libraries. This causes collisions if both libraries are imported.
 
 ### Avoid `FutureOr<T>` in public APIs
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -818,27 +818,28 @@ Widget build(BuildContext context) {
 
 ### Reactive state
 
-Three primitives, each for a specific job:
+The choice of primitive depends on the layer:
 
-- **`StateNotifier<S>`** (from `package:state_notifier`) — the going-forward
-  primitive for new product-SDK state. `S` is an immutable `@freezed` state
-  class. The notifier is internal; the public API is a high-level object that
-  wraps it. See [Product-SDK architecture](#product-sdk-architecture) for the
-  shape.
-- **`SharedEmitter<T>` / `StateEmitter<T>`** — internal transport-layer state in
-  `stream_core/lib/src/utils/` (WS events, connection lifecycle). Kotlin
+- **Pure-Dart product SDKs** — `StateNotifier<S>` from `package:state_notifier`.
+  `S` is an immutable `@freezed` state class. The notifier is internal; the
+  public API is a high-level object that wraps it. See
+  [Product-SDK architecture](#product-sdk-architecture) for the shape.
+  `StateNotifier` is functionally a pure-Dart equivalent of `ValueNotifier` —
+  used here because `Listenable` lives in `package:flutter/foundation.dart` and
+  isn't available in pure-Dart LLCs.
+- **Flutter widget code** — `ValueNotifier` / `ChangeNotifier` for widget-owned
+  state (animations, toggles, controller-adjacent state) and for controllers
+  exposed to the widget tree. Matches Flutter's own conventions.
+- **Transport internals** — `SharedEmitter<T>` / `StateEmitter<T>` in
+  `stream_core/lib/src/utils/` for WS events, connection lifecycle, and other
+  stream-based state that predates `StateNotifier` here. Kotlin
   `SharedFlow`/`StateFlow` equivalents; both implement `Stream<T>`. Don't build
   new product-facing state on emitters.
-- **`ValueNotifier` / `ChangeNotifier`** — widget-owned state that never leaves
-  the widget tree: animations, toggles, controller-adjacent state.
 
 Cancel `StreamSubscription`s in `dispose()`. `MutableSharedEmitter` /
-`MutableStateEmitter` have `close()`; `StateNotifier` has `dispose()`. Prefer
-RxDart operators over hand-rolled `.listen()` + `Controller` plumbing.
-
-This intentionally diverges from Flutter's style guide, which recommends
-`Listenable` over `Stream` — that reasoning doesn't apply to a real-time
-transport layer where events are the primary data model.
+`MutableStateEmitter` have `close()`; `StateNotifier`, `ValueNotifier`, and
+`ChangeNotifier` all have `dispose()`. Prefer RxDart operators over hand-rolled
+`.listen()` + `Controller` plumbing.
 
 ### Error handling with `Result<T>`
 
@@ -871,7 +872,10 @@ violation, programming error) — convert to `Result.failure` at the boundary.
 
 ### Product-SDK architecture
 
-New product-SDK code built on top of `stream_core` uses this layering:
+New **pure-Dart** product SDKs built on top of `stream_core` (Chat LLC, Feeds
+LLC, …) use this layering. Flutter UI packages built on top of an LLC follow
+Flutter conventions — see [Reactive state](#reactive-state) for the primitive
+per layer.
 
 ```text
 Client                    # public entry point (thin factory)

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -824,10 +824,11 @@ disadvantages that make them awkward inside widget code:
 
 This matches Flutter's own guidance inside the framework.
 
-At the transport layer, streams are the natural primitive — WebSocket events
-and connection lifecycle changes arrive asynchronously and have no meaningful
-"current value" at every moment. `SharedEmitter` and `StateEmitter` are the
-primitives; both implement `Stream<T>`.
+At the transport layer, events arrive asynchronously — WebSocket messages,
+connection changes, network state. `SharedEmitter` handles broadcast events
+(with optional replay for late subscribers); `StateEmitter` adds a
+current-value accessor for state that has a definite "now" and conflates
+duplicate emissions. Both implement `Stream<T>`.
 
 ## Testing
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -307,33 +307,39 @@ stream-core-flutter/
 
 ### Public barrel contract
 
-`stream_core_flutter` exposes two narrow public barrels so non-chat Stream SDKs
-(video, feeds, ...) can pull in just the shared primitives without paying for chat
-code:
+`stream_core_flutter` exposes multiple narrow public barrels so each Stream product
+SDK (chat today; video, feeds, … in the future) can pull in just the primitives it
+needs without paying for other products' code:
 
-- `package:stream_core_flutter/core.dart` — shared UI primitives, theme tokens, the
-  component factory. Safe for any Stream SDK.
+- `package:stream_core_flutter/core.dart` — cross-product primitives, theme tokens,
+  the component factory. Safe for any Stream SDK.
 - `package:stream_core_flutter/chat.dart` — chat-specific widgets (message bubble,
   composer attachments, reactions, …). Chat SDKs import this **alongside**
   `core.dart`.
 - `package:stream_core_flutter/stream_core_flutter.dart` — deprecated convenience
-  barrel that re-exports both. Will be removed at 1.0.0.
+  barrel that re-exports the others. Will be removed at 1.0.0.
+
+Additional product barrels (`video.dart`, `feeds.dart`, …) can be added when a new
+Stream product needs domain-specific widgets that don't belong in `core.dart`. Each
+new barrel gets its own entry in `check_barrels.yaml` under `barrels:`, and the
+same rules apply.
 
 Rules enforced by `melos run check:barrels` (config at
 `packages/stream_core_flutter/check_barrels.yaml`, wired into CI):
 
-1. Every public file under `lib/src/` must appear in exactly **one** barrel. No
-   duplicates, no orphans, no dangling exports.
+1. Every public file under `lib/src/` must appear in exactly **one** listed barrel.
+   No duplicates, no orphans, no dangling exports.
 2. No file under `lib/src/` may import a public barrel (`core.dart`, `chat.dart`,
-   `stream_core_flutter.dart`). Use a relative import to the source file — barrels
-   are for **consumers**, not internal code.
-3. Anything under an `internal/` directory listed in `check_barrels.yaml`'s
-   `internal_dirs` is excluded from coverage. Use this for figma-generated tokens
-   and other implementation-only artefacts.
+   `stream_core_flutter.dart`, and any future product barrel). Use a relative
+   import to the source file — barrels are for **consumers**, not internal code.
+3. Anything under a directory listed in `check_barrels.yaml`'s `internal_dirs` is
+   excluded from coverage. Use this for figma-generated tokens and other
+   implementation-only artefacts (currently: `lib/src/theme/primitives/internal`).
 
 When adding a new public widget or theme: create the file under `lib/src/…`, then
-add an `export 'src/…/my_file.dart';` line to either `core.dart` or `chat.dart`. The
-check fails on PR if you forget.
+add an `export 'src/…/my_file.dart';` line to the appropriate barrel — `core.dart`
+if the widget is product-agnostic, `chat.dart` if it's chat-specific, or a new
+product barrel if you're introducing one. The check fails on PR if you forget.
 
 ### Dependency management
 
@@ -1125,9 +1131,15 @@ Each component ships with:
 
 - **Widget file** — under `lib/src/components/<category>/<name>.dart`.
 - **Theme file** — under `lib/src/theme/components/<name>_theme.dart`. See
-  [Theme system](#theme-system). Note: the suffix is either `<Name>ThemeData` or
-  `<Name>Style` — both patterns exist in the repo (e.g. `StreamAvatarThemeData`,
-  `StreamMessageBubbleStyle`); pick whichever fits the component's semantics.
+  [Theme system](#theme-system).
+
+  Naming convention: top-level component themes use `<Component>ThemeData`;
+  sub-configurations nested inside a top-level theme use `<Component>Style`. For
+  example, `StreamButtonThemeData` (top-level) contains `StreamButtonTypeStyle` +
+  `StreamButtonThemeStyle` (per-variant sub-configurations). New code follows this
+  split. A handful of existing top-level themes are grandfathered into the `Style`
+  suffix (e.g. `StreamMessageBubbleStyle`, `StreamMessageMetadataStyle`) — don't
+  add more.
 - **Widget or unit tests** — under `test/components/<category>/<name>_test.dart`.
   Golden variants use the `_golden_test.dart` suffix (e.g.
   `stream_button_golden_test.dart`, `stream_button_test.dart`). See
@@ -1200,10 +1212,18 @@ Look at `stream_avatar_theme.dart` and any file in
 
 ### Component factory
 
-The design system uses `StreamComponentFactory` to allow consumers to substitute
+The design system uses `StreamComponentFactory` to let consumers substitute
 individual components without forking. When adding a new component that has a
-default implementation, register a factory hook so consumers can override it. See
-`lib/src/factory/stream_component_factory.dart` for the pattern.
+default implementation, register a factory hook so consumers can override it.
+
+Reference pattern: see how `StreamMessageBubble` resolves its default builder via
+`StreamComponentFactory.of(context).messageBubble` in
+`packages/stream_core_flutter/lib/src/components/message/stream_message_bubble.dart`.
+The factory class itself lives at
+`packages/stream_core_flutter/lib/src/factory/stream_component_factory.dart` —
+add a nullable builder field there, wire it up through the factory's `copyWith`
+and default fallback, and consume it in the component's `build` with the standard
+null-coalescing chain.
 
 ### Icons
 
@@ -1224,7 +1244,7 @@ Do not edit the generated `StreamIcons.dart` or the icon font by hand.
 
 ### Widget essentials
 
-Every new public widget in `stream_core_flutter` should:
+Every **new** public widget in `stream_core_flutter` should:
 
 - Accept `Key? key` in its constructor via `super.key`
   (`use_key_in_widget_constructors`, `use_super_parameters`).
@@ -1236,6 +1256,11 @@ Every new public widget in `stream_core_flutter` should:
 - Have a golden test covering the default state and the primary theme variants.
 - Have a Widgetbook use-case that lets a designer or reviewer interact with all
   props.
+
+Some earlier components predate parts of this checklist (e.g. missing widget tests
+or Widgetbook use-cases). When you touch such a component for a substantive change,
+try to close the gap in the same PR — but don't block landing a fix on backfilling
+years of missing coverage.
 
 
 ## Commits, PRs, and changelogs

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -649,12 +649,31 @@ trade-offs before reaching for one:
 - Extension methods are resolved statically and cannot be overridden.
 - Misusing extensions pollutes IDE suggestions and causes naming collisions.
 
-Rules:
+The repo intentionally maintains a **standard-library-style extension layer** in
+`packages/stream_core/lib/src/utils/`, exported from `stream_core.dart` and used
+across the codebase (100+ call sites). It includes:
 
+- `Standard<T extends Object> on T` — Kotlin-style scope functions
+  (`let`, `also`, `apply`, `takeIf`, `takeUnless`).
+- `ComparableExtension<T extends Comparable<T>> on T` — `<`, `>`, `<=`, `>=`
+  operators.
+- `IterableExtensions on Iterable<T>` — `sumOf`.
+- `ListExtensions` / `SortedListExtensions` on `List<T>` — `upsert`, `partition`,
+  `batchReplace`, `sortedInsert`, `sortedUpsert`, `merge`, `updateNested`,
+  `removeNested`, `updateWhere`, `insertUnique`.
+
+Use these freely — they are part of the SDK's DSL.
+
+Rules for new extensions:
+
+- **Standard utility extensions belong in `stream_core/lib/src/utils/`.** If you
+  need a new `on num` / `on List<T>` / `on Iterable<T>` / `on T extends Object`
+  helper, add it to the appropriate file there rather than defining a new
+  extension in feature code.
 - Don't declare an extension method when a regular method or a helper function
   will do.
-- Extensions on domain types are fine — they only apply when the caller is already
-  working with those types. Examples in the repo: `AttachmentFile`,
+- Extensions on domain types are fine — they only apply when the caller is
+  already working with those types. Examples in the repo: `AttachmentFile`,
   `DioException`, `RetryStrategy`, `SystemEnvironment`.
 - Extensions on `BuildContext` for scoped lookups are an accepted Flutter idiom.
   Examples: `StreamThemeExtension on BuildContext` exposing `context.streamTheme`;
@@ -662,11 +681,11 @@ Rules:
 - Units-of-measure extensions on primitives are acceptable when the extension is
   small, unambiguous, and lives next to the value type. Example:
   `DistanceExtension on num` exposing `5.kilometers` next to `Distance`.
-- Avoid public extensions on common types (`Object`, `Object?`, `List<T>`,
-  `Map<K, V>`, `Future<T>`, `String`, `int`, `num`) outside the two patterns above
-  — they show up on every value of that type in every file that imports the
-  package, causing IDE-completion noise and potential collisions with other
-  packages.
+
+Outside these patterns, avoid public extensions on `Object`, `Object?`,
+`Future<T>`, `String`, `Map<K, V>` — those show up on every value of that type in
+every file that imports the package, causing IDE-completion noise and potential
+collisions with other packages.
 
 ### Avoid `FutureOr<T>` in public APIs
 
@@ -819,27 +838,48 @@ Widget build(BuildContext context) {
 }
 ```
 
-### Use streams for real-time data
+### Use emitters for reactive state
 
-`stream_core` builds the transport layer for real-time products. `Stream` (via
-RxDart) is the primary reactive primitive for data that arrives asynchronously —
-WebSocket events, connection-state changes, backoff notifications. This
-intentionally diverges from Flutter's style guide, which recommends `Listenable`
-over `Stream` inside the framework.
+`stream_core` builds the transport layer for real-time products. The primary
+reactive primitives are the Kotlin-flavoured emitter types in
+`stream_core/lib/src/utils/` (both implement `Stream<T>` under the hood, so
+`StreamBuilder` still works on them):
 
-Rules of thumb for choosing between `Stream` and `Listenable`:
+- **`SharedEmitter<T>` / `MutableSharedEmitter<T>`** — Kotlin `SharedFlow`
+  equivalent. Multi-subscriber event broadcast. Use for events that don't have a
+  "current value" (WS events, one-shot notifications, connection lifecycle).
+  Supports replay via the `replay:` constructor argument.
+- **`StateEmitter<T>` / `MutableStateEmitter<T>`** — Kotlin `StateFlow`
+  equivalent. Always has a `.value`, replays it on subscribe, conflates duplicate
+  emissions. Use for values with a definite "current" state
+  (connection state, network state, lifecycle state, any controller-adjacent
+  value that a UI would render).
 
-- **`Stream`** — for data that originates outside the widget tree: WS events,
-  network responses, RxDart pipelines.
-- **`ValueNotifier` / `ChangeNotifier`** — for widget-owned reactive state:
-  animation-driven state, expanded/collapsed toggles, controller-adjacent state.
+Choose based on whether the data has a meaningful "current value":
 
-Consuming streams in widgets:
+- **`StateEmitter`** — connection state, feature-flag values, cached counts,
+  anything a widget would render as "the latest". Prefer this over
+  `ValueNotifier` for cross-boundary state (state that flows out of `stream_core`
+  into UI), because it composes with the rest of the emitter/stream ecosystem.
+- **`SharedEmitter`** — WS events, error notifications, one-shot signals.
+- **`ValueNotifier` / `ChangeNotifier`** — widget-owned reactive state that
+  never crosses out of the widget tree: animation-driven state,
+  expanded/collapsed toggles, `TextEditingController`-adjacent state.
 
-- Use `StreamBuilder` (or `initialData` on it) when a stream drives a widget subtree.
+Consuming emitters in widgets:
+
+- `SharedEmitter` and `StateEmitter` both `implements Stream<T>`, so
+  `StreamBuilder` (with `initialData: stateEmitter.value` when applicable) is
+  the standard consumer.
 - For pipelines that combine or transform streams, prefer RxDart operators over
   hand-rolled `.listen()`+`Controller` plumbing.
-- Always cancel `StreamSubscription`s in `dispose()`.
+- Always cancel `StreamSubscription`s in `dispose()`. `MutableSharedEmitter` and
+  `MutableStateEmitter` have `close()` — call it when the owning object is
+  disposed.
+
+This intentionally diverges from Flutter's style guide, which recommends
+`Listenable` over `Stream` inside the framework — that reasoning doesn't apply
+to a real-time transport layer where events are the primary data model.
 
 
 ## Testing

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -862,13 +862,19 @@ client, WebSocket, image loading). Do not mock every collaborator.
 ### Golden tests
 
 Widget tests that verify pixel-level rendering use the `alchemist` package. Golden
-files live under `test/components/<name>/goldens/`, split by target:
+tests live in `_golden_test.dart` files next to the unit tests, and the generated
+images go under `test/components/<category>/goldens/`. The alchemist config in
+`test/flutter_test_config.dart` runs:
 
-- `goldens/ci/` — used by CI
-- `goldens/macos/` — used for local macOS development
+- `ciGoldensConfig` — enabled only when `GITHUB_ACTIONS` is set. Produces
+  `goldens/ci/*.png`. **These are the goldens that get committed.**
+- `platformGoldensConfig` — enabled only locally. Produces `goldens/<platform>/`
+  (e.g. `goldens/macos/`). These are auto-generated during local runs and
+  gitignored (`.gitignore` allowlists only `goldens/ci/`).
 
 Golden tests are tagged with `golden` in `dart_test.yaml`. Every visible component
-must ship with a golden test.
+must ship with a golden test that exercises the primary variants (sizes, states,
+theme brightness).
 
 To regenerate goldens:
 
@@ -878,7 +884,8 @@ melos run update:goldens
 
 Regenerate goldens deliberately, in a separate commit from behavior changes, so
 reviewers can see what visually changed. Do not check in a golden mismatch just
-because a test "works locally".
+because a test "works locally" — only the CI-generated PNGs under `goldens/ci/`
+are committed and diffed.
 
 
 ## Naming
@@ -1121,7 +1128,9 @@ Each component ships with:
   [Theme system](#theme-system). Note: the suffix is either `<Name>ThemeData` or
   `<Name>Style` — both patterns exist in the repo (e.g. `StreamAvatarThemeData`,
   `StreamMessageBubbleStyle`); pick whichever fits the component's semantics.
-- **Golden test** — under `test/components/<name>/`. See
+- **Widget or unit tests** — under `test/components/<category>/<name>_test.dart`.
+  Golden variants use the `_golden_test.dart` suffix (e.g.
+  `stream_button_golden_test.dart`, `stream_button_test.dart`). See
   [Golden tests](#golden-tests).
 - **Widgetbook use-case** — under
   `apps/design_system_gallery/lib/components/<category>/`.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -838,48 +838,99 @@ Widget build(BuildContext context) {
 }
 ```
 
-### Use emitters for reactive state
+### Reactive state primitives
 
-`stream_core` builds the transport layer for real-time products. The primary
-reactive primitives are the Kotlin-flavoured emitter types in
-`stream_core/lib/src/utils/` (both implement `Stream<T>` under the hood, so
-`StreamBuilder` still works on them):
+There are three layers of reactive state in this repo, each with its own primitive:
+
+**1. Product-SDK state → `StateNotifier` (from `package:state_notifier`) — the
+going-forward pattern for new code.**
+
+Product SDKs built on top of `stream_core` (chat, feeds, video, …) manage state
+via `StateNotifier<State>` with an immutable `@freezed` `State` class. The
+reference implementation is stream-feeds-flutter — see its
+[`AGENTS.md`](https://github.com/GetStream/stream-feeds-flutter/blob/main/AGENTS.md)
+for the full pattern (Client → Repository → StateNotifier → public State object).
+Key rules for new state code:
+
+- `*State` classes use `@freezed` with const constructors and Freezed 3.0
+  mixed-mode syntax (`@override` on fields).
+- `*StateNotifier` implementations extend `StateNotifier<*State>` and are an
+  **internal** implementation detail — never exposed on the public API.
+- The public surface is the high-level state object (e.g. `Feed`, `ActivityList`)
+  that wraps the notifier.
+
+**2. Transport-layer state → existing emitters in `stream_core/lib/src/utils/`.**
+
+For state that lives inside `stream_core`'s transport layer (WS events,
+connection state, network state, lifecycle state) the existing
+`SharedEmitter`/`StateEmitter` primitives remain the right choice — they predate
+`StateNotifier` here and are wired into the WS reconnection machinery:
 
 - **`SharedEmitter<T>` / `MutableSharedEmitter<T>`** — Kotlin `SharedFlow`
-  equivalent. Multi-subscriber event broadcast. Use for events that don't have a
-  "current value" (WS events, one-shot notifications, connection lifecycle).
-  Supports replay via the `replay:` constructor argument.
+  equivalent. Multi-subscriber broadcast for events without a "current value".
+  Supports `replay:` for late subscribers.
 - **`StateEmitter<T>` / `MutableStateEmitter<T>`** — Kotlin `StateFlow`
-  equivalent. Always has a `.value`, replays it on subscribe, conflates duplicate
-  emissions. Use for values with a definite "current" state
-  (connection state, network state, lifecycle state, any controller-adjacent
-  value that a UI would render).
+  equivalent. Has `.value`, replays it on subscribe, conflates duplicates.
 
-Choose based on whether the data has a meaningful "current value":
+Both `implements Stream<T>`, so `StreamBuilder` (with `initialData:
+stateEmitter.value` for `StateEmitter`) is the standard widget-side consumer.
+Don't build new product-facing state on emitters — use `StateNotifier` for that.
 
-- **`StateEmitter`** — connection state, feature-flag values, cached counts,
-  anything a widget would render as "the latest". Prefer this over
-  `ValueNotifier` for cross-boundary state (state that flows out of `stream_core`
-  into UI), because it composes with the rest of the emitter/stream ecosystem.
-- **`SharedEmitter`** — WS events, error notifications, one-shot signals.
-- **`ValueNotifier` / `ChangeNotifier`** — widget-owned reactive state that
-  never crosses out of the widget tree: animation-driven state,
-  expanded/collapsed toggles, `TextEditingController`-adjacent state.
+**3. Widget-owned state → `ValueNotifier` / `ChangeNotifier`.**
 
-Consuming emitters in widgets:
+For reactive state that never crosses out of the widget tree — animation-driven
+values, expanded/collapsed toggles, `TextEditingController`-adjacent state.
 
-- `SharedEmitter` and `StateEmitter` both `implements Stream<T>`, so
-  `StreamBuilder` (with `initialData: stateEmitter.value` when applicable) is
-  the standard consumer.
+**General rules:**
+
+- Always cancel `StreamSubscription`s in `dispose()`. `MutableSharedEmitter` /
+  `MutableStateEmitter` have `close()`; `StateNotifier` has `dispose()` — call
+  the right one when the owning object is torn down.
 - For pipelines that combine or transform streams, prefer RxDart operators over
   hand-rolled `.listen()`+`Controller` plumbing.
-- Always cancel `StreamSubscription`s in `dispose()`. `MutableSharedEmitter` and
-  `MutableStateEmitter` have `close()` — call it when the owning object is
-  disposed.
 
 This intentionally diverges from Flutter's style guide, which recommends
 `Listenable` over `Stream` inside the framework — that reasoning doesn't apply
 to a real-time transport layer where events are the primary data model.
+
+### Error handling with `Result<T>`
+
+Public methods on repositories, clients, and CDN wrappers return
+`Future<Result<T>>` (from `stream_core/lib/src/utils/result.dart`) rather than
+throwing. Existing examples in the repo: `StreamAttachmentUploader.upload`,
+`CdnClient.uploadImage`/`uploadFile`/`deleteImage`/`deleteFile`.
+
+Rules:
+
+- SDK public methods that can fail return `Result<T>`. Never throw across the
+  SDK boundary.
+- Internal helpers can still throw when a failure is truly exceptional (an
+  `assert` violation, a programming error). Convert to `Result.failure` at the
+  boundary.
+- `Result` is a `sealed class` with `Success<T>` and `Failure` variants. Prefer
+  `switch` (exhaustive) over `isSuccess`/`isFailure` when acting on the outcome
+  in code you control.
+
+### Reference architecture: stream-feeds-flutter
+
+For new product-SDK code built on top of `stream_core` — a client that fetches
+data, hosts state, and exposes it to UI — mirror the layered architecture
+documented in
+[stream-feeds-flutter's AGENTS.md](https://github.com/GetStream/stream-feeds-flutter/blob/main/AGENTS.md):
+
+```text
+Client                    # public API entry point (thin factory)
+  └── Repository          # data access, returns Future<Result<T>>
+      └── StateNotifier   # internal; wraps state + reacts to WS events
+          └── State       # public @freezed value; what the UI renders
+```
+
+- Client and State/high-level state objects (`Feed`, `ActivityList`, …) are
+  public. Repository and StateNotifier are internal (`lib/src/`).
+- All Repository methods return `Result<T>` — no thrown exceptions.
+- Models under `src/models/` are `@freezed` (mixed-mode 3.0 with `@override`),
+  named `*Data`. Queries: `*Query`. Requests: `*Request`.
+- Tests go against the public API only — see [Testing](#testing) below.
 
 
 ## Testing
@@ -887,6 +938,20 @@ to a real-time transport layer where events are the primary data model.
 This section covers repo-level testing conventions. For guidance on **how to write
 good tests** — naming, factoring, one behavior per test — see
 [`TESTING.md`](TESTING.md).
+
+**For product-SDK tests built on top of `stream_core`** (chat, feeds, video), test
+exclusively through the public API. The reference is
+[stream-feeds-flutter's AGENTS.md](https://github.com/GetStream/stream-feeds-flutter/blob/main/AGENTS.md):
+
+- **Never test internal implementation directly** — no `.toModel()` mapper
+  invocations, no `*Repository` instantiations, no `*StateNotifier` instantiations
+  in tests. If a consuming app cannot call it, the test cannot either.
+- **Test via typed test helpers** (`feedsClientTest`, `feedTest`, and analogues
+  for other product SDKs). These wire up a real client against a mocked HTTP API
+  and expose `mockApi(...)` / `verifyApi(...)` / `emitEvent(...)`.
+- **Mock exact requests, not `any()`** — passing the concrete expected request
+  object simultaneously stubs the response and validates what the SDK sent. Using
+  `any()` matchers hides bugs where the SDK sends the wrong payload.
 
 ### Make each test entirely self-contained
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -160,14 +160,12 @@ Concretely for this repo: theme values flow one direction (theme data → widget
 `build`); widgets don't cache computed theme values. `ChangeNotifier`-driven state
 (controllers) is the source of truth; snapshots in local `State` are stale by design.
 
-### Getters feel faster than methods
+### Getters should be cheap
 
-Property getters should be efficient (e.g. returning a cached value or an O(1) table
-lookup). If an operation is inefficient, it should be a method instead.
-
-Similarly, a getter that returns a `Future` or `Stream` should not kick off the work
-represented by the future. The work should be started from a method or constructor,
-and the getter should return the preexisting future or stream.
+Getters should be O(1) or return a cached value — callers may hit them repeatedly
+during `build`, layout, or event handling. If an operation is slow or side-effectful,
+use a method. A getter that returns a `Future` or `Stream` returns the existing one;
+it doesn't kick off new work.
 
 ### No synchronous slow work
 
@@ -180,7 +178,7 @@ and the type signature (`Future`, `Stream`) should show it.
 The SDK is two-package layered:
 
 ```text
-stream_core            # Pure Dart — WebSocket (RxDart), HTTP (Dio), models
+stream_core            # Pure Dart transport layer
   └── stream_core_flutter  # Flutter UI primitives + design system
 ```
 
@@ -192,16 +190,6 @@ pulls higher-level concepts into places they don't belong.
 (cross-product primitives) and `chat.dart` (chat-domain widgets). See
 [Public barrel contract](#public-barrel-contract).
 
-### Avoid interleaving multiple concepts together
-
-Each API should be self-contained and should not know about other features.
-Interleaving concepts leads to complexity.
-
-- Widgets that take a `child` should be entirely agnostic about the type of that
-  child. Don't use `is` checks to act differently based on the type of the child.
-- Prefer immutable data models. `Message`, `User`, and friends are immutable. Themes
-  are immutable. Callers get a new instance from `copyWith`, never mutation.
-
 ### Avoid secret (or global) state
 
 A function should operate only on its arguments and, if it is an instance method,
@@ -212,30 +200,12 @@ Theme values are threaded through `StreamTheme.of(context)` — an
 `ThemeExtension` lookup that resolves to a concrete `StreamTheme`. We do
 not have singletons for theme, colors, or design tokens.
 
-### Prefer general APIs, but use dedicated APIs where there is a reason
-
-Having dedicated APIs for performance reasons is fine. If one specific operation is
-expensive using the general API but could be implemented more efficiently using a
-dedicated API, that is where a dedicated API belongs.
-
 ### Avoid APIs that encourage bad practices
 
 Don't provide APIs that walk entire trees, or that encourage O(N²) algorithms, or
 that encourage sequential long-lived operations where the operations could be run
 concurrently. Similarly, if an operation is expensive, that expense should be
 represented in the API (e.g. by returning a `Future` or a `Stream`).
-
-### Avoid heuristics and magic
-
-Predictable APIs that give the developer control are generally preferred over APIs
-that mostly do the right thing but don't give the developer any way to adjust the
-results. Predictability is reassuring.
-
-### Solve real problems by literally solving a real problem
-
-Where possible, partner with a real customer (an internal Stream product team or an
-external integrator) who wants the feature and is willing to help you test it. Only
-by actually using a feature in the real world can we be confident it is ready.
 
 ### Start designing APIs from the closest point to the developer
 
@@ -246,14 +216,12 @@ touch — then work down to the primitives.
 
 ### Only log actionable messages to the console
 
-If the logs contain messages users can safely ignore, they will do so, and eventually
-their logs will be so chatty they'll miss the critical messages. Only log actual
-errors and actionable warnings.
+If logs contain messages callers can safely ignore, they will do so, and eventually
+the logs are so chatty the critical messages get lost. Only log actual errors and
+actionable warnings.
 
-Use `Logger` from `stream_core/src/logger/` at an appropriate level. `avoid_print` is
-disabled repo-wide (`analysis_options.yaml`) but that's a temporary allowance — in
-`stream_core_flutter`, prefer `debugPrint` (which respects the framework's rate
-limiter) over raw `print`.
+Use the SDK's `Logger` utility, gated at an appropriate level. In Flutter code,
+prefer `debugPrint` over raw `print`.
 
 ### Error messages should be useful
 
@@ -298,7 +266,7 @@ stream-core-flutter/
 ├── STYLE_GUIDE.md            # This file
 ├── CLAUDE.md                 # AI-agent pointer to this guide + repo overview
 ├── packages/
-│   ├── stream_core/          # LLC — pure Dart (RxDart WebSocket, Dio HTTP)
+│   ├── stream_core/          # LLC — pure Dart transport layer
 │   └── stream_core_flutter/  # Flutter UI + design system
 ├── apps/
 │   └── design_system_gallery/  # Widgetbook-based interactive showcase
@@ -1117,14 +1085,11 @@ Padding(padding: EdgeInsets.all(8));   // avoid — reads as int
 
 ### Component structure
 
-Components live under `packages/stream_core_flutter/lib/src/components/<category>/`.
-Current categories: `accessories/`, `avatar/`, `badge/`, `buttons/`, `common/`,
-`context_menu/`, `controls/`, `emoji/`, `list/`, `media_viewer/`, `message/`,
-`message_composer/`, `message_layout/`, `reaction/`, `sheet/`, `snackbar/`,
-`toolbar/`. Add a new category directory when a component doesn't fit an existing
+Components live under `lib/src/components/<category>/`, one directory per
+category. Add a new category directory when a component doesn't fit an existing
 one.
 
-Each component ships with:
+Each new component ships with:
 
 - **Widget file** — under `lib/src/components/<category>/<name>.dart`.
 - **Theme file** — under `lib/src/theme/components/<name>_theme.dart`. See
@@ -1139,13 +1104,27 @@ Each component ships with:
   add more.
 - **Widget or unit tests** — under `test/components/<category>/<name>_test.dart`.
   Golden variants use the `_golden_test.dart` suffix (e.g.
-  `stream_button_golden_test.dart`, `stream_button_test.dart`). See
-  [Golden tests](#golden-tests).
+  `stream_button_golden_test.dart`, `stream_button_test.dart`). Every visible
+  component needs a golden test covering the default state and the primary theme
+  variants. See [Golden tests](#golden-tests).
 - **Widgetbook use-case** — under
-  `apps/design_system_gallery/lib/components/<category>/`.
+  `apps/design_system_gallery/lib/components/<category>/`, exercising every
+  meaningful prop combination.
 - **Barrel export** — an `export '…';` line added to `core.dart` or `chat.dart`.
 
-Missing any of the four is a review-blocker.
+The widget itself should:
+
+- Accept `Key? key` in its constructor via `super.key`
+  (`use_key_in_widget_constructors`, `use_super_parameters`).
+- Support accessibility on both Android (TalkBack) and iOS (VoiceOver). A
+  `Tooltip` is usually sufficient as the accessible label.
+- Support both LTR and RTL layouts.
+- Support text scaling.
+- Have documentation for every public member.
+
+Some earlier components predate parts of this checklist. When you touch such a
+component for a substantive change, try to close the gap in the same PR — but
+don't block landing a fix on backfilling years of missing coverage.
 
 ### Theme system
 
@@ -1210,18 +1189,14 @@ into Material's `ThemeData.extensions`. New component themes follow the
 
 ### Component factory
 
-The design system uses `StreamComponentFactory` to let consumers substitute
-individual components without forking. When adding a new component that has a
-default implementation, register a factory hook so consumers can override it.
+The design system exposes `StreamComponentFactory` so consumers can substitute
+individual components without forking. When adding a component with a default
+implementation, register a factory hook: add a nullable builder field on the
+factory class, wire it through `copyWith` and the default fallback, and consume
+it in the component's `build` with the standard null-coalescing chain.
 
-Reference pattern: see how `StreamMessageBubble` resolves its default builder via
-`StreamComponentFactory.of(context).messageBubble` in
-`packages/stream_core_flutter/lib/src/components/message/stream_message_bubble.dart`.
-The factory class itself lives at
-`packages/stream_core_flutter/lib/src/factory/stream_component_factory.dart` —
-add a nullable builder field there, wire it up through the factory's `copyWith`
-and default fallback, and consume it in the component's `build` with the standard
-null-coalescing chain.
+Look at any existing component that goes through the factory for the reference
+shape.
 
 ### Icons
 
@@ -1239,27 +1214,6 @@ When adding or updating icons:
    they must stay in sync.
 
 Do not edit the generated `StreamIcons.dart` or the icon font by hand.
-
-### Widget essentials
-
-Every **new** public widget in `stream_core_flutter` should:
-
-- Accept `Key? key` in its constructor via `super.key`
-  (`use_key_in_widget_constructors`, `use_super_parameters`).
-- Support accessibility on both Android (TalkBack) and iOS (VoiceOver). A `Tooltip`
-  is usually sufficient as the accessible label.
-- Support both LTR and RTL layouts.
-- Support text scaling.
-- Have documentation for every public member.
-- Have a golden test covering the default state and the primary theme variants.
-- Have a Widgetbook use-case that lets a designer or reviewer interact with all
-  props.
-
-Some earlier components predate parts of this checklist (e.g. missing widget tests
-or Widgetbook use-cases). When you touch such a component for a substantive change,
-try to close the gap in the same PR — but don't block landing a fix on backfilling
-years of missing coverage.
-
 
 ## Commits, PRs, and changelogs
 
@@ -1322,9 +1276,8 @@ X.Y.Z") is handled by the release tooling — do not write these entries by hand
 - **Melos commands**: `melos.yaml` — every task the repo runs.
 - **Design source**: the Chat SDK Design System Figma project — accessed via the
   Figma MCP when implementing UI.
-- **Design tokens**: `packages/stream_core_flutter/lib/src/theme/primitives/internal/tokens/`
-  and the [design-system-tokens](https://github.com/GetStream/design-system-tokens)
-  sibling repo.
+- **Design tokens**: the [design-system-tokens](https://github.com/GetStream/design-system-tokens)
+  sibling repo (mirrored internally in the theme primitives).
 
 When something isn't covered here and isn't obvious from surrounding code, prefer
 to ask in the PR rather than guessing. If a convention isn't documented, propose

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -845,19 +845,23 @@ There are three layers of reactive state in this repo, each with its own primiti
 **1. Product-SDK state → `StateNotifier` (from `package:state_notifier`) — the
 going-forward pattern for new code.**
 
-Product SDKs built on top of `stream_core` (chat, feeds, video, …) manage state
-via `StateNotifier<State>` with an immutable `@freezed` `State` class. The
-reference implementation is stream-feeds-flutter — see its
-[`AGENTS.md`](https://github.com/GetStream/stream-feeds-flutter/blob/main/AGENTS.md)
-for the full pattern (Client → Repository → StateNotifier → public State object).
+Product SDKs built on top of `stream_core` manage state via
+`StateNotifier<State>` with an immutable `@freezed` `State` class. The public
+surface is a high-level state object that wraps the notifier; the notifier
+itself is internal.
+
 Key rules for new state code:
 
 - `*State` classes use `@freezed` with const constructors and Freezed 3.0
   mixed-mode syntax (`@override` on fields).
 - `*StateNotifier` implementations extend `StateNotifier<*State>` and are an
-  **internal** implementation detail — never exposed on the public API.
-- The public surface is the high-level state object (e.g. `Feed`, `ActivityList`)
-  that wraps the notifier.
+  **internal** implementation detail (`lib/src/`) — never exposed on the public
+  API.
+- The public surface is the high-level state object that wraps the notifier;
+  callers hold a reference to that object and read its state.
+
+See [Product-SDK architecture](#product-sdk-architecture) below for the full
+layering that surrounds `StateNotifier`.
 
 **2. Transport-layer state → existing emitters in `stream_core/lib/src/utils/`.**
 
@@ -911,12 +915,10 @@ Rules:
   `switch` (exhaustive) over `isSuccess`/`isFailure` when acting on the outcome
   in code you control.
 
-### Reference architecture: stream-feeds-flutter
+### Product-SDK architecture
 
 For new product-SDK code built on top of `stream_core` — a client that fetches
-data, hosts state, and exposes it to UI — mirror the layered architecture
-documented in
-[stream-feeds-flutter's AGENTS.md](https://github.com/GetStream/stream-feeds-flutter/blob/main/AGENTS.md):
+data, hosts state, and exposes it to UI — use this layered architecture:
 
 ```text
 Client                    # public API entry point (thin factory)
@@ -925,12 +927,19 @@ Client                    # public API entry point (thin factory)
           └── State       # public @freezed value; what the UI renders
 ```
 
-- Client and State/high-level state objects (`Feed`, `ActivityList`, …) are
-  public. Repository and StateNotifier are internal (`lib/src/`).
-- All Repository methods return `Result<T>` — no thrown exceptions.
-- Models under `src/models/` are `@freezed` (mixed-mode 3.0 with `@override`),
-  named `*Data`. Queries: `*Query`. Requests: `*Request`.
-- Tests go against the public API only — see [Testing](#testing) below.
+- **Public API**: the `Client` + high-level state objects (the wrappers around
+  `StateNotifier`, exposed as classes like `Feed`, `ActivityList`, or whatever
+  the domain calls for). Both live at the top of `lib/`.
+- **Internal**: `Repository` and `*StateNotifier` implementations live under
+  `lib/src/`.
+- **All Repository methods return `Future<Result<T>>`** — no thrown exceptions
+  crossing the SDK boundary.
+- **Models** live under `src/models/`, are `@freezed` (mixed-mode 3.0 with
+  `@override` on fields), and follow naming conventions:
+  - `*Data` — domain models (e.g. `MessageData`, `UserData`).
+  - `*Query` — query descriptors (e.g. `MessagesQuery`).
+  - `*Request` — HTTP request payloads (e.g. `SendMessageRequest`).
+- **Tests** exercise the public API only — see [Testing](#testing) below.
 
 
 ## Testing
@@ -939,16 +948,16 @@ This section covers repo-level testing conventions. For guidance on **how to wri
 good tests** — naming, factoring, one behavior per test — see
 [`TESTING.md`](TESTING.md).
 
-**For product-SDK tests built on top of `stream_core`** (chat, feeds, video), test
-exclusively through the public API. The reference is
-[stream-feeds-flutter's AGENTS.md](https://github.com/GetStream/stream-feeds-flutter/blob/main/AGENTS.md):
+**For product-SDK tests built on top of `stream_core`**, test exclusively through
+the public API:
 
 - **Never test internal implementation directly** — no `.toModel()` mapper
   invocations, no `*Repository` instantiations, no `*StateNotifier` instantiations
   in tests. If a consuming app cannot call it, the test cannot either.
-- **Test via typed test helpers** (`feedsClientTest`, `feedTest`, and analogues
-  for other product SDKs). These wire up a real client against a mocked HTTP API
-  and expose `mockApi(...)` / `verifyApi(...)` / `emitEvent(...)`.
+- **Prefer typed test helpers** (`<Product>ClientTest`, `<Product>Test`) that
+  wire up a real client against a mocked HTTP API and expose `mockApi(...)` /
+  `verifyApi(...)` / `emitEvent(...)`. Each product SDK ships its own such
+  helper package alongside its tests.
 - **Mock exact requests, not `any()`** — passing the concrete expected request
   object simultaneously stubs the response and validates what the SDK sent. Using
   `any()` matchers hides bugs where the SDK sends the wrong payload.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -818,8 +818,6 @@ disadvantages that make them awkward inside widget code:
   or single-client, paused and resumed. Determining the right semantics for a
   particular stream when it's used in all the ways widget code could use it is
   non-trivial.
-- Streams don't have a "current value" accessor, which makes them difficult to
-  use in `build` methods.
 - The APIs for manipulating streams are non-trivial (e.g. transformers).
 
 This matches Flutter's own guidance inside the framework.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -643,27 +643,28 @@ groups (`directives_ordering`).
 
 ### Guidelines for `extension`s
 
-Extension methods are resolved statically and cannot be overridden; misuse
-pollutes IDE suggestions and causes naming collisions. Reach for one only when
-a regular method or helper function won't do.
-
-`stream_core/lib/src/utils/` is an intentional standard-library-style layer,
-exported from `stream_core.dart` and used across 100+ call sites: `Standard on T`
-(Kotlin scope funcs `let`/`also`/`apply`/`takeIf`), `ComparableExtension`,
-`IterableExtensions`, `ListExtensions`, `SortedListExtensions`. Use these
-freely. **New utility extensions belong here** — don't scatter them across
+New utility extensions on common types (`on T extends Object`, `on Iterable`,
+`on List`, `on Comparable`, `on num`) belong in `stream_core/lib/src/utils/`.
+That layer is exported from `stream_core.dart` and used in 100+ call sites:
+`Standard` (Kotlin scope funcs `let`/`also`/`apply`/`takeIf`),
+`ComparableExtension`, `IterableExtensions`, `ListExtensions`,
+`SortedListExtensions`. Add to it rather than scattering new extensions across
 feature code.
 
-Accepted extension targets outside `utils/`:
+Extensions outside `utils/` are fine on:
 
-- Domain types (`AttachmentFile`, `DioException`, `RetryStrategy`).
-- `BuildContext` for scoped lookups — e.g. `context.streamTheme`.
-- Units-of-measure on primitives when small and unambiguous — e.g.
-  `DistanceExtension on num` next to `Distance` (`5.kilometers`).
+- Domain types — `AttachmentFile`, `DioException`, `RetryStrategy`, etc.
+- `BuildContext`, for scoped lookups (`context.streamTheme`).
+- Primitives, for units-of-measure — `5.kilometers` via `DistanceExtension on num`.
+  Keep them small and colocated with the value type.
 
-Outside these patterns, avoid public extensions on `Object`, `Object?`,
-`Future<T>`, `String`, `Map<K, V>` — they show up on every value of that type
-in every importing file.
+Avoid public extensions on `Object`, `Object?`, `Future<T>`, `String`,
+`Map<K, V>` outside these patterns — they land on every value of that type in
+every file that imports the package.
+
+Extension methods are resolved statically and can't be overridden; if a caller
+might want to substitute the behaviour, expose an instance method or callback
+instead.
 
 ### Avoid `FutureOr<T>` in public APIs
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,1299 @@
+# Style guide for stream-core-flutter
+
+This style guide is adapted from the [Flutter repository's style guide](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md).
+Where our conventions differ, the divergence is called out inline so readers understand
+the choice was deliberate.
+
+The primary audience is contributors (human and AI) working inside this monorepo. If
+you are integrating the design system into your own app, follow whatever style your app
+uses — this guide is not meant to constrain consumers.
+
+## Summary
+
+Optimize for readability. Split the public API cleanly between `core.dart` and
+`chat.dart`. Use relative imports inside `lib/src/`. Every component ships with a
+theme, a golden test, and a Widgetbook use-case. Update the affected package's
+`CHANGELOG.md` in the same PR.
+
+## Introduction
+
+This document describes high-level philosophy, policy decisions, and specific style
+rules for the code in this monorepo. It applies to the two SDK packages (`stream_core`,
+`stream_core_flutter`) and the Widgetbook gallery under `apps/design_system_gallery/`.
+
+The linter here opts into **all** of Dart's lints via `all_lint_rules.yaml`, then
+selectively disables those that don't fit; the analyzer is the source of truth for
+what compiles cleanly. This guide covers the human conventions above and around the
+linter.
+
+Sections below cover:
+
+- [Quick rules](#quick-rules) — the short checklist to skim before every change
+- [Philosophy](#philosophy) — the "why" behind the rules
+- [Repository structure](#repository-structure) — monorepo layout, Melos, barrel contract
+- [Documentation](#documentation) — dartdoc conventions
+- [Coding patterns](#coding-patterns) — asserts, dispose, equality, streams, etc.
+- [Testing](#testing) — unit, widget, and golden tests
+- [Naming](#naming) — identifiers, callbacks, booleans
+- [Comments](#comments) — when to write them, when not to
+- [Formatting](#formatting) — line length, class ordering
+- [Widgets, themes, and design system](#widgets-themes-and-design-system) — components,
+  theme hierarchy, Widgetbook, icons
+- [Commits, PRs, and changelogs](#commits-prs-and-changelogs)
+
+
+## Quick rules
+
+The hard rules to check before opening a PR. Every rule below is expanded later in the
+document; the section link is provided.
+
+**Public API and package boundaries**
+
+- Every new public file under `lib/src/` must be exported from exactly one of
+  `core.dart` or `chat.dart`. `melos run check:barrels` enforces this and fails PR
+  builds. → [Public barrel contract](#public-barrel-contract)
+- No file under `lib/src/` may import a public barrel (`core.dart`, `chat.dart`,
+  `stream_core_flutter.dart`). Use a relative import to the source file. →
+  [Public barrel contract](#public-barrel-contract)
+- `stream_core` (the pure-Dart LLC) never depends on Flutter. Anything visual or
+  widget-related belongs in `stream_core_flutter`.
+
+**Code**
+
+- Line width: **120 characters** (configured in `analysis_options.yaml`). Comments
+  and docs follow the same limit.
+- Single quotes, **relative imports inside `lib/src/`** (`always_use_package_imports`
+  is disabled here — a deliberate divergence from Flutter's style, favouring
+  refactor-friendly relative paths inside the package).
+- Trailing commas preserved, `const` wherever possible, `final` for locals that
+  aren't reassigned.
+- Prefer named parameters for booleans (`avoid_positional_boolean_parameters`).
+- File names are `snake_case.dart` (`file_names`). Imports follow the standard order:
+  `dart:` → `package:` → relative — one blank line between groups
+  (`directives_ordering`).
+
+**Design system**
+
+- Every new component ships with:
+  1. A widget file under `lib/src/components/<category>/`.
+  2. A `<Widget>Theme` + `<Widget>ThemeData` in `lib/src/theme/components/`,
+     annotated with `@themeGen`. → [Theme system](#theme-system)
+  3. A golden test in `test/components/<name>/`.
+  4. A Widgetbook use-case in `apps/design_system_gallery/`.
+- Defaults live in the widget implementation (nullable theme fields, null-coalescing
+  chain in `build`) — mirrors Flutter's own `AppBar`/`TabBar` pattern.
+- Never hand-roll `copyWith`, `merge`, `lerp`, `==`, or `hashCode` on theme classes —
+  the generator produces them. → [Theme system](#theme-system)
+- Icons are generated from SVGs. Do not hand-edit the icon font or the generated
+  `StreamIcons` class. → [Icons](#icons)
+
+**Docs and comments**
+
+- Public dartdoc describes the observable contract, not the implementation. Skip
+  mentions of `BehaviorSubject`, "unmodifiable", "Stream emits X", or which internal
+  type is used. → [Public docs describe the contract, not implementation](#public-docs-describe-the-contract-not-implementation)
+- `_`-prefixed members receive `//` block comments, not `///` dartdoc.
+- Default to zero inline `//` comments in implementation. Prefer well-named locals
+  and early returns over comments explaining what code does.
+- `// ignore: ...` directives do not require an explanatory comment. This is the
+  repo style, not the Flutter convention.
+
+**Process**
+
+- Update the affected package's `CHANGELOG.md` under the `Upcoming` heading with
+  labels like `### ✨ Features`, `### 🐛 Bug Fixes`, `### 🛑 Breaking / Removals`.
+  → [Changelog policy](#changelog-policy)
+- PR titles follow [Conventional Commits](https://www.conventionalcommits.org/):
+  `fix(scope): …`, `feat(scope): …`, `refactor(scope)!: …` for breaking changes.
+
+
+## A word on designing APIs
+
+Designing an API is an art. Like all forms of art, one learns by practicing. In the
+absence of one's own experience, one can attempt to rely on the experience of others.
+When receiving feedback about API design from an experienced API designer, they will
+sometimes seem unhappy without being able to articulate why. When this happens,
+seriously consider that your API should be scrapped and a new solution found.
+
+This requires a different and equally important skill: not getting attached to your
+creations. Try many wildly different APIs, then write code that uses them. Throw away
+APIs that feel frustrating or lead to buggy code.
+
+An SDK API is for years, not just for the one PR you are working on. A design system
+is even worse — every widget lands in downstream apps, and each field of each theme
+becomes a compat constraint. A signature committed today is one we have to keep
+supporting until we ship a major version bump.
+
+
+## Philosophy
+
+### Lazy programming
+
+Write what you need and no more, but when you write it, do it right.
+
+Avoid implementing features you don't need. You can't design a feature without knowing
+what the constraints are. Implementing features "for completeness" results in unused
+code that is expensive to maintain, learn about, document, test, etc.
+
+Avoid workarounds. Workarounds merely kick the problem further down the road, but at
+a higher cost. Take the time to fix a problem properly rather than being the one who
+fixes everything quickly but leaves cleanup for later.
+
+### Write Test, Find Bug
+
+When you fix a bug, first write a test that fails, then fix the bug and verify the
+test passes.
+
+When you implement a new component or feature, write tests for it (widget tests and
+golden tests for visible components). If something isn't tested, it is very likely to
+regress or get "optimized away" during a refactor.
+
+Don't submit code with the promise to "write tests later".
+
+### Avoid duplicating state
+
+There should be no objects that represent live state that reflect some state from
+another source, since they are expensive to maintain. **Keep only one source of
+truth**, and **don't replicate live state**.
+
+Concretely for this repo: theme values flow one direction (theme data → widget
+`build`); widgets don't cache computed theme values. `ChangeNotifier`-driven state
+(controllers) is the source of truth; snapshots in local `State` are stale by design.
+
+### Getters feel faster than methods
+
+Property getters should be efficient (e.g. returning a cached value or an O(1) table
+lookup). If an operation is inefficient, it should be a method instead.
+
+Similarly, a getter that returns a `Future` or `Stream` should not kick off the work
+represented by the future. The work should be started from a method or constructor,
+and the getter should return the preexisting future or stream.
+
+### No synchronous slow work
+
+There should be no public APIs that require synchronously completing an expensive
+operation (e.g. blocking on a network call). Expensive work should be asynchronous
+and the type signature (`Future`, `Stream`) should show it.
+
+### Layers
+
+The SDK is two-package layered:
+
+```text
+stream_core            # Pure Dart — WebSocket (RxDart), HTTP (Dio), models
+  └── stream_core_flutter  # Flutter UI primitives + design system
+```
+
+Convenience APIs belong at the layer above the one they are simplifying. Do not push
+a "convenience" API down a layer just to have it available to lower layers — that
+pulls higher-level concepts into places they don't belong.
+
+`stream_core_flutter` further splits its public API through two barrels: `core.dart`
+(cross-product primitives) and `chat.dart` (chat-domain widgets). See
+[Public barrel contract](#public-barrel-contract).
+
+### Avoid interleaving multiple concepts together
+
+Each API should be self-contained and should not know about other features.
+Interleaving concepts leads to complexity.
+
+- Widgets that take a `child` should be entirely agnostic about the type of that
+  child. Don't use `is` checks to act differently based on the type of the child.
+- Prefer immutable data models. `Message`, `User`, and friends are immutable. Themes
+  are immutable. Callers get a new instance from `copyWith`, never mutation.
+
+### Avoid secret (or global) state
+
+A function should operate only on its arguments and, if it is an instance method,
+data stored on its object. Global state makes code hard to test, hard to reason
+about, and hard to reuse.
+
+Theme values are threaded through `StreamTheme.of(context)` — an
+`ThemeExtension` lookup that resolves to a concrete `StreamTheme`. We do
+not have singletons for theme, colors, or design tokens.
+
+### Prefer general APIs, but use dedicated APIs where there is a reason
+
+Having dedicated APIs for performance reasons is fine. If one specific operation is
+expensive using the general API but could be implemented more efficiently using a
+dedicated API, that is where a dedicated API belongs.
+
+### Avoid APIs that encourage bad practices
+
+Don't provide APIs that walk entire trees, or that encourage O(N²) algorithms, or
+that encourage sequential long-lived operations where the operations could be run
+concurrently. Similarly, if an operation is expensive, that expense should be
+represented in the API (e.g. by returning a `Future` or a `Stream`).
+
+### Avoid heuristics and magic
+
+Predictable APIs that give the developer control are generally preferred over APIs
+that mostly do the right thing but don't give the developer any way to adjust the
+results. Predictability is reassuring.
+
+### Solve real problems by literally solving a real problem
+
+Where possible, partner with a real customer (an internal Stream product team or an
+external integrator) who wants the feature and is willing to help you test it. Only
+by actually using a feature in the real world can we be confident it is ready.
+
+### Start designing APIs from the closest point to the developer
+
+When we create a new feature that requires a change across the stack, it's tempting
+to design the lowest-level API first, since that's the closest to the "interesting"
+code. Design the top-level API first — the widget or theme field a caller will
+touch — then work down to the primitives.
+
+### Only log actionable messages to the console
+
+If the logs contain messages users can safely ignore, they will do so, and eventually
+their logs will be so chatty they'll miss the critical messages. Only log actual
+errors and actionable warnings.
+
+Use `Logger` from `stream_core/src/logger/` at an appropriate level. `avoid_print` is
+disabled repo-wide (`analysis_options.yaml`) but that's a temporary allowance — in
+`stream_core_flutter`, prefer `debugPrint` (which respects the framework's rate
+limiter) over raw `print`.
+
+### Error messages should be useful
+
+Every time you find the need to report an error, consider how you can make this the
+most useful and helpful error message. Put yourself in the shoes of whoever sees it.
+**Every error message is an opportunity to make someone love our product.**
+
+
+## Policies
+
+### Workarounds
+
+Temporary workarounds (`// ignore` hacks, monkey-patches of upstream APIs) should be
+documented with a link to the tracking issue and a plan for removing them. Long-term
+workarounds should be turned into proper fixes.
+
+### Avoid abandonware
+
+Code that is no longer maintained should be deleted, not commented out. Commented-out
+code bitrots quickly and will confuse people maintaining the code.
+
+If a component is being deprecated, follow the deprecation policy: annotate with
+`@Deprecated('Use X instead.')`, add a `### 🛑 Breaking / Removals` CHANGELOG entry,
+and keep the deprecated API for at least one minor release before removal.
+
+### Copyright and licensing
+
+New source files should carry the standard header used elsewhere in the repo.
+Third-party code must live in a `third_party/` subdirectory of the package with a
+`LICENSE` file that describes the license and a `README` describing its provenance.
+
+
+## Repository structure
+
+### Monorepo layout
+
+```text
+stream-core-flutter/
+├── melos.yaml                # Workspace + centralized dependencies
+├── analysis_options.yaml     # Delegates to all_lint_rules.yaml + selective disables
+├── all_lint_rules.yaml       # Opt-in-all Dart lint set
+├── STYLE_GUIDE.md            # This file
+├── CLAUDE.md                 # AI-agent pointer to this guide + repo overview
+├── packages/
+│   ├── stream_core/          # LLC — pure Dart (RxDart WebSocket, Dio HTTP)
+│   └── stream_core_flutter/  # Flutter UI + design system
+├── apps/
+│   └── design_system_gallery/  # Widgetbook-based interactive showcase
+└── scripts/                  # Repo-level helpers
+```
+
+### Public barrel contract
+
+`stream_core_flutter` exposes two narrow public barrels so non-chat Stream SDKs
+(video, feeds, ...) can pull in just the shared primitives without paying for chat
+code:
+
+- `package:stream_core_flutter/core.dart` — shared UI primitives, theme tokens, the
+  component factory. Safe for any Stream SDK.
+- `package:stream_core_flutter/chat.dart` — chat-specific widgets (message bubble,
+  composer attachments, reactions, …). Chat SDKs import this **alongside**
+  `core.dart`.
+- `package:stream_core_flutter/stream_core_flutter.dart` — deprecated convenience
+  barrel that re-exports both. Will be removed at 1.0.0.
+
+Rules enforced by `melos run check:barrels` (config at
+`packages/stream_core_flutter/check_barrels.yaml`, wired into CI):
+
+1. Every public file under `lib/src/` must appear in exactly **one** barrel. No
+   duplicates, no orphans, no dangling exports.
+2. No file under `lib/src/` may import a public barrel (`core.dart`, `chat.dart`,
+   `stream_core_flutter.dart`). Use a relative import to the source file — barrels
+   are for **consumers**, not internal code.
+3. Anything under an `internal/` directory listed in `check_barrels.yaml`'s
+   `internal_dirs` is excluded from coverage. Use this for figma-generated tokens
+   and other implementation-only artefacts.
+
+When adding a new public widget or theme: create the file under `lib/src/…`, then
+add an `export 'src/…/my_file.dart';` line to either `core.dart` or `chat.dart`. The
+check fails on PR if you forget.
+
+### Dependency management
+
+Dependencies for all packages are centrally managed in `melos.yaml` under
+`command.bootstrap.dependencies`. Do **not** edit version constraints directly in an
+individual package's `pubspec.yaml` — update `melos.yaml` and run `melos bootstrap`.
+
+When you add a new dependency:
+
+1. Add it to `melos.yaml` under `command.bootstrap.dependencies` (or
+   `dev_dependencies`).
+2. Add the bare package name to the affected `pubspec.yaml` files.
+3. Run `melos bootstrap`.
+
+### Generated code
+
+Generated files (`*.g.dart`, `*.freezed.dart`, `*.g.theme.dart`) are excluded from
+analysis (`packages/*/lib/**/*.*.dart` in `analysis_options.yaml`). Do not edit them
+by hand. If a generated file is stale, run:
+
+```bash
+melos run generate:all
+```
+
+Sub-tasks:
+
+- `melos run generate:icons` — regenerates the icon font from SVGs in
+  `assets_source/icons/`. → [Icons](#icons)
+- `melos run gen-l10n` — regenerates localization ARB output.
+
+
+## Documentation
+
+Public dartdocs are encouraged but currently **not lint-enforced**
+(`public_member_api_docs` is disabled in `analysis_options.yaml`; this is temporary
+while the repo catches up). New public code should still ship with dartdocs.
+
+In general, follow the [Effective Dart documentation guide](https://dart.dev/effective-dart/documentation)
+except where this page contradicts it.
+
+### Answer your own questions straight away
+
+When working on the SDK, if you find yourself asking a question about our systems,
+place the answer into the documentation where you first looked. That way, the docs
+consist of answers to real questions, in the places where people would look to find
+them.
+
+### Avoid useless documentation
+
+If someone could have written the same documentation without knowing anything about
+the class other than its name, then it's useless.
+
+```dart
+// BAD:
+/// The size.
+final StreamAvatarSize size;
+
+// GOOD:
+/// The diameter of the avatar in logical pixels.
+///
+/// Defaults to [StreamAvatarSize.md] (32px). Use a preset like
+/// [StreamAvatarSize.sm] rather than a raw pixel value to stay aligned with the
+/// design system.
+final StreamAvatarSize size;
+```
+
+### Public docs describe the contract, not implementation
+
+Dartdoc describes the observable behavior of an API, not how it happens to be
+implemented today. Skip mentions of:
+
+- Specific implementation types the caller doesn't see (e.g. `BehaviorSubject`,
+  `UnmodifiableListView`)
+- Internal caching strategies unless the caller's code needs to know
+- "Stream emits X" style — describe what values are produced and when, not the
+  stream mechanics
+
+**Exception:** public base classes and mixins in the type signature (e.g.
+`extends ValueNotifier<T>`, `with ChangeNotifier`) are part of the contract, not a
+leak. Mentioning them helps callers reach for `ValueListenableBuilder`.
+
+### No Flutter internals in comments
+
+Do not justify code by cross-referencing Flutter framework internals ("matching
+Flutter's `AppBar`", "same behavior as `MaterialButton`"). Describe what the code
+does directly. This applies even here, where we deliberately follow Flutter's
+`AppBar`/`TabBar` pattern for defaults — say "defaults live in the widget's build,
+not the theme data" without name-dropping.
+
+### Writing prompts for good documentation
+
+If you're stuck coming up with useful documentation, some prompts:
+
+- If someone is looking at this documentation, they have a question they couldn't
+  answer by guessing or reading the code. What could that question be?
+- What might a caller want to know that isn't obvious from the type?
+- Are there edge cases outside the normal range (negative numbers, empty lists,
+  `null`, `disabled`, `loading`)?
+- Does this member interact with any others?
+- Are there lifecycle considerations? Who owns the object? Who calls `dispose`?
+
+### Avoid empty prose
+
+```dart
+// BAD:
+/// Note: It is important to be aware of the fact that in the absence of an
+/// explicit value, this property defaults to 2.
+
+// GOOD:
+/// Defaults to 2.
+```
+
+Do not start sentences with "Note:" or "Note that". It adds nothing.
+
+### Leave breadcrumbs in the comments
+
+If a class is typically obtained via some mechanism other than its constructor,
+mention that in the class documentation.
+
+Use `See also:` to link to related APIs:
+
+```dart
+/// See also:
+///
+///  * [StreamAvatar], which uses these size variants.
+///  * [StreamAvatarThemeData.size], for setting a global default size.
+```
+
+Each `See also:` line ends with a period. Prefer "which…" over parenthetical
+descriptions.
+
+### Refactor the code when the documentation would be incomprehensible
+
+If writing the documentation proves difficult because the API is convoluted, rewrite
+the API rather than trying to document it.
+
+### Use correct grammar
+
+Avoid starting a sentence with a lowercase letter. End all sentences with a period.
+
+```dart
+// BAD:
+/// [foo] must not be null.
+
+// GOOD:
+/// The [foo] argument must not be null.
+```
+
+### Use the passive voice; recommend, do not require
+
+Avoid "you" and "we". Rather than telling someone to do something, use "Consider",
+as in "To obtain the foo, consider using [bar]."
+
+Never use "simply", or say the reader need "just" do something.
+
+### Private members use `//`, not `///`
+
+`_`-prefixed members receive `//` block comments, not `///` dartdoc. Dartdoc
+machinery (cross-references, IDE hover from outside the library) buys nothing for
+library-private surfaces, and using `///` on private members makes the tooling
+suggest they should be public.
+
+```dart
+// GOOD (private member):
+// Cached because computing the mask involves iterating every pixel.
+Path? _cachedClipMask;
+
+// GOOD (public member):
+/// The diameter of the avatar in logical pixels.
+final double size;
+```
+
+### Provide sample code
+
+Include a short `dart` code block in the dartdoc for widgets and complex APIs.
+Longer, runnable examples belong in `apps/design_system_gallery/` (Widgetbook).
+
+Do not use `{@tool dartpad}` — we don't have infrastructure to render it.
+
+### Clearly mark deprecated APIs
+
+Use `@Deprecated('Use X instead.')`. Add a `CHANGELOG.md` entry under
+`### 🛑 Breaking / Removals` describing the deprecation and pointing at the
+replacement.
+
+### Dartdoc-specific requirements
+
+The first paragraph of any dartdoc section must be a short, self-contained sentence
+explaining the purpose of the item. Subsequent paragraphs elaborate. Avoid multi-
+sentence first paragraphs — the first paragraph gets extracted for tables of
+contents.
+
+When referencing a parameter, use backticks. When referencing a parameter that also
+corresponds to a property, use square brackets instead.
+
+Avoid using "above" or "below" to reference other dartdoc sections. Dartdoc pages
+are often viewed in isolation.
+
+
+## Coding patterns
+
+The linter enforces most of the rules in this section — see
+[`analysis_options.yaml`](analysis_options.yaml) (which delegates to
+[`all_lint_rules.yaml`](all_lint_rules.yaml)) for the authoritative list. Rules
+highlighted below either extend a lint (adding rationale or a repo-specific pattern)
+or capture conventions the linter can't check.
+
+### Use asserts liberally to detect contract violations
+
+`assert()` lets us verify invariants without paying a cost in release mode, because
+Dart only evaluates asserts in debug mode.
+
+Use asserts for conditions that should be impossible unless there is a bug. Do not
+use asserts to validate user input or network data (those must throw at runtime).
+
+Assert messages are **not required** in this repo (`prefer_asserts_with_message` is
+disabled). Add a message when the invariant isn't self-evident from the expression;
+otherwise a bare `assert(condition)` is fine.
+
+```dart
+// Fine — the expression is self-explanatory.
+assert(size > 0);
+
+// Better with a message — the invariant needs context.
+assert(!_disposed, 'StreamAvatarController used after dispose()');
+```
+
+### Prefer specialized functions, methods, and constructors
+
+Use the most relevant constructor when there are multiple options.
+
+```dart
+// BAD:
+const EdgeInsets.fromLTRB(0.0, 8.0, 0.0, 8.0);
+
+// GOOD:
+const EdgeInsets.symmetric(vertical: 8.0);
+```
+
+### Minimize the visibility scope of constants
+
+Prefer a local `const` or a `static const` in a relevant class over a global
+constant. Global constants that _do_ need to exist should be prefixed with `k`.
+
+### Avoid `if` chains or `?:` with enum values
+
+Use `switch` (statement or expression) with exhaustive cases when examining an enum;
+the analyzer will warn if you miss a value. Avoid `default:` unless the switched
+value isn't statically known — a default clause silences the exhaustiveness check.
+
+```dart
+// GOOD:
+final radius = switch (size) {
+  StreamAvatarSize.xs => 10.0,
+  StreamAvatarSize.sm => 12.0,
+  StreamAvatarSize.md => 16.0,
+  StreamAvatarSize.lg => 20.0,
+  StreamAvatarSize.xl => 24.0,
+  StreamAvatarSize.xxl => 40.0,
+};
+```
+
+### Prefer explicit types on public APIs, avoid `dynamic`
+
+The analyzer runs with `strict-inference: true` and `strict-raw-types: true`.
+Combined with the linter, this means:
+
+- All public API members should have explicit type annotations — parameters, fields,
+  and return types (`always_declare_return_types`, `type_annotate_public_apis`).
+- Raw types (`List`, `Map`, `Future` without a type argument) are flagged; declare
+  the element type.
+- Avoid `dynamic`. If the type is unknown, prefer `Object?` and casting; `dynamic`
+  disables all static checking.
+
+For local variables, follow the `omit_local_variable_types` lint — omit the
+annotation when the type is obvious from the initializer, but keep it when it isn't.
+
+### Import conventions inside the package
+
+Inside `packages/<pkg>/lib/src/`, use **relative imports**
+(`always_use_package_imports` is disabled here — a deliberate divergence from
+Flutter's style guide, matching Dart's Effective Dart recommendation for
+package-internal code).
+
+```dart
+// GOOD — relative for in-package files.
+import '../../theme/components/stream_avatar_theme.dart';
+import '../common/stream_network_image.dart';
+
+// GOOD — package: for external and cross-package imports.
+import 'package:flutter/material.dart';
+import 'package:stream_core/stream_core.dart';
+```
+
+Do not use `package:stream_core_flutter/...` inside `lib/src/` — that path is
+reserved for consumers, and using it internally would round-trip through the public
+barrel (which the `check:barrels` rule also forbids).
+
+Directive order: `dart:` → `package:` → relative, with one blank line between
+groups (`directives_ordering`).
+
+### Guidelines for `extension`s
+
+Extension methods let you add functionality to an existing type. Consider the
+trade-offs before reaching for one:
+
+- Extension methods are resolved statically and cannot be overridden.
+- Misusing extensions pollutes IDE suggestions and causes naming collisions.
+
+Rules:
+
+- Don't declare an extension method when a regular method or a helper function will
+  do.
+- Extensions on domain-typed collections (`Iterable<Message>`, `List<Attachment>`)
+  are fine — they only apply when the caller is already working with those types.
+- Avoid public extensions on unconstrained common types (`Object`, `Object?`,
+  `List<T>`, `Map<K, V>`, `Future<T>`, `String`, `int`) — those show up on every
+  value in every file that imports the package.
+
+### Avoid `FutureOr<T>` in public APIs
+
+`FutureOr` is a Dart-internal type used to explain aspects of the `Future` API.
+`avoid_futureor_void` is enabled here. In public APIs, avoid the temptation to
+create APIs that are both synchronous and asynchronous — it results in APIs that
+are less type-safe and harder to reason about.
+
+You may use `FutureOr` for callback parameters where the caller's callback may or
+may not be async.
+
+### Avoid `@visibleForTesting`
+
+The `@visibleForTesting` annotation marks a public API such that callers get a
+warning outside `test/` directories. The API is still public.
+
+Rather than rely on it, design APIs so they are testable through the public API
+without exposing sensitive internals. If a member is _only_ used for testing,
+prefix its name with `debug` or move it into the test file.
+
+### Never add timeouts, and avoid other race conditions
+
+If you look for an available port, then try to open it, several times a week some
+other code will open that port between your check and your open. Similarly, timeouts
+based on how long something "usually takes" will trigger spuriously.
+
+Race conditions are the primary cause of flaky tests. Avoid timeouts entirely. Wait
+for a triggering event.
+
+### Avoid magic numbers
+
+Numbers should be understandable. If the derivation isn't obvious, either restructure
+the expression to be self-describing or add a comment.
+
+```dart
+// BAD:
+final radius = 4.24264068712;
+
+// GOOD:
+final radius = 3.0 * math.sqrt(2);
+```
+
+### Perform dirty checks in setters
+
+When defining mutable properties that require notifying listeners on change:
+
+```dart
+StreamAvatarSize get size => _size;
+StreamAvatarSize _size;
+set size(StreamAvatarSize value) {
+  if (_size == value) {
+    return;
+  }
+  _size = value;
+  notifyListeners();
+}
+```
+
+Do not perform side effects in setters other than marking the object dirty and
+updating internal state.
+
+### Common boilerplates for `operator ==` and `hashCode`
+
+For value classes without generated equality, use:
+
+```dart
+@override
+bool operator ==(Object other) {
+  if (identical(other, this)) {
+    return true;
+  }
+  return other is Foo
+      && other.bar == bar
+      && other.baz == baz;
+}
+
+@override
+int get hashCode => Object.hash(bar, baz);
+```
+
+Themes get their `==`/`hashCode` from `theme_extensions_builder`; models often use
+`equatable`. Do not hand-roll equality when a generator or an `Equatable` base can
+do it.
+
+### Override `toString` on debuggable objects
+
+For classes that appear in error messages or logs, override `toString`. Avoid bare
+`$runtimeType` — use `objectRuntimeType(this, 'ClassName')`, which strips runtime
+type at release-mode.
+
+### Be explicit about `dispose()` and the object lifecycle
+
+If a class holds a `StreamSubscription`, a `Listenable` listener, a
+`ChangeNotifier`, or a persistent connection, provide a `dispose()` method and
+document who is responsible for calling it.
+
+The `close_sinks`, `cancel_subscriptions`, and
+`use_late_for_private_fields_and_variables` lints catch some cases; the rest is a
+review responsibility.
+
+### No InheritedWidget lookup in `initState`
+
+`InheritedWidget.of(context)` and `.maybeOf(context)` use
+`context.dependOnInheritedWidgetOfExactType`, which is forbidden inside `initState`.
+Move the lookup to `didChangeDependencies` (for lifecycle-scoped lookups) or
+`didUpdateWidget` (for reactions to prop changes). Reading the inherited widget in
+`initState` throws in debug mode and returns the wrong value in release mode.
+
+```dart
+// BAD:
+@override
+void initState() {
+  super.initState();
+  final theme = StreamTheme.of(context); // Throws in debug mode.
+}
+
+// GOOD:
+@override
+void didChangeDependencies() {
+  super.didChangeDependencies();
+  final theme = StreamTheme.of(context);
+}
+```
+
+### Prefer early returns
+
+Return inside each branch of a conditional rather than reassigning a shared variable
+that gets post-processed after the branches.
+
+```dart
+// BAD:
+Widget build(BuildContext context) {
+  Widget child;
+  if (isLoading) {
+    child = const CircularProgressIndicator();
+  } else if (hasError) {
+    child = const StreamErrorView();
+  } else {
+    child = _content();
+  }
+  return Padding(padding: const EdgeInsets.all(8), child: child);
+}
+
+// GOOD:
+Widget build(BuildContext context) {
+  const padding = EdgeInsets.all(8);
+  if (isLoading) return const Padding(padding: padding, child: CircularProgressIndicator());
+  if (hasError) return const Padding(padding: padding, child: StreamErrorView());
+  return Padding(padding: padding, child: _content());
+}
+```
+
+### Use streams for real-time data
+
+`stream_core` builds the transport layer for real-time products. `Stream` (via
+RxDart) is the primary reactive primitive for data that arrives asynchronously —
+WebSocket events, connection-state changes, backoff notifications. This
+intentionally diverges from Flutter's style guide, which recommends `Listenable`
+over `Stream` inside the framework.
+
+Rules of thumb for choosing between `Stream` and `Listenable`:
+
+- **`Stream`** — for data that originates outside the widget tree: WS events,
+  network responses, RxDart pipelines.
+- **`ValueNotifier` / `ChangeNotifier`** — for widget-owned reactive state:
+  animation-driven state, expanded/collapsed toggles, controller-adjacent state.
+
+Consuming streams in widgets:
+
+- Use `StreamBuilder` (or `initialData` on it) when a stream drives a widget subtree.
+- For pipelines that combine or transform streams, prefer RxDart operators over
+  hand-rolled `.listen()`+`Controller` plumbing.
+- Always cancel `StreamSubscription`s in `dispose()`.
+
+
+## Testing
+
+This section covers repo-level testing conventions. For guidance on **how to write
+good tests** — naming, factoring, one behavior per test — see
+[`TESTING.md`](TESTING.md).
+
+### Make each test entirely self-contained
+
+Embrace code duplication in tests. It makes it easier to create new tests by copying
+and tweaking existing ones.
+
+Avoid test-global variables or state shared between tests — they make maintenance,
+debugging, and refactoring significantly harder. Instead of `setUp`, use local
+helper functions called inside each test block. For cleanup, prefer `addTearDown`
+over the global `tearDown` callback.
+
+### Prefer more test files, avoid long test files
+
+Organize tests into smaller files grouped by feature, widget, or behavior. Split
+one big `stream_avatar_test.dart` into `stream_avatar_layout_test.dart`,
+`stream_avatar_theme_test.dart`, etc., as the test surface grows.
+
+### Mock only at the seam
+
+Prefer mocking at the boundary between your code and the outside world (HTTP
+client, WebSocket, image loading). Do not mock every collaborator.
+
+- Use `mocktail` (no code generation required). Extend `Mock` and stub the methods
+  you exercise.
+- For simple stubs, prefer explicit fake classes over `Mock` — they read better and
+  survive interface changes without a regeneration step.
+
+### Golden tests
+
+Widget tests that verify pixel-level rendering use the `alchemist` package. Golden
+files live under `test/components/<name>/goldens/`, split by target:
+
+- `goldens/ci/` — used by CI
+- `goldens/macos/` — used for local macOS development
+
+Golden tests are tagged with `golden` in `dart_test.yaml`. Every visible component
+must ship with a golden test.
+
+To regenerate goldens:
+
+```bash
+melos run update:goldens
+```
+
+Regenerate goldens deliberately, in a separate commit from behavior changes, so
+reviewers can see what visually changed. Do not check in a golden mismatch just
+because a test "works locally".
+
+
+## Naming
+
+### Begin global constant names with the prefix `k`
+
+```dart
+const double kDefaultBorderRadius = 8;
+const String kDefaultLocale = 'en';
+```
+
+Prefer avoiding global constants — `StreamAvatar.defaultSize` reads better than
+`kDefaultAvatarSize`. Reach for a class-scoped constant first.
+
+### Avoid abbreviations
+
+Unless the abbreviation is more recognizable than the expansion (e.g. `XML`, `HTTP`,
+`JSON`, `URL`, `SDK`), expand it. Avoid one-character names unless idiomatic
+(`i` for a loop counter is fine; `x` and `y` for coordinates are fine).
+
+### Stream-prefix all public widgets and themes
+
+Every public widget, theme, and enum in `stream_core_flutter` is prefixed with
+`Stream` (e.g. `StreamAvatar`, `StreamAvatarThemeData`, `StreamAvatarSize`). This
+avoids collisions with consumer app code and Material/Cupertino types.
+
+Private implementation classes do not need the prefix.
+
+### Naming rules for callbacks and typedefs
+
+For callbacks, use `FooCallback` for the typedef, `onFoo` for the property, and
+`handleFoo` for the method that is called.
+
+If `Foo` is a verb, prefer present tense over past tense (`onTap`, not `onTapped`).
+
+Never call a method `onFoo`. If a property is called `onFoo` it must be a function
+type. Prefer typedefs for callbacks — they can be documented and make it easier to
+grep for common signatures.
+
+### Spelling
+
+Prefer US English spellings. `color`, not `colour`. `canceled`, not `cancelled`.
+
+### Capitalization consistent with spelling
+
+If a word is written as a single compound word (e.g. `toolbar`, `scrollbar`), keep
+it compound: no inner capitalization. If it's two words (e.g. `app bar`), use
+camelCase: `appBar`, `tabBar`.
+
+Avoid class names containing `iOS`. Prefer `Cupertino` or `UIKit`. If you must use
+`iOS` in an identifier, capitalize it as `IOS`.
+
+### Avoid double negatives in APIs
+
+Name boolean variables positively, even if the default is `true`.
+
+### Prefer naming the argument to a setter `value`
+
+Unless it causes problems, use `value` for the setter's argument.
+
+### Qualify variables and methods used only for debugging
+
+Prefix debug-only helpers with `debug` (or `_debug` for private).
+
+### Avoid "new" / "old" modifiers
+
+The definition of "new" changes as code grows. Name things after the idea, not the
+version.
+
+
+## Comments
+
+### Avoid checking in comments that ask questions
+
+Find the answers to the questions, or describe the confusion, including references
+where you found answers.
+
+If commenting on a workaround for a bug, describe the constraint and (when one
+exists) link the tracking issue:
+
+```dart
+// TODO(localize): move "remove" hint to localizations.
+// TODO: When the minimum Flutter SDK is >= 3.40, replace this with X.
+```
+
+TODOs are either bare `// TODO:` or use a category tag `// TODO(<tag>):` where the
+tag names a workstream (e.g. `localize`, `perf-migration`). This diverges from
+Flutter's guide, which requires `TODO(github-handle):`. Include an issue link when
+the deferred work is tracked; if the constraint is self-explanatory, a link isn't
+required.
+
+### Bare ignore directives are fine
+
+`// ignore: rule_name` directives do not require an explanatory comment
+(`document_ignores` is disabled). This intentionally diverges from Flutter's guide.
+
+```dart
+// GOOD (matches repo style):
+foo(); // ignore: unnecessary_null_comparison
+```
+
+If an `// ignore` covers something genuinely subtle, a comment is welcome. Do not
+add "explanatory" comments to every ignore just to match Flutter's convention.
+
+### Minimize inline comments
+
+Default to zero `//` comments in implementation. Prefer named locals over rationale
+comments; prefer early returns over "// handle the loading case" markers.
+
+```dart
+// BAD:
+Widget build(BuildContext context) {
+  // If the user is offline, show the offline banner.
+  if (!isOnline) return const OfflineBanner();
+  // Otherwise, show the content.
+  return const _Content();
+}
+
+// GOOD:
+Widget build(BuildContext context) {
+  if (!isOnline) return const OfflineBanner();
+  return const _Content();
+}
+```
+
+Comments earn their place when they explain _why_ — a hidden constraint, a subtle
+invariant, a workaround for a specific bug. Pre-existing comments should not be
+removed as part of unrelated changes.
+
+### Comment all test skips
+
+Every skipped test must carry a reason as its `skip` argument. Bare `skip: true` is
+a red flag — the next person to look will not know whether the skip is temporary,
+permanent, or forgotten.
+
+```dart
+// GOOD:
+skip: 'Golden diverges on M1 hardware — investigating.'
+skip: 'Blocked on Flutter #12345 — remove once that ships.'
+
+// BAD:
+skip: true
+```
+
+Include an issue link when the skip is tied to a tracked bug; otherwise a plain
+reason is fine. File an issue if the skip becomes long-lived.
+
+### Comment empty closures to `setState`
+
+Usually the closure passed to `setState` includes all the state changes. Sometimes
+the state changed elsewhere and `setState` is called in response — in those cases
+include a comment describing what changed:
+
+```dart
+setState(() {
+  // The stream subscription fired; the state is already up to date.
+});
+```
+
+
+## Formatting
+
+Run the formatter via Melos, not directly:
+
+```bash
+melos run format          # dart format . across every package
+melos run format:verify   # check-only; used in CI
+melos run lint:all        # analyze + format check
+```
+
+`melos run format` wraps `dart format` so every package is checked with the same
+settings. Do not invoke `dart format` on a single file with ad-hoc flags — the
+workspace-level config (line length, trailing commas) applies uniformly.
+
+Line length is **120 characters** for both code and comments, configured in
+`analysis_options.yaml`. Trailing commas are preserved rather than automatically
+added, so include a trailing comma anywhere you want the formatter to break the
+argument list onto multiple lines.
+
+### Constructors come first
+
+The default constructor comes first, followed by named constructors, followed by
+everything else. Enforced by `sort_constructors_first` and
+`sort_unnamed_constructors_first`.
+
+### Order other class members in a way that makes sense
+
+If there's a clear lifecycle, order members chronologically (e.g. `initState` before
+`build` before `dispose`).
+
+If no order is obvious, use:
+
+1. Constructors, default first.
+2. Constants of the same type as the class.
+3. Static methods that return the same type as the class.
+4. Final fields set from the constructor.
+5. Other static methods.
+6. Static properties and constants.
+7. Mutable-property members (getter, private field, setter — no blank lines
+   separating the three).
+8. Read-only properties (other than `hashCode`).
+9. Operators (other than `==`).
+10. Methods (other than `toString` and `build`).
+11. The `build` method.
+12. `operator ==`, `hashCode`, `toString`, and diagnostics methods.
+
+### Use braces for long function bodies
+
+Use a block (with braces) when a body would wrap onto more than one line.
+
+### Prefer `+=` over `++`
+
+`+=` reads as an assignment. `++` hides mutation.
+
+### Use double literals for double constants
+
+Include a decimal point in double literals, even for whole numbers:
+
+```dart
+Padding(padding: EdgeInsets.all(8.0)); // good
+Padding(padding: EdgeInsets.all(8));   // avoid — reads as int
+```
+
+
+## Widgets, themes, and design system
+
+### Component structure
+
+Components live under `packages/stream_core_flutter/lib/src/components/<category>/`.
+Current categories: `accessories/`, `avatar/`, `badge/`, `buttons/`, `common/`,
+`context_menu/`, `controls/`, `emoji/`, `list/`, `media_viewer/`, `message/`,
+`message_composer/`, `message_layout/`, `reaction/`, `sheet/`, `snackbar/`,
+`toolbar/`. Add a new category directory when a component doesn't fit an existing
+one.
+
+Each component ships with:
+
+- **Widget file** — under `lib/src/components/<category>/<name>.dart`.
+- **Theme file** — under `lib/src/theme/components/<name>_theme.dart`. See
+  [Theme system](#theme-system). Note: the suffix is either `<Name>ThemeData` or
+  `<Name>Style` — both patterns exist in the repo (e.g. `StreamAvatarThemeData`,
+  `StreamMessageBubbleStyle`); pick whichever fits the component's semantics.
+- **Golden test** — under `test/components/<name>/`. See
+  [Golden tests](#golden-tests).
+- **Widgetbook use-case** — under
+  `apps/design_system_gallery/lib/components/<category>/`.
+- **Barrel export** — an `export '…';` line added to `core.dart` or `chat.dart`.
+
+Missing any of the four is a review-blocker.
+
+### Theme system
+
+Themes are generated via the `theme_extensions_builder` package. **Do not hand-roll
+`copyWith`, `merge`, `lerp`, `==`, or `hashCode`** — annotate with `@themeGen` (or
+`@ThemeExtensions` for the root theme) and let the generator produce them.
+
+The hierarchy is:
+
+1. **Primitives** (`lib/src/theme/primitives/`) — raw design tokens: colors,
+   typography, spacing, radius, icons.
+2. **Semantics** (`lib/src/theme/semantics/`) — semantic mappings on top of
+   primitives (e.g. `primaryColor`, `bodyText`).
+3. **Component themes** (`lib/src/theme/components/`) — per-widget theme classes
+   (50+ components).
+4. **Tokens** (`lib/src/theme/primitives/internal/tokens/`) — light/dark concrete
+   values, figma-generated, not part of the public API.
+
+When adding a new component theme:
+
+1. Create a `<Component>ThemeData` class that:
+   - Uses `with _$<Component>ThemeData` (the generated mixin) and is annotated with
+     `@immutable` + `@themeGen`. Component themes do **not** extend
+     `ThemeExtension`.
+   - Declares `part '<snake_name>.g.theme.dart';` at the top of the file.
+   - Has **all fields nullable** — defaults do not live here.
+
+   The root `StreamTheme` is an exception: it `extends ThemeExtension<StreamTheme>`
+   and uses `@ThemeExtensions(constructor: 'raw', buildContextExtension: false)`.
+   New component themes should follow the `@themeGen` pattern, not the root
+   pattern. There is no separate `StreamThemeData` — the root class is `StreamTheme`
+   itself.
+2. Create a `<Component>Theme` `InheritedTheme` widget that exposes the data via a
+   `static <Component>ThemeData of(BuildContext context)` lookup. Merge with the
+   root theme value in that lookup — the pattern is
+   `StreamTheme.of(context).<component>Theme.merge(localTheme?.data)`; see any file
+   under `lib/src/theme/components/` for a reference.
+3. Add the new theme data as a field on `StreamTheme`.
+4. **Place defaults in the widget's implementation, not in the theme data class.**
+   This mirrors Flutter's own convention (`AppBar`, `TabBar`): the theme data holds
+   overrides with nullable fields; the widget's `build` resolves the effective
+   value with a null-coalescing chain, falling back to hardcoded defaults or
+   upstream Material/Cupertino theme values at the leaf.
+
+   ```dart
+   Widget build(BuildContext context) {
+     final theme = StreamAvatarTheme.of(context);
+     final backgroundColor = widget.backgroundColor
+         ?? theme.backgroundColor
+         ?? Theme.of(context).colorScheme.surface;
+     // ...
+   }
+   ```
+5. Run `melos run generate:flutter` to produce the `.g.theme.dart` part.
+6. Read the theme from context via `StreamTheme.of(context).<component>Theme`
+   in the component's `build` (or via `<Component>Theme.of(context)` when the
+   widget lives inside its own theme scope).
+
+Look at `stream_avatar_theme.dart` and any file in
+`lib/src/theme/components/` for the reference shape.
+
+### Component factory
+
+The design system uses `StreamComponentFactory` to allow consumers to substitute
+individual components without forking. When adding a new component that has a
+default implementation, register a factory hook so consumers can override it. See
+`lib/src/factory/stream_component_factory.dart` for the pattern.
+
+### Icons
+
+Source SVGs live in `packages/stream_core_flutter/assets_source/icons/`. They come
+from the [design-system-tokens](https://github.com/GetStream/design-system-tokens/tree/main/assets/icons)
+repository.
+
+When adding or updating icons:
+
+1. Pull the latest SVGs from `design-system-tokens/assets/icons/` into
+   `assets_source/icons/`.
+2. Run `melos run generate:icons` to regenerate the icon font and the `StreamIcons`
+   class.
+3. Commit both the SVG sources and the regenerated font + Dart output together —
+   they must stay in sync.
+
+Do not edit the generated `StreamIcons.dart` or the icon font by hand.
+
+### Widget essentials
+
+Every new public widget in `stream_core_flutter` should:
+
+- Accept `Key? key` in its constructor via `super.key`
+  (`use_key_in_widget_constructors`, `use_super_parameters`).
+- Support accessibility on both Android (TalkBack) and iOS (VoiceOver). A `Tooltip`
+  is usually sufficient as the accessible label.
+- Support both LTR and RTL layouts.
+- Support text scaling.
+- Have documentation for every public member.
+- Have a golden test covering the default state and the primary theme variants.
+- Have a Widgetbook use-case that lets a designer or reviewer interact with all
+  props.
+
+
+## Commits, PRs, and changelogs
+
+### PR titles and commits
+
+PR titles follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `fix(scope): description` — bug fix
+- `feat(scope): description` — new feature
+- `refactor(scope)!: description` — breaking change (note the `!`)
+- `chore(scope): description`, `docs:`, `test:`, `ci:`
+
+`scope` is usually the affected package (`llc` for `stream_core`, `ui` for
+`stream_core_flutter`, or `repo` for monorepo-wide changes).
+
+### Changelog policy
+
+Every PR that changes package behavior updates the affected package's
+`CHANGELOG.md` under the `Upcoming` heading. Entries live under one of these
+sub-headings:
+
+```markdown
+## Upcoming
+
+### ✨ Features
+
+- Added `StreamJumpToUnreadButton` component and `StreamJumpToUnreadButtonTheme`.
+
+### 🐛 Bug Fixes
+
+- Fixed a crash when opening the media viewer with an empty attachments list.
+
+### 🛑 Breaking / Removals
+
+- Removed `StreamCoreMessageComposer`. Use `StreamMessageComposer` from
+  `stream_chat_flutter` instead.
+```
+
+Prefer **one short bullet** per entry, describing the functional change. Longer
+entries are acceptable for user-visible multi-facet features where the extra
+context matters to someone deciding whether to upgrade — but avoid sub-bullets,
+per-method enumeration, and internal implementation notes.
+
+Older entries in the changelog use `### 🐞 Fixed` and `### 💥 Breaking Changes` /
+`### 💥 BREAKING CHANGES` — those forms are grandfathered but new entries should
+use the labels above.
+
+### Cross-package PRs
+
+If a PR touches both `stream_core` and `stream_core_flutter`, update each package's
+`CHANGELOG.md` separately. Cross-linking between packages ("bumps stream_core to
+X.Y.Z") is handled by the release tooling — do not write these entries by hand.
+
+
+## Where to look when you're stuck
+
+- **Repo-wide overview**: [`CLAUDE.md`](CLAUDE.md) — architecture, commands, package
+  layout. Points here for style rules.
+- **Testing guide**: [`TESTING.md`](TESTING.md) — how to write effective tests.
+- **Melos commands**: `melos.yaml` — every task the repo runs.
+- **Design source**: the Chat SDK Design System Figma project — accessed via the
+  Figma MCP when implementing UI.
+- **Design tokens**: `packages/stream_core_flutter/lib/src/theme/primitives/internal/tokens/`
+  and the [design-system-tokens](https://github.com/GetStream/design-system-tokens)
+  sibling repo.
+
+When something isn't covered here and isn't obvious from surrounding code, prefer
+to ask in the PR rather than guessing. If a convention isn't documented, propose
+adding it to this guide as part of the PR.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -808,53 +808,26 @@ Widget build(BuildContext context) {
 }
 ```
 
-### Reactive state
+### Use of streams and `Listenable`s
 
-This repo is transport + design system; it doesn't own a state-management
-layer of its own.
+At the Flutter widget layer, prefer `Listenable` subclasses (`ValueNotifier`
+or `ChangeNotifier`) over `Stream` for widget-owned state. Streams have several
+disadvantages that make them awkward inside widget code:
 
-- Transport-layer state (WS events, connection lifecycle, network state) uses
-  `SharedEmitter` / `StateEmitter` from the utils layer.
-- Widget-owned state in the Flutter layer (animations, toggles,
-  controller-adjacent state, controllers exposed to the widget tree) uses
-  `Listenable` — `ValueNotifier` / `ChangeNotifier`. Matches Flutter's own
-  conventions.
+- Streams have a heavy API. They can be synchronous or asynchronous, broadcast
+  or single-client, paused and resumed. Determining the right semantics for a
+  particular stream when it's used in all the ways widget code could use it is
+  non-trivial.
+- Streams don't have a "current value" accessor, which makes them difficult to
+  use in `build` methods.
+- The APIs for manipulating streams are non-trivial (e.g. transformers).
 
-Release resources when the owning object is torn down: cancel
-`StreamSubscription`s, close emitters, dispose notifiers. Prefer RxDart
-operators over hand-rolled `.listen()` + `Controller` plumbing.
+This matches Flutter's own guidance inside the framework.
 
-Product SDKs built on top of this repo choose their own state primitives —
-each defines them in its own style guide.
-
-### Error handling with `Result<T>`
-
-Public methods that can fail return `Future<Result<T>>` (from
-`stream_core/lib/src/utils/result.dart`) rather than throwing. Existing examples:
-`StreamAttachmentUploader.upload`, `CdnClient.uploadImage`/`uploadFile`.
-
-```dart
-Future<Result<UploadedFile>> uploadImage(File image) async {
-  try {
-    final response = await _api.uploadImage(image);
-    return Result.success(response.toModel());
-  } on DioException catch (e) {
-    return Result.failure(_mapException(e));
-  }
-}
-
-// Consumer.
-switch (await cdn.uploadImage(file)) {
-  case Success(:final data): attach(data);
-  case Failure(:final error): showError(error);
-}
-```
-
-Internal helpers can throw when a failure is truly exceptional (assert
-violation, programming error) — convert to `Result.failure` at the boundary.
-`Result` is a `sealed class` — prefer exhaustive `switch` over
-`isSuccess`/`isFailure`.
-
+At the transport layer, streams are the natural primitive — WebSocket events
+and connection lifecycle changes arrive asynchronously and have no meaningful
+"current value" at every moment. `SharedEmitter` and `StateEmitter` are the
+primitives; both implement `Stream<T>`.
 
 ## Testing
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -192,17 +192,15 @@ pulls higher-level concepts into places they don't belong.
 (cross-product primitives) and `chat.dart` (chat-domain widgets). See
 [Public barrel contract](#public-barrel-contract).
 
-### Prefer immutable data
+### Avoid interleaving multiple concepts together
 
-Themes, `@freezed` models, and other value classes are immutable — callers get a
-new instance from `copyWith`, never mutation. Widgets that take a `child` should
-be agnostic about the type of that child; don't `is`-check to act differently on
-the child's runtime type.
+Each API should be self-contained and should not know about other features.
+Interleaving concepts leads to complexity.
 
-Note that "immutable" applies to values and configuration, not to the design
-system as a whole: components compose deliberately here (component factory,
-theme hierarchy, related message-layer widgets referencing each other). Coupling
-between design-system pieces is part of the point, not a smell.
+- Widgets that take a `child` should be entirely agnostic about the type of that
+  child. Don't use `is` checks to act differently based on the type of the child.
+- Prefer immutable data models. `Message`, `User`, and friends are immutable. Themes
+  are immutable. Callers get a new instance from `copyWith`, never mutation.
 
 ### Avoid secret (or global) state
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -643,49 +643,27 @@ groups (`directives_ordering`).
 
 ### Guidelines for `extension`s
 
-Extension methods let you add functionality to an existing type. Consider the
-trade-offs before reaching for one:
+Extension methods are resolved statically and cannot be overridden; misuse
+pollutes IDE suggestions and causes naming collisions. Reach for one only when
+a regular method or helper function won't do.
 
-- Extension methods are resolved statically and cannot be overridden.
-- Misusing extensions pollutes IDE suggestions and causes naming collisions.
+`stream_core/lib/src/utils/` is an intentional standard-library-style layer,
+exported from `stream_core.dart` and used across 100+ call sites: `Standard on T`
+(Kotlin scope funcs `let`/`also`/`apply`/`takeIf`), `ComparableExtension`,
+`IterableExtensions`, `ListExtensions`, `SortedListExtensions`. Use these
+freely. **New utility extensions belong here** — don't scatter them across
+feature code.
 
-The repo intentionally maintains a **standard-library-style extension layer** in
-`packages/stream_core/lib/src/utils/`, exported from `stream_core.dart` and used
-across the codebase (100+ call sites). It includes:
+Accepted extension targets outside `utils/`:
 
-- `Standard<T extends Object> on T` — Kotlin-style scope functions
-  (`let`, `also`, `apply`, `takeIf`, `takeUnless`).
-- `ComparableExtension<T extends Comparable<T>> on T` — `<`, `>`, `<=`, `>=`
-  operators.
-- `IterableExtensions on Iterable<T>` — `sumOf`.
-- `ListExtensions` / `SortedListExtensions` on `List<T>` — `upsert`, `partition`,
-  `batchReplace`, `sortedInsert`, `sortedUpsert`, `merge`, `updateNested`,
-  `removeNested`, `updateWhere`, `insertUnique`.
-
-Use these freely — they are part of the SDK's DSL.
-
-Rules for new extensions:
-
-- **Standard utility extensions belong in `stream_core/lib/src/utils/`.** If you
-  need a new `on num` / `on List<T>` / `on Iterable<T>` / `on T extends Object`
-  helper, add it to the appropriate file there rather than defining a new
-  extension in feature code.
-- Don't declare an extension method when a regular method or a helper function
-  will do.
-- Extensions on domain types are fine — they only apply when the caller is
-  already working with those types. Examples in the repo: `AttachmentFile`,
-  `DioException`, `RetryStrategy`, `SystemEnvironment`.
-- Extensions on `BuildContext` for scoped lookups are an accepted Flutter idiom.
-  Examples: `StreamThemeExtension on BuildContext` exposing `context.streamTheme`;
-  `StreamComponentFactoryExtension on BuildContext` exposing the factory.
-- Units-of-measure extensions on primitives are acceptable when the extension is
-  small, unambiguous, and lives next to the value type. Example:
-  `DistanceExtension on num` exposing `5.kilometers` next to `Distance`.
+- Domain types (`AttachmentFile`, `DioException`, `RetryStrategy`).
+- `BuildContext` for scoped lookups — e.g. `context.streamTheme`.
+- Units-of-measure on primitives when small and unambiguous — e.g.
+  `DistanceExtension on num` next to `Distance` (`5.kilometers`).
 
 Outside these patterns, avoid public extensions on `Object`, `Object?`,
-`Future<T>`, `String`, `Map<K, V>` — those show up on every value of that type in
-every file that imports the package, causing IDE-completion noise and potential
-collisions with other packages.
+`Future<T>`, `String`, `Map<K, V>` — they show up on every value of that type
+in every importing file.
 
 ### Avoid `FutureOr<T>` in public APIs
 
@@ -838,108 +816,112 @@ Widget build(BuildContext context) {
 }
 ```
 
-### Reactive state primitives
+### Reactive state
 
-There are three layers of reactive state in this repo, each with its own primitive:
+Three primitives, each for a specific job:
 
-**1. Product-SDK state → `StateNotifier` (from `package:state_notifier`) — the
-going-forward pattern for new code.**
+- **`StateNotifier<S>`** (from `package:state_notifier`) — the going-forward
+  primitive for new product-SDK state. `S` is an immutable `@freezed` state
+  class. The notifier is internal; the public API is a high-level object that
+  wraps it. See [Product-SDK architecture](#product-sdk-architecture) for the
+  shape.
+- **`SharedEmitter<T>` / `StateEmitter<T>`** — internal transport-layer state in
+  `stream_core/lib/src/utils/` (WS events, connection lifecycle). Kotlin
+  `SharedFlow`/`StateFlow` equivalents; both implement `Stream<T>`. Don't build
+  new product-facing state on emitters.
+- **`ValueNotifier` / `ChangeNotifier`** — widget-owned state that never leaves
+  the widget tree: animations, toggles, controller-adjacent state.
 
-Product SDKs built on top of `stream_core` manage state via
-`StateNotifier<State>` with an immutable `@freezed` `State` class. The public
-surface is a high-level state object that wraps the notifier; the notifier
-itself is internal.
-
-Key rules for new state code:
-
-- `*State` classes use `@freezed` with const constructors and Freezed 3.0
-  mixed-mode syntax (`@override` on fields).
-- `*StateNotifier` implementations extend `StateNotifier<*State>` and are an
-  **internal** implementation detail (`lib/src/`) — never exposed on the public
-  API.
-- The public surface is the high-level state object that wraps the notifier;
-  callers hold a reference to that object and read its state.
-
-See [Product-SDK architecture](#product-sdk-architecture) below for the full
-layering that surrounds `StateNotifier`.
-
-**2. Transport-layer state → existing emitters in `stream_core/lib/src/utils/`.**
-
-For state that lives inside `stream_core`'s transport layer (WS events,
-connection state, network state, lifecycle state) the existing
-`SharedEmitter`/`StateEmitter` primitives remain the right choice — they predate
-`StateNotifier` here and are wired into the WS reconnection machinery:
-
-- **`SharedEmitter<T>` / `MutableSharedEmitter<T>`** — Kotlin `SharedFlow`
-  equivalent. Multi-subscriber broadcast for events without a "current value".
-  Supports `replay:` for late subscribers.
-- **`StateEmitter<T>` / `MutableStateEmitter<T>`** — Kotlin `StateFlow`
-  equivalent. Has `.value`, replays it on subscribe, conflates duplicates.
-
-Both `implements Stream<T>`, so `StreamBuilder` (with `initialData:
-stateEmitter.value` for `StateEmitter`) is the standard widget-side consumer.
-Don't build new product-facing state on emitters — use `StateNotifier` for that.
-
-**3. Widget-owned state → `ValueNotifier` / `ChangeNotifier`.**
-
-For reactive state that never crosses out of the widget tree — animation-driven
-values, expanded/collapsed toggles, `TextEditingController`-adjacent state.
-
-**General rules:**
-
-- Always cancel `StreamSubscription`s in `dispose()`. `MutableSharedEmitter` /
-  `MutableStateEmitter` have `close()`; `StateNotifier` has `dispose()` — call
-  the right one when the owning object is torn down.
-- For pipelines that combine or transform streams, prefer RxDart operators over
-  hand-rolled `.listen()`+`Controller` plumbing.
+Cancel `StreamSubscription`s in `dispose()`. `MutableSharedEmitter` /
+`MutableStateEmitter` have `close()`; `StateNotifier` has `dispose()`. Prefer
+RxDart operators over hand-rolled `.listen()` + `Controller` plumbing.
 
 This intentionally diverges from Flutter's style guide, which recommends
-`Listenable` over `Stream` inside the framework — that reasoning doesn't apply
-to a real-time transport layer where events are the primary data model.
+`Listenable` over `Stream` — that reasoning doesn't apply to a real-time
+transport layer where events are the primary data model.
 
 ### Error handling with `Result<T>`
 
 Public methods on repositories, clients, and CDN wrappers return
 `Future<Result<T>>` (from `stream_core/lib/src/utils/result.dart`) rather than
-throwing. Existing examples in the repo: `StreamAttachmentUploader.upload`,
-`CdnClient.uploadImage`/`uploadFile`/`deleteImage`/`deleteFile`.
+throwing. Existing examples: `StreamAttachmentUploader.upload`, `CdnClient.uploadImage`.
 
-Rules:
+```dart
+Future<Result<UserData>> getUser(String id) async {
+  try {
+    final response = await _api.getUser(id: id);
+    return Result.success(response.toModel());
+  } on DioException catch (e) {
+    return Result.failure(_mapException(e));
+  }
+}
 
-- SDK public methods that can fail return `Result<T>`. Never throw across the
-  SDK boundary.
-- Internal helpers can still throw when a failure is truly exceptional (an
-  `assert` violation, a programming error). Convert to `Result.failure` at the
-  boundary.
-- `Result` is a `sealed class` with `Success<T>` and `Failure` variants. Prefer
-  `switch` (exhaustive) over `isSuccess`/`isFailure` when acting on the outcome
-  in code you control.
+// Consumer.
+final result = await client.getUser('123');
+switch (result) {
+  case Success(:final data): render(data);
+  case Failure(:final error): showError(error);
+}
+```
+
+Internal helpers can throw when a failure is truly exceptional (assert
+violation, programming error) — convert to `Result.failure` at the boundary.
+`Result` is a `sealed class` — prefer exhaustive `switch` over
+`isSuccess`/`isFailure`.
 
 ### Product-SDK architecture
 
-For new product-SDK code built on top of `stream_core` — a client that fetches
-data, hosts state, and exposes it to UI — use this layered architecture:
+New product-SDK code built on top of `stream_core` uses this layering:
 
 ```text
-Client                    # public API entry point (thin factory)
+Client                    # public entry point (thin factory)
   └── Repository          # data access, returns Future<Result<T>>
-      └── StateNotifier   # internal; wraps state + reacts to WS events
-          └── State       # public @freezed value; what the UI renders
+      └── StateNotifier   # internal; wraps state, reacts to WS events
+          └── State       # public @freezed value the UI renders
 ```
 
-- **Public API**: the `Client` + high-level state objects (the wrappers around
-  `StateNotifier`, exposed as classes like `Feed`, `ActivityList`, or whatever
-  the domain calls for). Both live at the top of `lib/`.
-- **Internal**: `Repository` and `*StateNotifier` implementations live under
-  `lib/src/`.
-- **All Repository methods return `Future<Result<T>>`** — no thrown exceptions
-  crossing the SDK boundary.
-- **Models** live under `src/models/`, are `@freezed` (mixed-mode 3.0 with
-  `@override` on fields), and follow naming conventions:
-  - `*Data` — domain models (e.g. `MessageData`, `UserData`).
-  - `*Query` — query descriptors (e.g. `MessagesQuery`).
-  - `*Request` — HTTP request payloads (e.g. `SendMessageRequest`).
-- **Tests** exercise the public API only — see [Testing](#testing) below.
+Skeleton:
+
+```dart
+// State — @freezed with Freezed 3.0 mixed-mode syntax + @override on fields.
+@freezed
+class FeatureState with _$FeatureState {
+  const FeatureState({required this.id, required this.items});
+
+  @override
+  final String id;
+  @override
+  final List<ItemData> items;
+}
+
+// StateNotifier — internal, under lib/src/state/.
+class FeatureStateNotifier extends StateNotifier<FeatureState> {
+  FeatureStateNotifier(this._repo, FeatureState initial) : super(initial);
+
+  final FeatureRepository _repo;
+
+  Future<void> refresh() async {
+    switch (await _repo.fetch(id: state.id)) {
+      case Success(:final data): state = state.copyWith(items: data);
+      case Failure(): break;
+    }
+  }
+}
+
+// Public wrapper — lives at the top of lib/.
+class Feature {
+  Feature._(this._notifier);
+  final FeatureStateNotifier _notifier;
+  FeatureState get state => _notifier.state;
+  Stream<FeatureState> get stateChanges => _notifier.stream;
+}
+```
+
+- Public: `Client` + high-level wrappers (like `Feature` above). Both at top of `lib/`.
+- Internal: `Repository`, `*StateNotifier`. Under `lib/src/`.
+- Models under `src/models/`: `*Data` (domain), `*Query` (query descriptor),
+  `*Request` (HTTP payload). All `@freezed`.
+- Tests exercise the public API only — see [Testing](#testing).
 
 
 ## Testing
@@ -1275,63 +1257,64 @@ Missing any of the four is a review-blocker.
 
 ### Theme system
 
-Themes are generated via the `theme_extensions_builder` package. **Do not hand-roll
-`copyWith`, `merge`, `lerp`, `==`, or `hashCode`** — annotate with `@themeGen` (or
-`@ThemeExtensions` for the root theme) and let the generator produce them.
+Themes are generated via `theme_extensions_builder`. **Never hand-roll `copyWith`,
+`merge`, `lerp`, `==`, or `hashCode`.** Annotate with `@themeGen` (or
+`@ThemeExtensions` for the root) and let the generator produce them.
 
-The hierarchy is:
+The hierarchy is layered: **primitives** (`theme/primitives/`, raw tokens) →
+**semantics** (`theme/semantics/`, semantic mappings) → **component themes**
+(`theme/components/`, per-widget classes, 50+) → **tokens** (figma-generated,
+internal).
 
-1. **Primitives** (`lib/src/theme/primitives/`) — raw design tokens: colors,
-   typography, spacing, radius, icons.
-2. **Semantics** (`lib/src/theme/semantics/`) — semantic mappings on top of
-   primitives (e.g. `primaryColor`, `bodyText`).
-3. **Component themes** (`lib/src/theme/components/`) — per-widget theme classes
-   (50+ components).
-4. **Tokens** (`lib/src/theme/primitives/internal/tokens/`) — light/dark concrete
-   values, figma-generated, not part of the public API.
+Adding a new component theme:
 
-When adding a new component theme:
+```dart
+// lib/src/theme/components/stream_widget_theme.dart
 
-1. Create a `<Component>ThemeData` class that:
-   - Uses `with _$<Component>ThemeData` (the generated mixin) and is annotated with
-     `@immutable` + `@themeGen`. Component themes do **not** extend
-     `ThemeExtension`.
-   - Declares `part '<snake_name>.g.theme.dart';` at the top of the file.
-   - Has **all fields nullable** — defaults do not live here.
+@immutable
+@themeGen
+class StreamWidgetThemeData with _$StreamWidgetThemeData {
+  const StreamWidgetThemeData({this.backgroundColor, this.borderRadius});
 
-   The root `StreamTheme` is an exception: it `extends ThemeExtension<StreamTheme>`
-   and uses `@ThemeExtensions(constructor: 'raw', buildContextExtension: false)`.
-   New component themes should follow the `@themeGen` pattern, not the root
-   pattern. There is no separate `StreamThemeData` — the root class is `StreamTheme`
-   itself.
-2. Create a `<Component>Theme` `InheritedTheme` widget that exposes the data via a
-   `static <Component>ThemeData of(BuildContext context)` lookup. Merge with the
-   root theme value in that lookup — the pattern is
-   `StreamTheme.of(context).<component>Theme.merge(localTheme?.data)`; see any file
-   under `lib/src/theme/components/` for a reference.
-3. Add the new theme data as a field on `StreamTheme`.
-4. **Place defaults in the widget's implementation, not in the theme data class.**
-   This mirrors Flutter's own convention (`AppBar`, `TabBar`): the theme data holds
-   overrides with nullable fields; the widget's `build` resolves the effective
-   value with a null-coalescing chain, falling back to hardcoded defaults or
-   upstream Material/Cupertino theme values at the leaf.
+  // All fields are nullable — defaults do not live here.
+  final Color? backgroundColor;
+  final double? borderRadius;
+}
 
-   ```dart
-   Widget build(BuildContext context) {
-     final theme = StreamAvatarTheme.of(context);
-     final backgroundColor = widget.backgroundColor
-         ?? theme.backgroundColor
-         ?? Theme.of(context).colorScheme.surface;
-     // ...
-   }
-   ```
-5. Run `melos run generate:flutter` to produce the `.g.theme.dart` part.
-6. Read the theme from context via `StreamTheme.of(context).<component>Theme`
-   in the component's `build` (or via `<Component>Theme.of(context)` when the
-   widget lives inside its own theme scope).
+class StreamWidgetTheme extends InheritedTheme {
+  const StreamWidgetTheme({super.key, required this.data, required super.child});
+  final StreamWidgetThemeData data;
 
-Look at `stream_avatar_theme.dart` and any file in
-`lib/src/theme/components/` for the reference shape.
+  static StreamWidgetThemeData of(BuildContext context) {
+    final local = context.dependOnInheritedWidgetOfExactType<StreamWidgetTheme>();
+    return StreamTheme.of(context).widgetTheme.merge(local?.data);
+  }
+  // ... wrap + updateShouldNotify.
+}
+```
+
+Then add `widgetTheme` as a field on `StreamTheme`, run `melos run generate:flutter`,
+and consume it in the widget:
+
+```dart
+Widget build(BuildContext context) {
+  final theme = StreamWidgetTheme.of(context);
+  final backgroundColor = widget.backgroundColor
+      ?? theme.backgroundColor
+      ?? Theme.of(context).colorScheme.surface;
+  // ...
+}
+```
+
+**Place defaults in the widget's `build`, not in the theme data class.** This
+mirrors Flutter's `AppBar`/`TabBar` pattern: theme data holds overrides with
+nullable fields; the widget resolves the effective value via null-coalescing.
+
+Note: the root `StreamTheme` is an exception — it extends
+`ThemeExtension<StreamTheme>` and uses
+`@ThemeExtensions(constructor: 'raw', buildContextExtension: false)` so it plugs
+into Material's `ThemeData.extensions`. New component themes follow the
+`@themeGen` pattern above, not the root pattern.
 
 ### Component factory
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -808,25 +808,21 @@ Widget build(BuildContext context) {
 }
 ```
 
-### Use of streams and `Listenable`s
+### Reactive primitives
 
-At the Flutter widget layer, prefer `Listenable` subclasses (`ValueNotifier`
-or `ChangeNotifier`) over `Stream` for widget-owned state. Streams have several
-disadvantages that make them awkward inside widget code:
+Two primitives cover reactive state in this repo:
 
-- Streams have a heavy API. They can be synchronous or asynchronous, broadcast
-  or single-client, paused and resumed. Determining the right semantics for a
-  particular stream when it's used in all the ways widget code could use it is
-  non-trivial.
-- The APIs for manipulating streams are non-trivial (e.g. transformers).
+- **`SharedEmitter` / `StateEmitter`** — for stream-like reactive data (WS
+  events, connection changes, transport-layer state). `SharedEmitter`
+  broadcasts events with optional replay for late subscribers; `StateEmitter`
+  adds a current-value accessor and conflates duplicate emissions. Both
+  implement `Stream<T>`, so `StreamBuilder` can consume them directly.
+- **`Listenable` subclasses** (`ValueNotifier`, `ChangeNotifier`) — for
+  widget-owned state at the Flutter layer: animations, toggles,
+  controller-adjacent state, and controllers exposed to the widget tree.
+  Matches Flutter's own convention.
 
-This matches Flutter's own guidance inside the framework.
-
-At the transport layer, events arrive asynchronously — WebSocket messages,
-connection changes, network state. `SharedEmitter` handles broadcast events
-(with optional replay for late subscribers); `StateEmitter` adds a
-current-value accessor for state that has a definite "now" and conflates
-duplicate emissions. Both implement `Stream<T>`.
+Don't use raw `Stream` directly — reach for the emitters instead.
 
 ## Testing
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -819,7 +819,7 @@ This repo is transport + design system; it doesn't own a state-management
 layer of its own.
 
 - Transport-layer state (WS events, connection lifecycle, network state) uses
-  the shared emitter primitives in the utils layer.
+  `SharedEmitter` / `StateEmitter` from the utils layer.
 - Widget-owned state in the Flutter layer (animations, toggles,
   controller-adjacent state, controllers exposed to the widget tree) uses
   `Listenable` — `ValueNotifier` / `ChangeNotifier`. Matches Flutter's own

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -815,23 +815,22 @@ Widget build(BuildContext context) {
 
 ### Reactive state
 
-This repo is transport + design system, not a product SDK — it doesn't own a
-state-management layer. The primitives here are:
+This repo is transport + design system; it doesn't own a state-management
+layer of its own.
 
-- **`SharedEmitter<T>` / `StateEmitter<T>`** (in `stream_core/lib/src/utils/`)
-  — internal transport-layer state: WS events, connection lifecycle, network
-  state. Kotlin `SharedFlow`/`StateFlow` equivalents; both implement `Stream<T>`.
-- **`ValueNotifier` / `ChangeNotifier`** — widget-owned state in
-  `stream_core_flutter`: animations, toggles, controller-adjacent state, and
-  controllers exposed to the widget tree. Matches Flutter's own conventions.
+- Transport-layer state (WS events, connection lifecycle, network state) uses
+  the shared emitter primitives in the utils layer.
+- Widget-owned state in the Flutter layer (animations, toggles,
+  controller-adjacent state, controllers exposed to the widget tree) uses
+  `Listenable` — `ValueNotifier` / `ChangeNotifier`. Matches Flutter's own
+  conventions.
 
-Cancel `StreamSubscription`s in `dispose()`. `MutableSharedEmitter` /
-`MutableStateEmitter` have `close()`; `ValueNotifier` / `ChangeNotifier` have
-`dispose()`. Prefer RxDart operators over hand-rolled `.listen()` + `Controller`
-plumbing.
+Release resources when the owning object is torn down: cancel
+`StreamSubscription`s, close emitters, dispose notifiers. Prefer RxDart
+operators over hand-rolled `.listen()` + `Controller` plumbing.
 
-Product SDKs built on top of `stream_core` (pure-Dart LLCs, Flutter UI wrappers)
-choose their own state primitives — each defines them in its own style guide.
+Product SDKs built on top of this repo choose their own state primitives —
+each defines them in its own style guide.
 
 ### Error handling with `Result<T>`
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -107,17 +107,7 @@ document; the section link is provided.
   `fix(scope): …`, `feat(scope): …`, `refactor(scope)!: …` for breaking changes.
 
 
-## A word on designing APIs
-
-Designing an API is an art. Like all forms of art, one learns by practicing. In the
-absence of one's own experience, one can attempt to rely on the experience of others.
-When receiving feedback about API design from an experienced API designer, they will
-sometimes seem unhappy without being able to articulate why. When this happens,
-seriously consider that your API should be scrapped and a new solution found.
-
-This requires a different and equally important skill: not getting attached to your
-creations. Try many wildly different APIs, then write code that uses them. Throw away
-APIs that feel frustrating or lead to buggy code.
+## Public API stability
 
 An SDK API is for years, not just for the one PR you are working on. A design system
 is even worse — every widget lands in downstream apps, and each field of each theme
@@ -225,11 +215,14 @@ Predictable APIs that give the developer control are generally preferred over
 APIs that mostly do the right thing but don't give the developer any way to
 adjust the results. Predictability is reassuring.
 
-### Solve real problems by literally solving a real problem
+### Design against a concrete use case
 
-Where possible, partner with a real customer who wants the feature and is
-willing to help you test it. Only by actually using a feature in the real world
-can we be confident it is ready.
+Before adding a public API, be able to point to a specific integration that needs
+it — a real customer request, a downstream consumer in `stream-chat-flutter` or
+`stream-video-flutter`, a documented gallery use-case. APIs designed against
+hypothetical needs tend to have the wrong shape for every real caller; APIs
+designed against one real caller are easier to generalize later, once a second
+caller shows up.
 
 ### Start designing APIs from the closest point to the developer
 
@@ -271,11 +264,19 @@ If a component is being deprecated, follow the deprecation policy: annotate with
 `@Deprecated('Use X instead.')`, add a `### 🛑 Breaking / Removals` CHANGELOG entry,
 and keep the deprecated API for at least one minor release before removal.
 
-### Copyright and licensing
+Deprecating an API that a product SDK (`stream-chat-flutter`, `stream-video-flutter`)
+re-exports is different — those product SDKs have their own deprecation cycles with
+their own users. Removing a re-exported API in the next minor of core would break
+the product SDK's public surface without going through *its* deprecation cycle. Do
+not remove such an API until every product SDK that re-exports it has completed a
+deprecation cycle for it (typically the next major of the product SDK). When in
+doubt, check who re-exports the symbol before removing it.
 
-New source files should carry the standard header used elsewhere in the repo.
+### Third-party code
+
 Third-party code must live in a `third_party/` subdirectory of the package with a
-`LICENSE` file that describes the license and a `README` describing its provenance.
+`LICENSE` file that describes the license and a `README` describing its
+provenance. Avoid third-party code unless strictly necessary.
 
 
 ## Repository structure
@@ -844,6 +845,15 @@ Organize tests into smaller files grouped by feature, widget, or behavior. Split
 one big `stream_avatar_test.dart` into `stream_avatar_layout_test.dart`,
 `stream_avatar_theme_test.dart`, etc., as the test surface grows.
 
+### Use `group` sparingly, only for tight clusters
+
+`group(...)` is fine — and used widely across the repo — for a small cluster of
+tests that share a precondition, e.g. "when the widget is in dark mode", "when
+`textDirection` is RTL". Keep the group's description short and describe the
+precondition, not the widget under test. Prefer splitting the file over piling
+up nested groups; if a group is doing the job a separate file should be doing,
+split the file instead.
+
 ### Mock only at the seam
 
 Prefer mocking at the boundary between your code and the outside world (HTTP
@@ -871,16 +881,23 @@ Golden tests are tagged with `golden` in `dart_test.yaml`. Every visible compone
 must ship with a golden test that exercises the primary variants (sizes, states,
 theme brightness).
 
-To regenerate goldens:
+**Regenerate committed goldens via the `update_goldens` GitHub Action**, not
+locally. The action runs on Linux — the same host CI uses — so the committed
+`goldens/ci/*.png` match what CI compares against. Locally-generated goldens
+carry host-specific font hinting and antialiasing that will fail CI on other
+machines.
+
+For local iteration only, you can run:
 
 ```bash
 melos run update:goldens
 ```
 
-Regenerate goldens deliberately, in a separate commit from behavior changes, so
-reviewers can see what visually changed. Do not check in a golden mismatch just
-because a test "works locally" — only the CI-generated PNGs under `goldens/ci/`
-are committed and diffed.
+…but do not commit those files. Once you're confident the visual change is what
+you want, dispatch the `update_goldens` workflow from the PR branch — it runs
+`melos run update:goldens` on Linux and auto-commits the updated PNGs back to
+the branch as a `chore: Update Goldens` commit. Pull the branch after the
+workflow finishes.
 
 
 ## Naming
@@ -1084,8 +1101,23 @@ If no order is obvious, use:
 8. Read-only properties (other than `hashCode`).
 9. Operators (other than `==`).
 10. Methods (other than `toString` and `build`).
-11. The `build` method.
+11. The `build` method (together with its `_build*` helpers — see below).
 12. `operator ==`, `hashCode`, `toString`, and diagnostics methods.
+
+### Group methods by feature, not by visibility
+
+The list above is a fallback ordering. Within slots 10–11 (`Methods` and
+`build`), group by concept, not by public/private:
+
+- A private helper called by one public method should live directly under that
+  method, not in a separate "private helpers" block at the bottom of the class.
+- Related methods (e.g. all the drag handlers for a sheet, or all the setup
+  helpers used by `initState`) sit as a run.
+- `_build*` helpers used by `build` cluster around it. `build` heads the block,
+  its helpers follow. Don't separate them with unrelated methods.
+
+This matches the existing repo (e.g. `StreamSheet`, `StreamSnackbarMessenger`)
+and keeps a private helper visually close to the code that uses it.
 
 ### Use braces for long function bodies
 
@@ -1232,9 +1264,17 @@ When adding or updating icons:
 
 1. Pull the latest SVGs from `design-system-tokens/assets/icons/` into
    `assets_source/icons/`.
-2. Run `melos run generate:icons` to regenerate the icon font and the `StreamIcons`
-   class.
-3. Commit both the SVG sources and the regenerated font + Dart output together —
+2. If the icon should mirror in RTL layouts, add its base name to the
+   `_rtlIcons` list in `scripts/generate_icons.dart` so the generator emits
+   `matchTextDirection: true` for it. This covers obvious directional glyphs
+   (arrows, chevrons, `reply`, `send`, `sidebar`) but also icons with
+   directional metaphors that read wrong when unmirrored (`audio`, `megaphone`,
+   `search`, `video`). Skip icons that are symmetric or shouldn't mirror
+   (a bell, a heart, brand logos). If in doubt, look at what comparable icons
+   already do in `_rtlIcons`.
+3. Run `melos run generate:icons` to regenerate the icon font and the
+   `StreamIcons` class.
+4. Commit both the SVG sources and the regenerated font + Dart output together —
    they must stay in sync.
 
 Do not edit the generated `StreamIcons.dart` or the icon font by hand.

--- a/TESTING.md
+++ b/TESTING.md
@@ -177,6 +177,26 @@ When writing a test, imagine the developer who will read it six months from now.
 Anything you can do to help that reader understand what and why the test is
 checking is worth doing.
 
+## `group` is for shared preconditions, not for organizing a file
+
+Reach for `group(...)` when several tests share a precondition that's worth
+stating once: "when the widget is in dark mode", "when `textDirection` is RTL",
+"when the button is disabled". The group description names the precondition;
+the test descriptions inside name the behaviors that follow from it.
+
+```dart
+group('when textDirection is RTL', () {
+  testWidgets('StreamAvatar keeps its label on the trailing side', (tester) async { ... });
+  testWidgets('StreamButton mirrors its leading icon', (tester) async { ... });
+});
+```
+
+Do not use `group` to organize a file by widget or method — that's what the
+file itself is for. If a `group` is doing the work a separate file should be
+doing,
+[split the file instead](STYLE_GUIDE.md#prefer-more-test-files-avoid-long-test-files).
+Nested groups more than one level deep are almost always a signal to split.
+
 ## Golden tests are behavioural tests too
 
 Golden tests aren't a shortcut around the four principles above. A golden with a
@@ -201,8 +221,10 @@ goldenTest(
 );
 ```
 
-Regenerate goldens (`melos run update:goldens`) deliberately, in a separate commit
-from behavior changes, so reviewers can see what visually changed.
+Regenerate goldens deliberately, in a separate commit from behavior changes, so
+reviewers can see what visually changed. Prefer the `update_goldens` GitHub
+Action over regenerating locally — see
+[Golden tests in STYLE_GUIDE.md](STYLE_GUIDE.md#golden-tests) for the workflow.
 
 ## See also
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,213 @@
+# Writing effective tests
+
+This guide is about **how to write good tests**, not how to run them or which
+testing tools to use. For repo-level testing conventions (mocking library, golden
+tests, `mocktail`, `alchemist`, self-containment), see the
+[Testing section of STYLE_GUIDE.md](STYLE_GUIDE.md#testing).
+
+This document is adapted from Flutter's
+[Writing-Effective-Tests](https://github.com/flutter/flutter/blob/master/docs/contributing/testing/Writing-Effective-Tests.md).
+
+Tests are a critical tool for stability and education. They fulfill three roles:
+
+- Automatically protect against regressions.
+- Define an executable specification that captures original intent.
+- Educate other developers about why and how to use an API.
+
+To support those roles, four practices matter more than any others.
+
+## Name tests based on the behavior being tested
+
+Tests often get named after the widget or class under test rather than the
+behavior. That communicates nothing to the reader — the class is already visible
+from the file being edited.
+
+```dart
+// BAD — the reader already knows we're testing StreamAvatar.
+testWidgets('StreamAvatar', (tester) async { ... });
+
+// BAD — same problem.
+test('StreamWsClient', () { ... });
+```
+
+Instead, name the test after the behavior or the expected outcome:
+
+```dart
+// GOOD
+testWidgets('StreamAvatar renders initials when image is null', (tester) async { ... });
+
+// GOOD
+testWidgets('StreamAvatar uses the size from theme when size is not overridden', (tester) async { ... });
+
+// GOOD
+test('StreamWsClient reconnects with exponential backoff after connection loss', () { ... });
+```
+
+A reader scanning `flutter test`'s output should be able to tell what broke from
+the test name alone, without opening the file.
+
+## One behavior per test
+
+A single test that exercises multiple behaviors turns a failure report into a
+mystery: is one thing broken, or many?
+
+```dart
+// BAD — this test exercises three behaviors.
+testWidgets('StreamAvatar', (tester) async {
+  await _pumpAvatar(tester, size: StreamAvatarSize.md);
+  expect(find.byType(StreamAvatar), findsOneWidget);
+
+  await _pumpAvatar(tester, size: StreamAvatarSize.lg);
+  expect(tester.getSize(find.byType(StreamAvatar)).width, equals(40.0));
+
+  await _pumpAvatar(tester, size: StreamAvatarSize.md, name: 'Ada');
+  expect(find.text('A'), findsOneWidget);
+});
+```
+
+Split into one behavior per test:
+
+```dart
+// GOOD
+testWidgets('StreamAvatar renders when given no other arguments', (tester) async {
+  await _pumpAvatar(tester);
+
+  expect(find.byType(StreamAvatar), findsOneWidget);
+});
+
+testWidgets('StreamAvatar sizes itself to StreamAvatarSize.lg (40px)', (tester) async {
+  await _pumpAvatar(tester, size: StreamAvatarSize.lg);
+
+  expect(tester.getSize(find.byType(StreamAvatar)).width, equals(40.0));
+});
+
+testWidgets('StreamAvatar renders the first letter of the name when no image', (tester) async {
+  await _pumpAvatar(tester, name: 'Ada');
+
+  expect(find.text('A'), findsOneWidget);
+});
+```
+
+**What counts as "one behavior"?** Usually one action with one assertion. There are
+cases where multiple calls represent a single behavior (e.g. "when the WebSocket
+disconnects and then reconnects, missed frames are re-fetched") — use your
+judgment. A larger number of shorter tests beats a smaller number of longer ones.
+
+## Only include relevant details in a test
+
+Tests often need setup that isn't part of the behavior under test. When that setup
+lives inline, readers can't easily tell which parts of the fixture matter and which
+are noise.
+
+```dart
+// BAD — the setup dwarfs the behavior being tested.
+testWidgets('StreamAvatar renders a fallback icon when name is empty', (tester) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: StreamTheme(
+        data: StreamThemeData.light(),
+        child: const Scaffold(
+          body: Center(
+            child: StreamAvatar(
+              name: '',
+              size: StreamAvatarSize.md,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  expect(find.byType(Icon), findsOneWidget);
+});
+```
+
+Extract the setup into a helper named for its purpose:
+
+```dart
+// GOOD — the test reads as a specification.
+testWidgets('StreamAvatar renders a fallback icon when name is empty', (tester) async {
+  await _pumpAvatar(tester, name: '');
+
+  expect(find.byType(Icon), findsOneWidget);
+});
+```
+
+The helper (`_pumpAvatar`) lives at the bottom of the test file. Its name tells the
+reader what it does; the reader doesn't need to look inside unless something breaks.
+
+## Optimize tests for comprehension
+
+Even a well-factored test benefits from small edits that separate "the thing under
+test" from "the actions we take on it".
+
+```dart
+// OK — but the thing being tested and the action are entangled.
+testWidgets('StreamAvatar honors the size passed as a constructor argument', (tester) async {
+  await _pumpAvatar(
+    tester,
+    size: StreamAvatarSize.lg,
+    name: 'Ada',
+    padding: const EdgeInsets.all(8),
+  );
+
+  expect(tester.getSize(find.byType(StreamAvatar)).width, equals(40.0));
+});
+```
+
+Extract the props and let the test name the two moving parts explicitly:
+
+```dart
+// GOOD — the props are named and the action is a separate line.
+testWidgets('StreamAvatar honors the size passed as a constructor argument', (tester) async {
+  const props = _AvatarProps(size: StreamAvatarSize.lg, name: 'Ada');
+
+  await _pumpAvatar(tester, props: props);
+
+  final width = tester.getSize(find.byType(StreamAvatar)).width;
+  expect(width, equals(40.0));
+});
+```
+
+The difference is small but real: on a scan, the reader sees "here are the props,
+here is the action, here is the assertion" as three separate ideas instead of one
+blob of arguments.
+
+When writing a test, imagine the developer who will read it six months from now.
+Anything you can do to help that reader understand what and why the test is
+checking is worth doing.
+
+## Golden tests are behavioural tests too
+
+Golden tests aren't a shortcut around the four principles above. A golden with a
+name like `StreamAvatar_default` is worse than a plain unit test named
+`StreamAvatar_default` — the golden's failure mode is "pixels changed", not "a
+specific behavior broke", which makes triage harder.
+
+Instead, name goldens after the variant being pinned:
+
+```dart
+// GOOD
+goldenTest(
+  'StreamAvatar renders correctly across every size preset',
+  fileName: 'stream_avatar_sizes',
+  builder: () => ...,
+);
+
+goldenTest(
+  'StreamButton disabled state is dimmed and non-interactive',
+  fileName: 'stream_button_disabled',
+  builder: () => ...,
+);
+```
+
+Regenerate goldens (`melos run update:goldens`) deliberately, in a separate commit
+from behavior changes, so reviewers can see what visually changed.
+
+## See also
+
+- [STYLE_GUIDE.md — Testing](STYLE_GUIDE.md#testing) — repo-level testing
+  conventions (mocktail, alchemist golden tests, self-contained tests,
+  `addTearDown`).
+- Flutter's [Writing-Effective-Tests](https://github.com/flutter/flutter/blob/master/docs/contributing/testing/Writing-Effective-Tests.md)
+  — the source this guide was adapted from.


### PR DESCRIPTION
## Summary

- Adds `STYLE_GUIDE.md` at the repo root — a canonical style guide adapted from [Flutter's repo style guide](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md), reshaped for the design-system + LLC-transport structure of this repo.
- Adds `TESTING.md` at the repo root — a companion doc on **how to write good tests** adapted from Flutter's [Writing-Effective-Tests](https://github.com/flutter/flutter/blob/master/docs/contributing/testing/Writing-Effective-Tests.md).
- Wires `CLAUDE.md` to open with a pointer directing AI agents to read `STYLE_GUIDE.md` before writing or reviewing code, plus a `TESTING.md` link for test-writing tasks.

Mirrors the equivalent PR in [stream-chat-flutter #2793](https://github.com/GetStream/stream-chat-flutter/pull/2793), tuned for this repo's actual conventions.

## What's in STYLE_GUIDE

- **Quick rules** — a scannable checklist near the top with the hard rules (barrel contract, line width, relative imports inside `lib/src/`, private-member commenting, changelog labels, no `InheritedWidget` lookup in `initState`, named boolean parameters, `file_names`, `directives_ordering`).
- **Philosophy** — layering (`stream_core` → `stream_core_flutter`), avoiding secret state, error-message quality, streams as primary reactive primitive for real-time data.
- **Repository structure** — monorepo layout, Melos-managed deps, generated code, and — critically — the **public barrel contract** (`core.dart` vs `chat.dart`, `melos run check:barrels` enforcement).
- **Documentation** — dartdoc conventions, plus repo-specific rules (public docs describe the contract not the implementation, no Flutter internals in comments, private members use `//` not `///`).
- **Coding patterns** — asserts (no message required here — `prefer_asserts_with_message` is disabled), dispose lifecycle, equality boilerplates, dot shorthands, `strict-inference` / `strict-raw-types` implications, no `InheritedWidget` lookup in `initState`, early-return pattern, relative-imports convention.
- **Testing** — self-contained tests, `mocktail`, `alchemist` golden tests, `test/components/<name>/goldens/{ci,macos}` layout. Points at `TESTING.md` for writing-style guidance.
- **Widgets, themes, and design system** — the component/theme/golden/Widgetbook 4-artifact rule, the theme hierarchy (primitives → semantics → components → tokens), `@themeGen` for component themes vs `@ThemeExtensions(constructor: 'raw', ...)` for the root `StreamTheme`, defaults in widget `build` (Flutter's `AppBar`/`TabBar` pattern), icon generation from SVGs.
- **Naming, comments, formatting, commits/PRs/changelogs** — the usual sections, with rules that match verified repo practice.

## What's in TESTING.md

Four principles from Flutter's Writing-Effective-Tests with Stream-Core-flavoured examples using `StreamAvatar`, `StreamAvatarSize`, `StreamMessageBubble`:

1. Name tests based on the behavior being tested, not the object.
2. One behavior per test.
3. Only include relevant details — extract setup into named helpers.
4. Optimize for comprehension — separate "the thing under test" from "the actions on it".
5. Bonus: golden tests are behavioural tests too — name them after the variant being pinned, not the widget.

## Divergences from Flutter's guide

Called out inline every time; the notable ones:

- **Relative imports inside `lib/src/`** — this repo has `always_use_package_imports: false`. Flutter's guide requires `package:` imports; we prefer relative paths inside a package for refactor safety.
- **Bare `// ignore:` directives** and **bare `// TODO:`** (with optional category tag like `TODO(localize):`, not GitHub handles) match repo practice.
- **Assert messages not required** — `prefer_asserts_with_message` is disabled here.
- **Streams as the primary reactive primitive** for WS/RxDart pipelines. Flutter recommends `Listenable`; that reasoning doesn't apply to a real-time transport layer.
- **Private members use `//`, not `///`**.
- **Line width 120**, not 100.

## Verified against the repo before merging

- Root theme class is `StreamTheme` (extends `ThemeExtension<StreamTheme>`) — there is no `StreamThemeData`. Fixed in the guide.
- Component categories list matches `lib/src/components/` (17 categories, not the 10 previously in CLAUDE.md).
- Widgetbook use-cases live under `apps/design_system_gallery/lib/components/`, not `/use_cases/`.
- `StreamAvatarSize` enum values (`xs, sm, md, lg, xl, xxl`) — the switch example uses correct radii.
- No `BetterStreamBuilder` reference (that class lives in `stream-chat-flutter`, not here).
- TESTING.md examples use only real APIs (`StreamAvatar`, `StreamAvatarSize`, `StreamMessageBubble`, `StreamWsClient`).
- Changelog labels (`### ✨ Features`, `### 🐛 Bug Fixes`, `### 🛑 Breaking / Removals`) match current package changelogs, with grandfathered `### 🐞 Fixed` / `### 💥 BREAKING CHANGES` noted.
- Theming section describes `@themeGen` for component themes and `@ThemeExtensions(constructor: 'raw', ...)` for the root — verified against `stream_theme.dart` and `stream_avatar_theme.dart`.
- Extension-methods section distinguishes domain-typed collections (fine) from unconstrained-type extensions (avoid new ones).

## Test plan

- [ ] Skim the "Quick rules" section — every bullet links to its full section below.
- [ ] Read `TESTING.md` end-to-end — it's short (~210 lines).
- [ ] Verify divergences from Flutter's guide match your read of current repo practice.
- [ ] Confirm the barrel-contract wording matches your `check_barrels.yaml` intent.
- [ ] Suggest anything missing (a rule you rely on that isn't captured, an example that would help).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a repository style guide defining Dart/Flutter/Widgetbook conventions, public API boundaries, documentation expectations, formatting/process rules, and detailed design-system implementation requirements.
  * Added comprehensive testing guidance focused on behavior-driven, readable, and maintainable tests, including best practices for structuring assertions and golden tests.
  * Updated contributor instructions to direct readers to the style guide as the source of truth for repo coding conventions and related policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->