### PR TITLE
feat(ui): composer & design-system a11y pass

### DIFF
--- a/.claude/skills/flutter-a11y/SKILL.md
+++ b/.claude/skills/flutter-a11y/SKILL.md
@@ -262,13 +262,13 @@ await expectLater(tester, meetsGuideline(textContrastGuideline));       // ≥4.
 
 | Matcher | Behavior | When to use |
 |---|---|---|
-| `containsSemantics(...)` | Subset — only specified properties checked; allows extras | **Default for most tests.** Survives SDK upgrades that add new flags. |
-| `matchesSemantics(...)` | Exhaustive — every parameter checked, unspecified MUST be absent | When you want to lock down a precise spec. Brittle to Flutter SDK additions. |
-| `isSemantics(...)` | Strict (Flutter 3.43+ replacement for `matchesSemantics`) | Same use case as `matchesSemantics`; preferred for new code. |
+| `containsSemantics(...)` | Subset — only specified properties checked; allows extras. **`@Deprecated` in Flutter 3.41+**, replaced by `isSemantics`. | Legacy code. Prefer `isSemantics` on any repo pinned to Flutter 3.41 or later. |
+| `matchesSemantics(...)` | Exhaustive — every parameter checked, unspecified MUST be absent. | When you want to lock down a precise spec. Brittle to Flutter SDK additions. |
+| `isSemantics(...)` | Subset — same behavior as `containsSemantics`, updated naming (Flutter 3.41+). | **Default for most tests.** Survives SDK upgrades that add new flags. |
 | `includesNodeWith(...)` | "Some node in the tree matches" | Existence checks ("there's a node labeled 'Alert' with `namesRoute` flag"). |
 | `meetsGuideline(...)` | Guideline-level | Tap targets, contrast, label presence. |
 
-> ⚠️ `TestSemantics`/`SemanticsTester`/`hasSemantics(TestSemantics.root(...))` are **`@Deprecated` (Flutter 3.43+)**. Don't reach for full-tree-shape assertions in new tests — they break on every SDK change. Use `containsSemantics`/`isSemantics` against `tester.semantics.find(finder)` or `tester.getSemantics(finder)` instead.
+> ⚠️ `TestSemantics`/`SemanticsTester`/`hasSemantics(TestSemantics.root(...))` are **`@Deprecated`**. Don't reach for full-tree-shape assertions in new tests — they break on every SDK change. Use `isSemantics` (or `containsSemantics` on older SDKs) against `tester.semantics.find(finder)` or `tester.getSemantics(finder)` instead.
 
 ### Inspecting a single node
 

--- a/.claude/skills/flutter-a11y/SKILL.md
+++ b/.claude/skills/flutter-a11y/SKILL.md
@@ -80,6 +80,60 @@ Semantics(
 
 Without `explicitChildNodes`, children merge into the container and lose individual access.
 
+### Re-emitting semantics on a custom chassis
+
+When you wrap an inner widget that auto-emits its own semantics (most commonly `EditableText` / `TextField`, but also `Image`, `Switch`, framework chips) inside a chassis with chrome — border, leading/trailing slots, helper text — the inner widget's semantic node lives at *its* bounds, not the chassis bounds. Screen-reader focus lands on the inner editable area only and the chrome is invisible to the SR.
+
+The fix is to **replace** the inner's semantics rather than merge with them: suppress the inner's auto-emitted node and re-emit a full semantic node on the outer chassis.
+
+```dart
+return Semantics(
+  container: true,
+  explicitChildNodes: true,
+  textField: true,                       // mirror the inner widget's role
+  enabled: enabled,
+  readOnly: readOnly,
+  focused: focusNode.hasFocus,
+  label: value.isEmpty ? hintText : null,
+  value: value,
+  hint: errorText,                       // surface validation errors
+  maxValueLength: maxLength,
+  currentValueLength: value.length,
+  onTap: (enabled && !readOnly) ? focusNode.requestFocus : null,
+  onFocus: enabled ? focusNode.requestFocus : null,
+  child: ChassisFrame(
+    leading: leadingWidget,
+    trailing: trailingWidget,
+    child: ExcludeSemantics(child: innerEditable),
+  ),
+);
+```
+
+Why each piece matters:
+
+- `container: true` — the chassis becomes the semantic node, at the chassis's visible bounds.
+- `explicitChildNodes: true` — interactive leading / trailing widgets stay individually focusable instead of merging into the chassis.
+- `ExcludeSemantics(child: inner)` — drops the inner widget's redundant duplicate node.
+- Every a11y property the inner would have provided (`textField`, `value`, `maxValueLength`, etc.) is re-emitted manually on the chassis.
+
+Don't reach for `MergeSemantics` for this case — it absorbs interactive leading / trailing widgets too. Don't omit `container: true` — without it the outer `Semantics` decorates whatever ancestor container exists, not the chassis bounds.
+
+### Logical traversal order in RTL
+
+A `Row` of `[leading, content, trailing]` widgets renders trailing-on-the-left visually in an RTL text direction. Without a sort key, screen readers walk siblings by visual position — so in RTL they read trailing before leading, the wrong order for a left-to-right logical flow.
+
+Force logical order with `OrdinalSortKey`:
+
+```dart
+Row(children: [
+  Semantics(sortKey: const OrdinalSortKey(0), child: leading),
+  Expanded(child: content),
+  Semantics(sortKey: const OrdinalSortKey(2), child: trailing),
+])
+```
+
+`OrdinalSortKey` is sibling-relative — lower values come first regardless of layout direction. Apply only where visual and logical orders diverge; sprinkling it everywhere fights the platform's default traversal.
+
 ### Focus management
 
 Prefer `autofocus:` over plumbing FocusNodes when the use case fits:
@@ -93,7 +147,29 @@ IconButton(autofocus: isSelected, ...)      // for the current tab/option in a t
 
 For design-system widgets that have a "selected" or "current" notion (tab buttons, segmented controls, radio chips), accept an `autofocus` param and forward it to the inner focusable. Don't force consumers to plumb FocusNodes for the common case.
 
-Gate SR-specific behavior with `MediaQuery.accessibleNavigationOf(context)`.
+### Gating SR-specific behavior
+
+`MediaQuery.accessibleNavigationOf(context)` returns `true` when a screen reader (TalkBack / VoiceOver / Switch Control / comparable AT) is active. Use it to *adapt* UI to SR users — not to add a parallel SR-only code path.
+
+Common adaptations:
+
+- **Skip transient animations.** When a snackbar / banner / toast fades in over 250ms while the SR announces its content, the announcement and the visible state diverge. Jump the animation to its terminal value so the SR experience matches what sighted users see at the end of the fade. This mirrors `ScaffoldMessenger`'s own pattern:
+
+  ```dart
+  if (MediaQuery.accessibleNavigationOf(context)) {
+    _animation.value = 1; // entry: skip to fully visible
+  } else {
+    _animation.forward(from: 0);
+  }
+  ```
+
+  And likewise on exit (`_animation.value = 0` instead of `_animation.reverse()`).
+
+- **Extend or remove auto-dismiss timers.** A 4-second snackbar may not give an SR user enough time to read it; a 10-second timeout (or manual-dismiss-only) is safer when SR is active.
+
+- **Promote swipe-only affordances to discoverable actions.** Sighted users get swipe-to-dismiss; SR users need an explicit dismiss action. Expose `Semantics(onDismiss: ...)` so VoiceOver / TalkBack get a discoverable handler.
+
+Don't subscribe to `accessibleNavigationOf` inside list items or other widgets that rebuild frequently — toggling SR re-renders every subscriber. Subscribe only in components that actually swap behavior based on SR state.
 
 ### Modal sheets & dialogs
 
@@ -163,6 +239,25 @@ The critical distinction: `liveRegion: true` dedupes on string identity (correct
    Chrome DevTools → Elements tab → "Accessibility" sub-tab shows the exported ARIA tree.
 
 6. **On Android, TalkBack may fail to focus content rendered outside its parent's measured bounds.** Android's accessibility framework uses each view's `getBoundsInScreen()` for hit testing. If a Flutter `Stack` child overflows the Stack via `Positioned` with offsets that exceed the parent's bounds, the visual rendering can look fine while TalkBack reports degenerate bounds and can't focus the content. Most Flutter overlays (via `Overlay`/`OverlayPortal`) mount into the Navigator's full-screen overlay and aren't affected — but a `Stack`-with-overflow in a small parent (e.g., a tooltip-like popover inside a 48dp button row) can hit this. If you suspect it, dump the a11y tree with `uiautomator dump` (see Debugging section) and look for `bounds="[x,y][x,y]"` with `top > bottom` — that's the symptom. Fix by mounting the overlay in a taller ancestor (use `Overlay.of(context)` rather than a local `Stack`).
+
+7. **`Semantics(container: false)` merges *upward* into ancestor containers, not downward into descendant containers.** This is the most-misremembered semantic rule, and it makes "wrap from the outside" feel like it should work when it doesn't. The framework dartdoc spells it out: `'If [container] is true, this widget will introduce a new node in the semantics tree. Otherwise, the semantics will be merged with the semantics of any ancestors (if the ancestor allows that)'`. To decorate a *descendant* interactive widget (e.g. `ElevatedButton`'s built-in `Semantics(container: true, button: true)` node, or any custom widget that establishes its own container) with extra properties like `selected:`, the decorating `Semantics` must be placed *inside* the descendant — typically as its `child:` — not wrapping it from above. Concrete:
+
+   ```dart
+   // ✓ selected: lands on ElevatedButton's semantic node
+   ElevatedButton(
+     onPressed: onPressed,
+     child: Semantics(selected: isSelected, child: label),
+   )
+
+   // ✗ selected: floats up to the ambient Scaffold/Material instead;
+   //   the button itself has no isSelected flag.
+   Semantics(
+     selected: isSelected,
+     child: ElevatedButton(onPressed: onPressed, child: label),
+   )
+   ```
+
+   The "if the ancestor allows that" caveat refers to `explicitChildNodes`: an ancestor `Semantics(container: true, explicitChildNodes: true)` blocks descendants' `container: false` configs from merging in, forcing them to introduce their own nodes. The same rule applies to any `container: false` decorator (`Tooltip` semantics, custom `hint:`/`label:` overrides) wrapping a `container: true` widget. If you genuinely need to wrap from the outside, set `container: true` on your wrapper so it becomes its own node — but then you lose the merge-into-descendant behavior and pick up the wrapper's bounds instead of the inner widget's.
 
 ### Anti-patterns to avoid
 
@@ -277,16 +372,20 @@ This pins the announcement-on-action contract — pickers, mention overlays, err
 
 ### Simulating a screen-reader-triggered action
 
-To verify the SR-driven activation path (which can differ from finger-tap, especially for desktop `TextField` focus):
+To verify the SR-driven activation path (which can differ from finger-tap — desktop `TextField` focus, semantic dismiss handlers, custom `onTap` on a non-tappable widget, etc.), use the higher-level `tester.semantics.performAction`:
 
 ```dart
-tester.platformDispatcher.onSemanticsActionEvent!(SemanticsActionEvent(
-  type: SemanticsAction.tap,
-  viewId: tester.view.viewId,
-  nodeId: tester.semantics.find(find.byType(MyWidget)).id,
-));
+tester.semantics.performAction(
+  find.semantics.byLabel('Email'),
+  SemanticsAction.tap,
+);
 await tester.pumpAndSettle();
+expect(focusNode.hasFocus, isTrue);
 ```
+
+`find.semantics.byLabel(...)` returns a `SemanticsFinder`. For other lookups use `find.semantics.byPredicate(...)`, or convert from a widget finder via `tester.semantics.find(widgetFinder)`.
+
+The lower-level `tester.platformDispatcher.onSemanticsActionEvent!` route still works but requires manually constructing a `SemanticsActionEvent` with a node ID and view ID — prefer the higher-level API for new tests.
 
 ### Validating `Semantics(role: ...)` configuration
 

--- a/.claude/skills/flutter-a11y/SKILL.md
+++ b/.claude/skills/flutter-a11y/SKILL.md
@@ -41,7 +41,7 @@ When adding a new component to the design system or modifying an existing one, t
 - **For icon-only widgets, expose a label parameter.** Either a `tooltip:` (matches `IconButton`) or a `semanticLabel:` (matches `Icon`). Either is acceptable; pick one and be consistent across the library.
 - **Place internal `Semantics` / `Tooltip` widgets inside the component, not as the wrapper around it.** This matters especially for `ButtonStyleButton` subclasses (Elevated/Text/Outlined/Filled) — their outer `Semantics(container: true)` blocks ancestor merging. The component itself should wrap the child below that boundary.
 - **Internal MergeSemantics for composite chrome.** If your component renders bordered chrome around an inner editable widget (a text input with leading/trailing icons; a card with an avatar), wrap the chassis in `MergeSemantics` so consumers see one focus region matching the visible bounds — not the inner editable area alone.
-- **Preserve a11y across customization.** If your component supports a factory / builder / override pattern (e.g., `StreamComponentFactory`-style), the default implementation must be accessible. Document which `Semantics` properties a custom implementation must preserve to keep parity. A consumer overriding your button should not silently lose tooltip behavior.
+- **Preserve a11y across customization.** If your component supports a factory / builder / override pattern (custom child builders, `WidgetBuilder`-style hooks, replaceable sub-slots), the default implementation must be accessible and the docs should call out which `Semantics` properties a custom implementation must preserve to keep parity. A consumer overriding your button should not silently lose tooltip behavior.
 - **Test the component's a11y in isolation.** A regression in the design system breaks every consumer. The component's tests should hold the line — see *Auditing accessibility* below.
 - **Document a11y behavior in the component dartdoc.** Public APIs that affect a11y (`tooltip:`, `autofocus:`, `isSelected:`, `semanticLabel:`) should call out the effect — "Used as the visual tooltip and as the screen-reader accessibility label" — so consumers don't have to read source.
 
@@ -80,59 +80,28 @@ Semantics(
 
 Without `explicitChildNodes`, children merge into the container and lose individual access.
 
-### Re-emitting semantics on a custom chassis
+### Role-annotation vs. container wrapping
 
-When you wrap an inner widget that auto-emits its own semantics (most commonly `EditableText` / `TextField`, but also `Image`, `Switch`, framework chips) inside a chassis with chrome — border, leading/trailing slots, helper text — the inner widget's semantic node lives at *its* bounds, not the chassis bounds. Screen-reader focus lands on the inner editable area only and the chrome is invisible to the SR.
-
-The fix is to **replace** the inner's semantics rather than merge with them: suppress the inner's auto-emitted node and re-emit a full semantic node on the outer chassis.
+For a widget that only needs to carry a semantic *role* (`tabPanel`, `list`, `search`, `alert`), pass the role as an annotation on a non-container `Semantics`; don't reach for `container: true` reflexively.
 
 ```dart
-return Semantics(
+// ✓ Matches Flutter's own TabBarView — role attaches to the panel content's
+//   existing semantic node, no extra SR stop introduced.
+Semantics(role: SemanticsRole.tabPanel, child: panelContent)
+
+// ✗ Introduces a separate SR stop announcing the panel-level label before
+//   the user can reach panel content. If the tab bar already announced
+//   "Poll tab, selected", the second announcement is redundant.
+Semantics(
   container: true,
   explicitChildNodes: true,
-  textField: true,                       // mirror the inner widget's role
-  enabled: enabled,
-  readOnly: readOnly,
-  focused: focusNode.hasFocus,
-  label: value.isEmpty ? hintText : null,
-  value: value,
-  hint: errorText,                       // surface validation errors
-  maxValueLength: maxLength,
-  currentValueLength: value.length,
-  onTap: (enabled && !readOnly) ? focusNode.requestFocus : null,
-  onFocus: enabled ? focusNode.requestFocus : null,
-  child: ChassisFrame(
-    leading: leadingWidget,
-    trailing: trailingWidget,
-    child: ExcludeSemantics(child: innerEditable),
-  ),
-);
+  role: SemanticsRole.tabPanel,
+  label: tabTitle,
+  child: panelContent,
+)
 ```
 
-Why each piece matters:
-
-- `container: true` — the chassis becomes the semantic node, at the chassis's visible bounds.
-- `explicitChildNodes: true` — interactive leading / trailing widgets stay individually focusable instead of merging into the chassis.
-- `ExcludeSemantics(child: inner)` — drops the inner widget's redundant duplicate node.
-- Every a11y property the inner would have provided (`textField`, `value`, `maxValueLength`, etc.) is re-emitted manually on the chassis.
-
-Don't reach for `MergeSemantics` for this case — it absorbs interactive leading / trailing widgets too. Don't omit `container: true` — without it the outer `Semantics` decorates whatever ancestor container exists, not the chassis bounds.
-
-### Logical traversal order in RTL
-
-A `Row` of `[leading, content, trailing]` widgets renders trailing-on-the-left visually in an RTL text direction. Without a sort key, screen readers walk siblings by visual position — so in RTL they read trailing before leading, the wrong order for a left-to-right logical flow.
-
-Force logical order with `OrdinalSortKey`:
-
-```dart
-Row(children: [
-  Semantics(sortKey: const OrdinalSortKey(0), child: leading),
-  Expanded(child: content),
-  Semantics(sortKey: const OrdinalSortKey(2), child: trailing),
-])
-```
-
-`OrdinalSortKey` is sibling-relative — lower values come first regardless of layout direction. Apply only where visual and logical orders diverge; sprinkling it everywhere fights the platform's default traversal.
+Rule of thumb: if the descendant already establishes its own container (typical for interactive widgets), a role-only wrapper is enough. Reach for `container: true, explicitChildNodes: true` only when you need the wrapper itself to be a distinct orientation stop with its own label.
 
 ### Focus management
 
@@ -147,29 +116,26 @@ IconButton(autofocus: isSelected, ...)      // for the current tab/option in a t
 
 For design-system widgets that have a "selected" or "current" notion (tab buttons, segmented controls, radio chips), accept an `autofocus` param and forward it to the inner focusable. Don't force consumers to plumb FocusNodes for the common case.
 
-### Gating SR-specific behavior
+Gate SR-specific behavior with `MediaQuery.accessibleNavigationOf(context)`.
 
-`MediaQuery.accessibleNavigationOf(context)` returns `true` when a screen reader (TalkBack / VoiceOver / Switch Control / comparable AT) is active. Use it to *adapt* UI to SR users — not to add a parallel SR-only code path.
+### `FocusTraversalGroup` is for keyboards, not screen readers
 
-Common adaptations:
+Common misconception: `FocusTraversalGroup` does *not* control screen-reader traversal order. Its dartdoc is explicit — "the policy used to move the focus from one focus node to another when traversing them using a keyboard." Internally the widget wraps its child in a `Focus(includeSemantics: false, …)`, so it contributes nothing to the semantic tree.
 
-- **Skip transient animations.** When a snackbar / banner / toast fades in over 250ms while the SR announces its content, the announcement and the visible state diverge. Jump the animation to its terminal value so the SR experience matches what sighted users see at the end of the fade. This mirrors `ScaffoldMessenger`'s own pattern:
+Two separate trees; only one is walked by SR gestures:
 
-  ```dart
-  if (MediaQuery.accessibleNavigationOf(context)) {
-    _animation.value = 1; // entry: skip to fully visible
-  } else {
-    _animation.forward(from: 0);
-  }
-  ```
+| Tree | Built from | Traversed by |
+|---|---|---|
+| Focus | `Focus` / `FocusScope` / `FocusTraversalGroup` | Keyboard Tab, arrow keys |
+| Semantics | `Semantics` widget | TalkBack / VoiceOver swipe gestures |
 
-  And likewise on exit (`_animation.value = 0` instead of `_animation.reverse()`).
+To reorder SR traversal, use `Semantics(sortKey: OrdinalSortKey(...))` on siblings, restructure the widget tree, or use `Semantics(container: true)` grouping — not `FocusTraversalGroup`.
 
-- **Extend or remove auto-dismiss timers.** A 4-second snackbar may not give an SR user enough time to read it; a 10-second timeout (or manual-dismiss-only) is safer when SR is active.
+### Programmatic focus dispatch (`FocusSemanticEvent`)
 
-- **Promote swipe-only affordances to discoverable actions.** Sighted users get swipe-to-dismiss; SR users need an explicit dismiss action. Expose `Semantics(onDismiss: ...)` so VoiceOver / TalkBack get a discoverable handler.
+`RenderObject.sendSemanticsEvent(const FocusSemanticEvent())` moves the SR reading cursor onto a specific node. Use it for the narrow case where the platform's automatic focus decision on route/modal entry isn't the element the user needs to interact with (e.g., landing focus on the primary input rather than the toolbar's first button). For everything else, prefer declarative Semantics (`autofocus:`, `scopesRoute: true`, `namesRoute: true`) which the platform handles more reliably.
 
-Don't subscribe to `accessibleNavigationOf` inside list items or other widgets that rebuild frequently — toggling SR re-renders every subscriber. Subscribe only in components that actually swap behavior based on SR state.
+One constraint to know: **`onDidGainAccessibilityFocus` does not fire from these dispatches.** The callback fires only when the platform SR service explicitly acquires focus via `ACTION_ACCESSIBILITY_FOCUS` (user-initiated navigation). A programmatic `FocusSemanticEvent` moves the cursor but doesn't round-trip back through the callback, so it isn't usable as an "early stop" signal for retry loops.
 
 ### Modal sheets & dialogs
 
@@ -239,25 +205,6 @@ The critical distinction: `liveRegion: true` dedupes on string identity (correct
    Chrome DevTools → Elements tab → "Accessibility" sub-tab shows the exported ARIA tree.
 
 6. **On Android, TalkBack may fail to focus content rendered outside its parent's measured bounds.** Android's accessibility framework uses each view's `getBoundsInScreen()` for hit testing. If a Flutter `Stack` child overflows the Stack via `Positioned` with offsets that exceed the parent's bounds, the visual rendering can look fine while TalkBack reports degenerate bounds and can't focus the content. Most Flutter overlays (via `Overlay`/`OverlayPortal`) mount into the Navigator's full-screen overlay and aren't affected — but a `Stack`-with-overflow in a small parent (e.g., a tooltip-like popover inside a 48dp button row) can hit this. If you suspect it, dump the a11y tree with `uiautomator dump` (see Debugging section) and look for `bounds="[x,y][x,y]"` with `top > bottom` — that's the symptom. Fix by mounting the overlay in a taller ancestor (use `Overlay.of(context)` rather than a local `Stack`).
-
-7. **`Semantics(container: false)` merges *upward* into ancestor containers, not downward into descendant containers.** This is the most-misremembered semantic rule, and it makes "wrap from the outside" feel like it should work when it doesn't. The framework dartdoc spells it out: `'If [container] is true, this widget will introduce a new node in the semantics tree. Otherwise, the semantics will be merged with the semantics of any ancestors (if the ancestor allows that)'`. To decorate a *descendant* interactive widget (e.g. `ElevatedButton`'s built-in `Semantics(container: true, button: true)` node, or any custom widget that establishes its own container) with extra properties like `selected:`, the decorating `Semantics` must be placed *inside* the descendant — typically as its `child:` — not wrapping it from above. Concrete:
-
-   ```dart
-   // ✓ selected: lands on ElevatedButton's semantic node
-   ElevatedButton(
-     onPressed: onPressed,
-     child: Semantics(selected: isSelected, child: label),
-   )
-
-   // ✗ selected: floats up to the ambient Scaffold/Material instead;
-   //   the button itself has no isSelected flag.
-   Semantics(
-     selected: isSelected,
-     child: ElevatedButton(onPressed: onPressed, child: label),
-   )
-   ```
-
-   The "if the ancestor allows that" caveat refers to `explicitChildNodes`: an ancestor `Semantics(container: true, explicitChildNodes: true)` blocks descendants' `container: false` configs from merging in, forcing them to introduce their own nodes. The same rule applies to any `container: false` decorator (`Tooltip` semantics, custom `hint:`/`label:` overrides) wrapping a `container: true` widget. If you genuinely need to wrap from the outside, set `container: true` on your wrapper so it becomes its own node — but then you lose the merge-into-descendant behavior and pick up the wrapper's bounds instead of the inner widget's.
 
 ### Anti-patterns to avoid
 
@@ -372,20 +319,16 @@ This pins the announcement-on-action contract — pickers, mention overlays, err
 
 ### Simulating a screen-reader-triggered action
 
-To verify the SR-driven activation path (which can differ from finger-tap — desktop `TextField` focus, semantic dismiss handlers, custom `onTap` on a non-tappable widget, etc.), use the higher-level `tester.semantics.performAction`:
+To verify the SR-driven activation path (which can differ from finger-tap, especially for desktop `TextField` focus):
 
 ```dart
-tester.semantics.performAction(
-  find.semantics.byLabel('Email'),
-  SemanticsAction.tap,
-);
+tester.platformDispatcher.onSemanticsActionEvent!(SemanticsActionEvent(
+  type: SemanticsAction.tap,
+  viewId: tester.view.viewId,
+  nodeId: tester.semantics.find(find.byType(MyWidget)).id,
+));
 await tester.pumpAndSettle();
-expect(focusNode.hasFocus, isTrue);
 ```
-
-`find.semantics.byLabel(...)` returns a `SemanticsFinder`. For other lookups use `find.semantics.byPredicate(...)`, or convert from a widget finder via `tester.semantics.find(widgetFinder)`.
-
-The lower-level `tester.platformDispatcher.onSemanticsActionEvent!` route still works but requires manually constructing a `SemanticsActionEvent` with a node ID and view ID — prefer the higher-level API for new tests.
 
 ### Validating `Semantics(role: ...)` configuration
 

--- a/.claude/skills/flutter-a11y/SKILL.md
+++ b/.claude/skills/flutter-a11y/SKILL.md
@@ -1,0 +1,423 @@
+---
+name: flutter-a11y
+description: >
+  Apply when adding or modifying Flutter accessibility (a11y) in a design system or reusable component library —
+  Semantics widget properties, MergeSemantics, ExcludeSemantics, SemanticsRole, focus management, screen reader
+  announcements (one-shot vs live regions), and accessibility testing (meetsGuideline, tester.semantics.find,
+  custom widget semantics). Use whenever building a new component, exposing a11y parameters (tooltip / autofocus /
+  semanticLabel) on a public API, or wiring Semantics inside a reusable widget. Also applies to debugging
+  "TalkBack focus / announcement / role is wrong" issues by dumping the semantics tree.
+---
+
+# flutter-a11y
+
+Directive shortlist for Flutter accessibility work in a design system / reusable component library. Organized as a workflow: how to **manage** semantics when writing components, how to **audit** them with tests, and how to **debug** the semantics tree when something is wrong.
+
+## Contents
+
+- [Core principle](#core-principle)
+- [Managing semantics](#managing-semantics)
+- [Auditing accessibility](#auditing-accessibility)
+- [Debugging the semantics tree](#debugging-the-semantics-tree)
+- [When in doubt](#when-in-doubt)
+
+## Core principle
+
+**One focus stop per interactive element.** Don't merge interactive children together. Don't leave decorative elements as separate focus stops. Use a container label for orientation, but keep children individually focusable.
+
+**For design system components specifically:** consumers should get correct a11y *by default*. They shouldn't have to wrap your widget with `Semantics(...)` or remember to pass labels for the common case. Bake a11y in.
+
+---
+
+## Managing semantics
+
+How to wire accessibility into Flutter widgets correctly the first time. Pick the right primitive, place wrappers in the right position, avoid the common pitfalls.
+
+### Building accessible components
+
+When adding a new component to the design system or modifying an existing one, the goal is **accessibility by default** — consumers using the public API correctly should produce a screen-reader-friendly result without extra work.
+
+- **Mirror Flutter's standard widget API for a11y parameters.** Match `IconButton.tooltip`, `ElevatedButton.autofocus`, `Image.semanticLabel`, `Text.semanticsLabel`, `Tooltip.message`. Consumers already know these names; gratuitous renaming creates friction.
+- **For icon-only widgets, expose a label parameter.** Either a `tooltip:` (matches `IconButton`) or a `semanticLabel:` (matches `Icon`). Either is acceptable; pick one and be consistent across the library.
+- **Place internal `Semantics` / `Tooltip` widgets inside the component, not as the wrapper around it.** This matters especially for `ButtonStyleButton` subclasses (Elevated/Text/Outlined/Filled) — their outer `Semantics(container: true)` blocks ancestor merging. The component itself should wrap the child below that boundary.
+- **Internal MergeSemantics for composite chrome.** If your component renders bordered chrome around an inner editable widget (a text input with leading/trailing icons; a card with an avatar), wrap the chassis in `MergeSemantics` so consumers see one focus region matching the visible bounds — not the inner editable area alone.
+- **Preserve a11y across customization.** If your component supports a factory / builder / override pattern (e.g., `StreamComponentFactory`-style), the default implementation must be accessible. Document which `Semantics` properties a custom implementation must preserve to keep parity. A consumer overriding your button should not silently lose tooltip behavior.
+- **Test the component's a11y in isolation.** A regression in the design system breaks every consumer. The component's tests should hold the line — see *Auditing accessibility* below.
+- **Document a11y behavior in the component dartdoc.** Public APIs that affect a11y (`tooltip:`, `autofocus:`, `isSelected:`, `semanticLabel:`) should call out the effect — "Used as the visual tooltip and as the screen-reader accessibility label" — so consumers don't have to read source.
+
+### Quick decisions
+
+| Need | Use |
+|---|---|
+| Label an icon-only button | `IconButton(tooltip: ..., onPressed: ..., icon: ...)` — `tooltip` becomes both visual tooltip and a11y label. For your own icon-button widgets, expose the same `tooltip:` parameter. |
+| Label a text button | The child `Text` is the label. No tooltip needed. (`ElevatedButton`/`TextButton`/`OutlinedButton`) |
+| Override a11y label without changing visible text | `Text(text, semanticsLabel: ...)` or `Icon(icon, semanticLabel: ...)` |
+| Make a composite widget one accessible region | `MergeSemantics(child: ...)` |
+| Exclude a decorative icon from a11y tree | `ExcludeSemantics(child: ...)` |
+| Add an orientation label to a region | `Semantics(container: true, explicitChildNodes: true, label: ..., child: ...)` |
+| Announce one-shot event | `SemanticsService.sendAnnouncement(View.of(context), msg, Directionality.of(context))` |
+| Auto-announce on value change | `Semantics(liveRegion: true, child: ...)` |
+| Tab/toggle selected state | `Semantics(selected: true, ...)` |
+| Hint about activation behavior | `Semantics(hint: ..., child: ...)` |
+| Assign an explicit role (Flutter 3.27+) | `Semantics(role: SemanticsRole.list, child: ...)` — newer API; complements the boolean-flag style (`button: true`, `header: true`). Available roles include `list`, `listItem`, `button`, `link`, `tab`, `tabPanel`, `menu`, `menuItem`, `radioGroup`, `radio`, etc. Use when boolean flags don't cover the semantic. |
+| Tap target ≥ 48dp | Material defaults handle it; check with `meetsGuideline(androidTapTargetGuideline)` |
+
+### Container regions
+
+For a logical UI section that should announce itself when entered (e.g., a toolbar, a settings group, a navigation rail):
+
+```dart
+Semantics(
+  container: true,
+  explicitChildNodes: true,
+  label: 'Toolbar',
+  child: Row(children: [...]),
+)
+```
+
+- `container: true` — creates the orientation node carrying the label.
+- `explicitChildNodes: true` — children remain individually focusable.
+
+Without `explicitChildNodes`, children merge into the container and lose individual access.
+
+### Focus management
+
+Prefer `autofocus:` over plumbing FocusNodes when the use case fits:
+
+```dart
+TextField(autofocus: true)                  // initial focus on mount
+IconButton(autofocus: isSelected, ...)      // for the current tab/option in a tab strip
+```
+
+`autofocus` only fires on first mount — perfect for "focus when a new subtree appears" (pickers, dialogs, freshly-opened regions).
+
+For design-system widgets that have a "selected" or "current" notion (tab buttons, segmented controls, radio chips), accept an `autofocus` param and forward it to the inner focusable. Don't force consumers to plumb FocusNodes for the common case.
+
+Gate SR-specific behavior with `MediaQuery.accessibleNavigationOf(context)`.
+
+### Modal sheets & dialogs
+
+```dart
+showModalBottomSheet(
+  context: context,
+  barrierLabel: 'Error',  // ← TalkBack announces when modal appears
+  builder: (_) => MySheet(),
+);
+
+// Inside the sheet:
+Semantics(header: true, child: Text('Title', style: textTheme.headingMd))
+```
+
+Flutter handles focus trap and return-focus for `showModalBottomSheet`/`showDialog` automatically.
+
+For inline dismissable panels (not modals), use `PopScope` to intercept system back:
+
+```dart
+PopScope(
+  canPop: !_isPickerVisible,
+  onPopInvokedWithResult: (didPop, _) {
+    if (!didPop) _hidePicker();
+  },
+  child: ...,
+)
+```
+
+### Announcement patterns — choose the right one
+
+Three distinct shapes; mixing them up causes either silent failures or announcement spam.
+
+| Pattern | When to use | API |
+|---|---|---|
+| **One-shot event** — fires on a discrete action that happened (picker opened, attachment added, error appeared). No deduplication; the same call always announces. | Picker open/close, item added, error appeared, action confirmed. | `SemanticsService.sendAnnouncement(View.of(context), msg, Directionality.of(context))` |
+| **State-change with dedup** — content changes; should announce on each *string* change, but consecutive calls with the same message should not re-announce. | A status indicator that updates (`"AI is typing"` → `"AI is generating"`); upload progress label changes. | Wrap in `Semantics(liveRegion: true)`. Flutter dedupes consecutive identical strings. |
+| **Reshow-on-visible** — a transient surface that appears/disappears repeatedly; each *show* should re-announce (different from string-change dedup). | Replying-to preview, autocomplete suggestions, snackbars that may reappear with the same message. | Trigger `sendAnnouncement` on every `false → true` visibility transition. Don't rely on `liveRegion: true` (which dedupes identical strings across show/hide cycles). |
+
+The critical distinction: `liveRegion: true` dedupes on string identity (correct for state changes), `sendAnnouncement` on every visibility flip is correct for transient reshows. They're not interchangeable.
+
+### Pitfalls to check before writing
+
+1. **`MergeSemantics` absorbs ALL descendants, interactive ones included.** Don't wrap a Row of multiple buttons in MergeSemantics — they collapse into one focus stop, losing individual access. Only use when descendants are decorative or share a single semantic action.
+
+2. **`SemanticsService.announce` is deprecated.** Use `SemanticsService.sendAnnouncement(view, message, textDirection)` — multi-window safe.
+
+3. **`Semantics(hint:)` is user-disable-able.** Never put critical info in hints. Critical info goes in `label:` or `value:`.
+
+4. **Focusing a `TextField`'s FocusNode opens the IME.** There is no clean Flutter API to focus an editable text field without the keyboard. Workarounds (`readOnly`, `keyboardType: TextInputType.none`) make the field non-editable. Accept the keyboard opening, or focus a non-TextField parent if you need "focus the area without keyboard."
+
+5. **Flutter Web's semantics tree is disabled by default** for performance. The DOM only includes the invisible `aria-label="Enable accessibility"` button until the user activates it — assistive tech users won't get a11y info otherwise. If shipping for web, either tell users about the button, or force semantics on programmatically:
+
+   ```dart
+   import 'package:flutter/foundation.dart';
+   import 'package:flutter/semantics.dart';
+
+   void main() {
+     if (kIsWeb) SemanticsBinding.instance.ensureSemantics();
+     runApp(const MyApp());
+   }
+   ```
+
+   To visualize web semantics during development:
+   ```
+   flutter run -d chrome --profile --dart-define=FLUTTER_WEB_DEBUG_SHOW_SEMANTICS=true
+   ```
+   Chrome DevTools → Elements tab → "Accessibility" sub-tab shows the exported ARIA tree.
+
+6. **On Android, TalkBack may fail to focus content rendered outside its parent's measured bounds.** Android's accessibility framework uses each view's `getBoundsInScreen()` for hit testing. If a Flutter `Stack` child overflows the Stack via `Positioned` with offsets that exceed the parent's bounds, the visual rendering can look fine while TalkBack reports degenerate bounds and can't focus the content. Most Flutter overlays (via `Overlay`/`OverlayPortal`) mount into the Navigator's full-screen overlay and aren't affected — but a `Stack`-with-overflow in a small parent (e.g., a tooltip-like popover inside a 48dp button row) can hit this. If you suspect it, dump the a11y tree with `uiautomator dump` (see Debugging section) and look for `bounds="[x,y][x,y]"` with `top > bottom` — that's the symptom. Fix by mounting the overlay in a taller ancestor (use `Overlay.of(context)` rather than a local `Stack`).
+
+### Anti-patterns to avoid
+
+1. **Auto-focusing typeahead / autocomplete suggestions on appear.** Each keystroke that produces new suggestions would re-steal focus from the active `TextField`, breaking continuous typing. ARIA combobox spec explicitly forbids this; iOS VoiceOver and Android TalkBack have the same constraint. Announce on show via `sendAnnouncement('Suggestions available')` instead, and rely on standard screen-reader navigation gestures (swipe) for the user to reach the list when they want.
+
+2. **Nested focusables.** Don't wrap a `GestureDetector(onTap: ...)` around an `IconButton(onPressed: ...)` (or any tappable inside another tappable). The user gets two focus stops for one action. Either make the outer non-interactive (`HitTestBehavior.translucent` only, no callback) or mark the inner with `ExcludeSemantics`.
+
+3. **Hardcoded labels in a design system component.** A component shipped to multiple products must accept localized labels through its public API; never bake English strings inside. Required-label parameters (`tooltip: String` not `tooltip: String?`) for icon-only widgets are a defensible pattern.
+
+4. **`Semantics(hint:)` as the only carrier of critical information.** Users can disable hints in screen-reader settings. Hints are *supplementary*. Critical state goes in `label:` or `value:`.
+
+5. **Auto-focusing a screen's primary `TextField` on page entry.** Opens the IME on page load, partially covers content, disorients SR users. Most mainstream apps land focus at the top of the screen (channel header, screen title, back button) on entry and let the user explicitly tap into the input when they're ready — match that convention unless there's a strong reason to override.
+
+6. **Subscribing to `MediaQuery.accessibleNavigationOf(context)` inside list items.** Toggling SR re-renders every item. Subscribe only in components that actually swap UI based on SR state.
+
+7. **Returning focus to the trigger element on close for inline pickers tightly coupled to a primary input.** For one-shot system modals (settings sheets, confirmation dialogs) the trigger-return pattern is correct. But for inline pickers attached to a text input where the user is mid-flow (e.g., emoji pickers, mention pickers, attachment menus), the convention is to focus the primary input on close so the user can keep typing. Match what mainstream apps in your domain do; don't reinvent.
+
+8. **`liveRegion: true` to force-announce a static dialog title.** Use `Semantics(header: true)` + `barrierLabel:` on `showModalBottomSheet` instead. Live regions are for content that *changes*.
+
+9. **Pushing a11y responsibility to consumers.** "The consumer can wrap our widget with `Semantics(label: ...)` if they want a screen reader to read it" is the wrong default for a design system. Bake a11y in; require labels in the public API where appropriate.
+
+---
+
+## Auditing accessibility
+
+How to verify that what you wrote actually works. The canonical Flutter testing flow: enable semantics, run guideline checks first (they catch ~80% of regressions), then drop into per-node assertions for the specific behavior you fixed.
+
+For a design system, tests are the contract: a regression in a base component breaks every consumer. Hold the line in the component's own test file, not downstream.
+
+### Setup — the canonical pattern
+
+```dart
+testWidgets('...', (tester) async {
+  final handle = tester.ensureSemantics();
+  await tester.pumpWidget(...);
+  // assertions
+  handle.dispose();
+});
+```
+
+Dispose the handle **inline at the end of the test body**. Roughly 99% of Flutter's own widget tests use this pattern (counted across the 3.44 SDK: 164 uses of `tester.ensureSemantics()`, only 2 with `addTearDown(handle.dispose)` — and those 2 don't actually call `tester.ensureSemantics()`).
+
+> ⚠️ **Don't use `addTearDown(handle.dispose)` with `tester.ensureSemantics()`.** Inside `testWidgets`, the framework's `_verifySemanticsHandlesWereDisposed` check runs *before* tearDown callbacks fire — the handle is still active at verification time, the test fails. The `addTearDown` pattern *is* valid for rendering-only tests that use `TestRenderingFlutterBinding.instance.ensureSemantics()` or `SemanticsBinding.instance.ensureSemantics()` directly (different binding, no end-of-test handle check). For `testWidgets`, inline dispose is the only correct pattern.
+
+### Guideline-level checks (catches most regressions)
+
+```dart
+await expectLater(tester, meetsGuideline(androidTapTargetGuideline));   // ≥48×48
+await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));       // ≥44×44
+await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));   // every tappable labeled
+await expectLater(tester, meetsGuideline(textContrastGuideline));       // ≥4.5:1 / 3:1
+```
+
+### Matchers — pick by intent
+
+| Matcher | Behavior | When to use |
+|---|---|---|
+| `containsSemantics(...)` | Subset — only specified properties checked; allows extras | **Default for most tests.** Survives SDK upgrades that add new flags. |
+| `matchesSemantics(...)` | Exhaustive — every parameter checked, unspecified MUST be absent | When you want to lock down a precise spec. Brittle to Flutter SDK additions. |
+| `isSemantics(...)` | Strict (Flutter 3.43+ replacement for `matchesSemantics`) | Same use case as `matchesSemantics`; preferred for new code. |
+| `includesNodeWith(...)` | "Some node in the tree matches" | Existence checks ("there's a node labeled 'Alert' with `namesRoute` flag"). |
+| `meetsGuideline(...)` | Guideline-level | Tap targets, contrast, label presence. |
+
+> ⚠️ `TestSemantics`/`SemanticsTester`/`hasSemantics(TestSemantics.root(...))` are **`@Deprecated` (Flutter 3.43+)**. Don't reach for full-tree-shape assertions in new tests — they break on every SDK change. Use `containsSemantics`/`isSemantics` against `tester.semantics.find(finder)` or `tester.getSemantics(finder)` instead.
+
+### Inspecting a single node
+
+```dart
+// Returns the merged node when MergeSemantics is involved.
+final node = tester.semantics.find(find.byType(MyWidget));
+expect(node, containsSemantics(label: 'Send', isButton: true, hasTapAction: true));
+```
+
+`tester.semantics.find` is the newer API and recommended; `tester.getSemantics` still works and returns the same node.
+
+### Testing focus / traversal order
+
+`tester.semantics.simulatedAccessibilityTraversal` is the closest you get to "what a TalkBack user swiping right experiences":
+
+```dart
+final order = tester.semantics
+  .simulatedAccessibilityTraversal(startNode: find.semantics.byLabel('Add attachment'))
+  .map((node) => node.label)
+  .toList();
+
+expect(order, ['Add attachment', 'Message input', 'Send message']);
+```
+
+Use this for any UI where the focus order matters (composers, toolbars, forms, picker tab strips).
+
+### Verifying announcements fire
+
+Mock the platform a11y channel and capture the announcement payload:
+
+```dart
+final announcements = <String>[];
+TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+  .setMockDecodedMessageHandler<dynamic>(SystemChannels.accessibility, (msg) async {
+    if (msg is Map && msg['type'] == 'announce') {
+      announcements.add(msg['data']['message'] as String);
+    }
+  });
+
+await tester.pumpWidget(MyComposer());
+await tester.tap(find.bySemanticsLabel('Add attachment'));
+await tester.pump();
+
+expect(announcements, contains('Attachment picker opened'));
+```
+
+This pins the announcement-on-action contract — pickers, mention overlays, error states.
+
+### Simulating a screen-reader-triggered action
+
+To verify the SR-driven activation path (which can differ from finger-tap, especially for desktop `TextField` focus):
+
+```dart
+tester.platformDispatcher.onSemanticsActionEvent!(SemanticsActionEvent(
+  type: SemanticsAction.tap,
+  viewId: tester.view.viewId,
+  nodeId: tester.semantics.find(find.byType(MyWidget)).id,
+));
+await tester.pumpAndSettle();
+```
+
+### Validating `Semantics(role: ...)` configuration
+
+Flutter throws `FlutterError` when `SemanticsRole.tab` is missing `selected:`, `radioGroup` has multiple checked items, etc. Assert no exception is thrown:
+
+```dart
+await tester.pumpWidget(MyWidget());
+expect(tester.takeException(), isNull, reason: 'Semantic role configured correctly');
+```
+
+Catches "I added `role: tab` but forgot `selected:`" before it ships.
+
+### Recipe per widget shape
+
+| Widget shape | Minimal assertion |
+|---|---|
+| Icon-only button | `containsSemantics(label: ..., isButton: true, hasTapAction: true)` against `find.byType(MyButton)` |
+| Disabled button | `containsSemantics(label: ..., isButton: true, hasTapAction: false)` |
+| Toggle / switch | `containsSemantics(hasToggledState: true, isToggled: <expected>)` |
+| Checkbox | `containsSemantics(hasCheckedState: true, isChecked: <expected>)` |
+| Tab in a TabBar | `containsSemantics(hasSelectedState: true, isSelected: <expected>)` |
+| Slider | `containsSemantics(value: '50%', increasedValue: '55%', decreasedValue: '45%')` |
+| TextField | `final node = tester.getSemantics(find.byType(MyField)); expect(node.label, ...); expect(node.value, ...);` |
+| Live-region content | `containsSemantics(label: ..., isLiveRegion: true)` |
+| Dialog title | `expect(semantics, includesNodeWith(label: ..., flags: [namesRoute, scopesRoute]))` |
+| Focus order | `tester.semantics.simulatedAccessibilityTraversal(...).map((n) => n.label).toList()` |
+| Announcement on action | Mock `SystemChannels.accessibility`, assert log |
+| Tap-target compliance | `await expectLater(tester, meetsGuideline(androidTapTargetGuideline))` |
+
+### Regression-guard discipline
+
+Verify the test FAILS without your fix. `git stash` the fix, run the test, restore.
+
+A passing test that doesn't fail without the fix is a false positive — common when a `containsSemantics(...)` happens to match irrelevant properties, or when `meetsGuideline` is checking a guideline the widget already satisfied. Always verify the test's negative case.
+
+### Platform-conditional assertions
+
+If your widget's a11y differs per platform (common for dialogs — iOS/macOS skip the `Alert` wrapper that Android/Linux/Windows include), branch the assertion:
+
+```dart
+final isApple = defaultTargetPlatform == TargetPlatform.iOS ||
+    defaultTargetPlatform == TargetPlatform.macOS;
+
+if (isApple) {
+  expect(semantics, isNot(includesNodeWith(label: 'Alert')));
+} else {
+  expect(
+    semantics,
+    includesNodeWith(
+      label: 'Alert',
+      flags: [SemanticsFlag.namesRoute, SemanticsFlag.scopesRoute],
+    ),
+  );
+}
+```
+
+Run such tests across platforms via `TargetPlatformVariant`:
+
+```dart
+testWidgets('...', (tester) async {
+  // ...
+}, variant: const TargetPlatformVariant({
+  TargetPlatform.iOS,
+  TargetPlatform.android,
+}));
+```
+
+---
+
+## Debugging the semantics tree
+
+When TalkBack ignores a view, can't focus a row, focuses the wrong thing, or announces the wrong text — dump the semantics tree and read it directly. Two complementary tools, use whichever fits the diagnosis.
+
+### `debugDumpSemanticsTree()` — Flutter-native, fastest
+
+Print the current semantic tree to the debug console from inside the app:
+
+```dart
+import 'package:flutter/rendering.dart';
+
+GestureDetector(
+  onLongPress: () => debugDumpSemanticsTree(),
+  child: ...,
+)
+```
+
+Output shows the full SemanticsNode hierarchy, each node's rect, flags, label, hint, value, and actions. Use when you want to verify a node exists / merged correctly / has the right flags without leaving Flutter. No platform tooling needed.
+
+Tip: ensure semantics are actually being computed before dumping — `tester.ensureSemantics()` in tests, or `MaterialApp(showSemanticsDebugger: true)` in runtime debugging.
+
+### `uiautomator dump` — Android-side ground truth
+
+Use when the Flutter dump looks correct but TalkBack still behaves wrong — the issue is likely in how Flutter's semantic tree maps to Android `View` bounds.
+
+```bash
+# 1. Put the app in the state you want to inspect.
+adb shell uiautomator dump /sdcard/window_dump.xml
+adb pull /sdcard/window_dump.xml ./window_dump.xml
+
+# 2. Find your view — grep by a known label / text.
+grep -A2 'text="Submit"' window_dump.xml
+grep -B1 -A1 'content-desc="Profile section"' window_dump.xml
+```
+
+Each `<node>` has `bounds="[left,top][right,bottom]"` in screen pixels:
+
+| Symptom in `bounds` | Meaning |
+|---|---|
+| `[0,0][0,0]` | View never measured (mid-mount or detached from a11y tree). |
+| `top > bottom` or `left > right` | Clipped by parent — `getBoundsInScreen()` clamped to a smaller ancestor. TalkBack treats this as empty. **Move the mount to a taller parent.** |
+| Bounds outside the screen | Off-screen or pushed by keyboard; TalkBack won't focus it. |
+| Bounds present, `clickable="true"`, `focusable="true"`, but still unreachable | Check `importantForAccessibility` chain and sibling z-order — something opaque may be above it. |
+
+Other useful node attributes: `class` (underlying Android View class — helps when a Flutter widget compiles to something unexpected), `package` (confirms you're looking at your app, not system UI), `clickable`/`focusable`/`enabled` (all must be true for TalkBack focus), `content-desc` (what TalkBack speaks — if empty when you expected a label, the prop didn't bind correctly).
+
+Caveats:
+- Single snapshot. If the view animates in, dump *after* the animation settles.
+- TalkBack itself can affect what gets dumped — turn it off when diagnosing layout, on when diagnosing focus order.
+- The XML reflects native bounds *after* Flutter's layout pass. A wrong dump usually means Flutter gave Android wrong layout, not that the dump is lying.
+
+---
+
+## When in doubt
+
+1. Default to one focus stop per interactive element.
+2. Bake a11y into the component's public API; don't push it to consumers.
+3. Mirror Flutter's standard a11y parameter names (`tooltip:`, `autofocus:`, `semanticLabel:`).
+4. Use `MergeSemantics` for composite chrome — but only when descendants are decorative or share an action.
+5. Use `ExcludeSemantics` aggressively for decorative icons.
+6. Use `Semantics.liveRegion` sparingly — only when content genuinely needs auto-announce on change.
+7. Use `SemanticsService.sendAnnouncement` for one-shot events.
+8. Write a `meetsGuideline` regression test in the component's own test file.
+9. Test on a real device with TalkBack/VoiceOver before declaring done.
+10. Don't over-plumb FocusNodes. `autofocus:` often gets the same result with less code.

--- a/apps/design_system_gallery/lib/components/common/stream_text_input.dart
+++ b/apps/design_system_gallery/lib/components/common/stream_text_input.dart
@@ -34,6 +34,11 @@ class _PlaygroundDemoState extends State<_PlaygroundDemo> {
     final radius = context.streamRadius;
     final spacing = context.streamSpacing;
 
+    final labelText = context.knobs.stringOrNull(
+      label: 'Label Text',
+      description: 'Persistent label rendered above the input.',
+    );
+
     final hintText = context.knobs.string(
       label: 'Hint Text',
       initialValue: 'Enter text...',
@@ -48,6 +53,15 @@ class _PlaygroundDemoState extends State<_PlaygroundDemo> {
       options: StreamHelperState.values,
       labelBuilder: (s) => s.name,
       description: 'Only visible when helper text is set.',
+    );
+
+    final helperAffinity = context.knobs.object.dropdown<StreamHelperAffinity>(
+      label: 'Helper Affinity',
+      options: StreamHelperAffinity.values,
+      labelBuilder: (a) => a.name,
+      description:
+          'Where the helper text sits — inside the bordered area or '
+          'below it as an external caption.',
     );
 
     final isDisabled = context.knobs.boolean(
@@ -125,9 +139,11 @@ class _PlaygroundDemoState extends State<_PlaygroundDemo> {
                   spacing: spacing.sm,
                   children: [
                     StreamTextInput(
+                      labelText: labelText,
                       hintText: hintText,
                       helperText: helperText,
                       helperState: helperText != null ? helperState : null,
+                      style: StreamTextInputStyle(helperAffinity: helperAffinity),
                       enabled: !isDisabled,
                       readOnly: isReadOnly,
                       maxLines: maxLines,
@@ -214,6 +230,16 @@ class _StatesSection extends StatelessWidget {
                 description: 'Empty field with hint text',
                 child: StreamTextInput(
                   hintText: 'Enter text...',
+                  onChanged: (_) {},
+                ),
+              ),
+              Divider(height: 1, color: colorScheme.borderSubtle),
+              _StateDemo(
+                label: 'Labeled',
+                description: 'Persistent label above the field',
+                child: StreamTextInput(
+                  labelText: 'Email',
+                  hintText: 'name@example.com',
                   onChanged: (_) {},
                 ),
               ),
@@ -625,7 +651,8 @@ class _LoginFormExampleState extends State<_LoginFormExample> {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         StreamTextInput(
-          hintText: 'Email address',
+          labelText: 'Email',
+          hintText: 'name@example.com',
           initialValue: _email,
           keyboardType: TextInputType.emailAddress,
           leading: const Icon(Icons.email_outlined, size: 20),
@@ -634,7 +661,8 @@ class _LoginFormExampleState extends State<_LoginFormExample> {
           onChanged: (v) => setState(() => _email = v),
         ),
         StreamTextInput(
-          hintText: 'Password',
+          labelText: 'Password',
+          hintText: 'Enter your password',
           initialValue: _password,
           leading: Icon(context.streamIcons.lock),
           helperText: _successText(_passwordError),

--- a/apps/design_system_gallery/lib/config/preview_configuration.dart
+++ b/apps/design_system_gallery/lib/config/preview_configuration.dart
@@ -15,6 +15,7 @@ class PreviewConfiguration extends ChangeNotifier {
   DeviceInfo _selectedDevice = Devices.ios.iPhone13ProMax;
   var _textScale = 1.0;
   var _showDeviceFrame = false;
+  var _showSemanticsDebugger = false;
   var _textDirection = TextDirection.ltr;
   TargetPlatform? _targetPlatform;
 
@@ -25,6 +26,7 @@ class PreviewConfiguration extends ChangeNotifier {
   DeviceInfo get selectedDevice => _selectedDevice;
   double get textScale => _textScale;
   bool get showDeviceFrame => _showDeviceFrame;
+  bool get showSemanticsDebugger => _showSemanticsDebugger;
   TextDirection get textDirection => _textDirection;
 
   /// The target platform override, or `null` to use the system default.
@@ -77,6 +79,11 @@ class PreviewConfiguration extends ChangeNotifier {
 
   void toggleDeviceFrame() {
     _showDeviceFrame = !_showDeviceFrame;
+    notifyListeners();
+  }
+
+  void toggleSemanticsDebugger() {
+    _showSemanticsDebugger = !_showSemanticsDebugger;
     notifyListeners();
   }
 

--- a/apps/design_system_gallery/lib/core/preview_wrapper.dart
+++ b/apps/design_system_gallery/lib/core/preview_wrapper.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:stream_core_flutter/core.dart';
 
 import '../config/preview_configuration.dart';
+import '../widgets/scoped_semantics_debugger.dart';
 
 /// Wrapper widget that applies device frame and text scale to the preview.
 ///
@@ -59,6 +60,11 @@ class PreviewWrapper extends StatelessWidget {
     if (previewConfig.targetPlatform case final targetPlatform?) {
       content = _PlatformOverride(platform: targetPlatform, child: content);
     }
+
+    content = ScopedSemanticsDebugger(
+      enabled: previewConfig.showSemanticsDebugger,
+      child: content,
+    );
 
     if (previewConfig.showDeviceFrame) {
       return Center(

--- a/apps/design_system_gallery/lib/widgets/scoped_semantics_debugger.dart
+++ b/apps/design_system_gallery/lib/widgets/scoped_semantics_debugger.dart
@@ -75,11 +75,12 @@ class _ScopedSemanticsDebuggerState extends State<ScopedSemanticsDebugger> with 
   }
 
   void _attach() {
+    // `View.pipelineOwnerOf(context)` uses `dependOnInheritedWidgetOfExactType`
+    // and can't be called from `initState`. The listener wire-up happens in
+    // `didChangeDependencies` instead, which is always called after
+    // `initState` on first mount (and again on any owner change).
     _semanticsHandle = SemanticsBinding.instance.ensureSemantics();
     WidgetsBinding.instance.addObserver(this);
-    final owner = View.pipelineOwnerOf(context);
-    owner.semanticsOwner?.addListener(_update);
-    _pipelineOwner = owner;
   }
 
   void _detach() {
@@ -230,7 +231,7 @@ class _ScopedSemanticsDebuggerPainter extends CustomPainter {
     final data = node.getSemanticsData();
     if (data.flagsCollection.isTextField) return StreamColors.green.shade500;
     if (data.flagsCollection.isButton) return StreamColors.blue.shade500;
-    if (data.flagsCollection.isSelected != Tristate.none) return StreamColors.purple.shade500;
+    if (data.flagsCollection.isSelected == Tristate.isTrue) return StreamColors.purple.shade500;
     if (data.hasAction(SemanticsAction.tap)) return StreamColors.cyan.shade500;
     return StreamColors.neutral.shade400;
   }

--- a/apps/design_system_gallery/lib/widgets/scoped_semantics_debugger.dart
+++ b/apps/design_system_gallery/lib/widgets/scoped_semantics_debugger.dart
@@ -1,0 +1,237 @@
+import 'dart:math' as math;
+import 'dart:ui' show Tristate;
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:stream_core_flutter/core.dart';
+
+/// A scoped variant of Flutter's [SemanticsDebugger].
+///
+/// Walks the global semantics tree but draws onto a clipped, locally-aligned
+/// canvas so only nodes intersecting the scope are visualized at correct
+/// positions. Purely decorative — never claims pointer events. Shows:
+///
+///   * A semi-transparent dim over the preview so the colored boundaries pop.
+///   * A role-colored 1.5px outline around every semantic node.
+///   * A dashed outline for nodes with `mergeAllDescendantsIntoThisNode`,
+///     so over-collapsing `MergeSemantics` is immediately obvious.
+///
+/// For the actual announcement text, use a real screen reader (TalkBack /
+/// VoiceOver) on device — that's the ground truth anyway.
+class ScopedSemanticsDebugger extends StatefulWidget {
+  const ScopedSemanticsDebugger({
+    super.key,
+    required this.child,
+    this.enabled = true,
+  });
+
+  final Widget child;
+  final bool enabled;
+
+  @override
+  State<ScopedSemanticsDebugger> createState() => _ScopedSemanticsDebuggerState();
+}
+
+class _ScopedSemanticsDebuggerState extends State<ScopedSemanticsDebugger> with WidgetsBindingObserver {
+  PipelineOwner? _pipelineOwner;
+  SemanticsHandle? _semanticsHandle;
+  var _generation = 0;
+  final _paintKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.enabled) _attach();
+  }
+
+  @override
+  void didUpdateWidget(ScopedSemanticsDebugger oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.enabled != oldWidget.enabled) {
+      widget.enabled ? _attach() : _detach();
+    }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!widget.enabled) return;
+    final newOwner = View.pipelineOwnerOf(context);
+    if (newOwner != _pipelineOwner) {
+      _pipelineOwner?.semanticsOwner?.removeListener(_update);
+      newOwner.semanticsOwner?.addListener(_update);
+      _pipelineOwner = newOwner;
+    }
+  }
+
+  @override
+  void didChangeMetrics() => setState(() {});
+
+  @override
+  void dispose() {
+    _detach();
+    super.dispose();
+  }
+
+  void _attach() {
+    _semanticsHandle = SemanticsBinding.instance.ensureSemantics();
+    WidgetsBinding.instance.addObserver(this);
+    final owner = View.pipelineOwnerOf(context);
+    owner.semanticsOwner?.addListener(_update);
+    _pipelineOwner = owner;
+  }
+
+  void _detach() {
+    _pipelineOwner?.semanticsOwner?.removeListener(_update);
+    _semanticsHandle?.dispose();
+    _semanticsHandle = null;
+    _pipelineOwner = null;
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  void _update() {
+    _generation++;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() {});
+    }, debugLabel: 'ScopedSemanticsDebugger.update');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.enabled) return widget.child;
+    return CustomPaint(
+      key: _paintKey,
+      foregroundPainter: _ScopedSemanticsDebuggerPainter(
+        owner: _pipelineOwner!,
+        generation: _generation,
+        devicePixelRatio: View.of(context).devicePixelRatio,
+        dimColor: context.streamColorScheme.backgroundApp,
+        renderBoxFinder: () => _paintKey.currentContext?.findRenderObject() as RenderBox?,
+      ),
+      child: widget.child,
+    );
+  }
+}
+
+class _ScopedSemanticsDebuggerPainter extends CustomPainter {
+  _ScopedSemanticsDebuggerPainter({
+    required this.owner,
+    required this.generation,
+    required this.devicePixelRatio,
+    required this.dimColor,
+    required this.renderBoxFinder,
+  });
+
+  final PipelineOwner owner;
+  final int generation;
+  final double devicePixelRatio;
+  final Color dimColor;
+  final RenderBox? Function() renderBoxFinder;
+
+  static const _kStrokeWidth = 1.5;
+  static const _kInnerInset = 0.75;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rootNode = owner.semanticsOwner?.rootSemanticsNode;
+    if (rootNode == null) return;
+
+    canvas.clipRect(Offset.zero & size);
+    canvas.drawRect(Offset.zero & size, Paint()..color = dimColor.withValues(alpha: 0.38));
+
+    final renderBox = renderBoxFinder();
+    final globalOffsetLogical = renderBox?.localToGlobal(Offset.zero) ?? Offset.zero;
+    final globalOffsetPhysical = globalOffsetLogical * devicePixelRatio;
+
+    canvas.save();
+    canvas.scale(1.0 / devicePixelRatio, 1.0 / devicePixelRatio);
+    canvas.translate(-globalOffsetPhysical.dx, -globalOffsetPhysical.dy);
+    _paint(canvas, rootNode);
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(_ScopedSemanticsDebuggerPainter oldDelegate) {
+    return owner != oldDelegate.owner || generation != oldDelegate.generation || dimColor != oldDelegate.dimColor;
+  }
+
+  void _paint(Canvas canvas, SemanticsNode node) {
+    if (node.traversalChildIdentifier != null) return;
+    canvas.save();
+    if (node.transform != null) {
+      canvas.transform(node.transform!.storage);
+    }
+    final rect = node.rect;
+    if (!rect.isEmpty) {
+      final lineColor = _colorForNode(node);
+      final innerRect = rect.deflate(_kInnerInset);
+      final strokePaint = Paint()
+        ..strokeWidth = _kStrokeWidth
+        ..color = lineColor
+        ..style = PaintingStyle.stroke;
+      if (innerRect.isEmpty) {
+        canvas.drawRect(
+          rect,
+          Paint()
+            ..color = lineColor
+            ..style = PaintingStyle.fill,
+        );
+      } else if (node.mergeAllDescendantsIntoThisNode) {
+        _drawDashedRect(canvas, innerRect, strokePaint);
+      } else {
+        canvas.drawRect(innerRect, strokePaint);
+      }
+    }
+    if (!node.mergeAllDescendantsIntoThisNode) {
+      node.visitChildren((child) {
+        _paint(canvas, child);
+        return true;
+      });
+    }
+    canvas.restore();
+  }
+
+  void _drawDashedRect(
+    Canvas canvas,
+    Rect rect,
+    Paint paint, {
+    double dashLength = 4,
+    double gapLength = 3,
+  }) {
+    final path = Path();
+    for (var x = rect.left; x < rect.right; x += dashLength + gapLength) {
+      path
+        ..moveTo(x, rect.top)
+        ..lineTo(math.min(x + dashLength, rect.right), rect.top);
+    }
+    for (var y = rect.top; y < rect.bottom; y += dashLength + gapLength) {
+      path
+        ..moveTo(rect.right, y)
+        ..lineTo(rect.right, math.min(y + dashLength, rect.bottom));
+    }
+    for (var x = rect.right; x > rect.left; x -= dashLength + gapLength) {
+      path
+        ..moveTo(x, rect.bottom)
+        ..lineTo(math.max(x - dashLength, rect.left), rect.bottom);
+    }
+    for (var y = rect.bottom; y > rect.top; y -= dashLength + gapLength) {
+      path
+        ..moveTo(rect.left, y)
+        ..lineTo(rect.left, math.max(y - dashLength, rect.top));
+    }
+    canvas.drawPath(path, paint);
+  }
+
+  /// Role-based colors from StreamColors. Order matters — earlier checks win
+  /// for nodes that match multiple roles (e.g., a selected button shows as a
+  /// button).
+  static Color _colorForNode(SemanticsNode node) {
+    final data = node.getSemanticsData();
+    if (data.flagsCollection.isTextField) return StreamColors.green.shade500;
+    if (data.flagsCollection.isButton) return StreamColors.blue.shade500;
+    if (data.flagsCollection.isSelected != Tristate.none) return StreamColors.purple.shade500;
+    if (data.hasAction(SemanticsAction.tap)) return StreamColors.cyan.shade500;
+    return StreamColors.neutral.shade400;
+  }
+}

--- a/apps/design_system_gallery/lib/widgets/toolbar/semantics_debugger_toggle.dart
+++ b/apps/design_system_gallery/lib/widgets/toolbar/semantics_debugger_toggle.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../config/preview_configuration.dart';
+import 'toolbar_button.dart';
+
+/// Toggles a [SemanticsDebugger] overlay over the widget preview, drawing
+/// boxes and labels around every semantic node.
+class SemanticsDebuggerToggle extends StatelessWidget {
+  const SemanticsDebuggerToggle({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final previewConfig = context.watch<PreviewConfiguration>();
+
+    return ToolbarButton(
+      icon: previewConfig.showSemanticsDebugger ? Icons.accessibility_new : Icons.accessibility,
+      tooltip: 'Semantics Debugger',
+      isActive: previewConfig.showSemanticsDebugger,
+      onTap: previewConfig.toggleSemanticsDebugger,
+    );
+  }
+}

--- a/apps/design_system_gallery/lib/widgets/toolbar/toolbar.dart
+++ b/apps/design_system_gallery/lib/widgets/toolbar/toolbar.dart
@@ -10,6 +10,7 @@ import 'baselines_toggle.dart';
 import 'debug_paint_toggle.dart';
 import 'device_selector.dart';
 import 'platform_selector.dart';
+import 'semantics_debugger_toggle.dart';
 import 'text_direction_selector.dart';
 import 'text_scale_selector.dart';
 import 'theme_mode_toggle.dart';
@@ -103,6 +104,7 @@ class GalleryToolbar extends StatelessWidget {
                     const DebugPaintToggle(),
                     const BaselinesToggle(),
                     const WidgetSelectToggle(),
+                    const SemanticsDebuggerToggle(),
                   ],
                 ],
               ),

--- a/packages/stream_core/lib/src/ws/client/engine/web_socket_engine.dart
+++ b/packages/stream_core/lib/src/ws/client/engine/web_socket_engine.dart
@@ -176,7 +176,7 @@ extension type const CloseCode(int code) implements int {
   static const tlsHandshakeFailure = CloseCode(1015);
 }
 
-class WebSocketEngineException with EquatableMixin implements Exception {
+class WebSocketEngineException extends Equatable implements Exception {
   const WebSocketEngineException({
     String? reason,
     int? code = 0,

--- a/packages/stream_core_flutter/CHANGELOG.md
+++ b/packages/stream_core_flutter/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 0.5.0
+
+### ✨ Features
+
+- Added `StreamAccessibilityAutofocus` — behavior-only wrapper that requests screen-reader focus on its child shortly after mount; useful for redirecting focus on route entry (bounded retries, SR-toggle reactive, per-route debug uniqueness assertion).
+- Added `StreamSemanticsAnnouncer` — imperative one-shot screen-reader announcement helper wrapping `SemanticsService.sendAnnouncement`.
+- Added `StreamSemanticsTransitionAnnouncer` — observes a `Listenable`, snapshots its value on each notification, derives a transition message via a resolver, and dispatches through `StreamSemanticsAnnouncer`.
+- Added `labelText` and `helperAffinity` to `StreamTextInput` for a floating label above the field and helper text positioned inside or outside the bordered chassis.
+- Added `focusNode` and `autofocus` pass-through on `StreamListTile`.
+- Added optional `semanticLabel` to `StreamBadgeNotification` and `StreamFileTypeIcon`.
+- Added `onVisible` callback to `StreamSnackbar` — fires after the entrance animation completes (or synchronously when SR is active), enabling explicit a11y announcement hooks.
+- Improved `StreamSheet` a11y semantics: route scoping, semantic dismissal, hit-test-opaque wrap so barrier taps don't fall through.
+- Improved `StreamAppBar` and `StreamSheetHeader` a11y: title/subtitle merged as one announcement; wrapped in `Semantics(header: true, namesRoute: true)` by default (with `excludeHeaderSemantics` opt-out); auto-implied leading gets localized close/back tooltip.
+- Improved `StreamBottomAppBar` a11y: outer semantic container groups children; title/subtitle merged (no heading role, secondary toolbar).
+- Improved `StreamButton` a11y: `Semantics(selected)` and `Tooltip` moved outside `ElevatedButton` with a `MergeSemantics` wrap so a11y state merges cleanly with the button's own node.
+- Improved `StreamStepper` a11y: announces as a single `slider` node with `value`/`increasedValue`/`decreasedValue`/`onIncrease`/`onDecrease`; internal +/- buttons and text field excluded from SR. New optional `semanticLabel` prop.
+- Improved `StreamTextInput` a11y: desktop-only `onDidGainAccessibilityFocus` / `onDidLoseAccessibilityFocus` handlers (no more IME open on SR swipe on iOS/Android); error text moved to its own live-region container.
+- Improved `StreamMessageComposerAttachment` a11y: new `semanticLabel` and `mergeRemoveAction` props; content sub-trees excluded so the tile is one focus stop with a `remove` tap action. Forwarded through file, media, and unsupported attachment subclasses.
+
 ## 0.4.0
 
 ### ✨ Features

--- a/packages/stream_core_flutter/CHANGELOG.md
+++ b/packages/stream_core_flutter/CHANGELOG.md
@@ -8,7 +8,6 @@
 - Added `labelText` and `helperAffinity` to `StreamTextInput` for a floating label above the field and helper text positioned inside or outside the bordered chassis.
 - Added `focusNode` and `autofocus` pass-through on `StreamListTile`.
 - Added optional `semanticLabel` to `StreamBadgeNotification`, `StreamFileTypeIcon`, `StreamStepper`, `StreamMessageComposerAttachment`, and `StreamMessageComposerMediaAttachment`.
-- Added `mergeRemoveAction` to `StreamMessageComposerAttachment` — collapses the tile into a single screen-reader focus stop whose `tap` maps to the remove callback.
 - Added `excludeHeaderSemantics` to `StreamAppBar` and `StreamSheetHeader` for opting out of the default heading role and route naming on the title.
 - Added `onVisible` callback to `StreamSnackbar` — fires after the entrance animation completes (or synchronously when a screen reader is active).
 

--- a/packages/stream_core_flutter/CHANGELOG.md
+++ b/packages/stream_core_flutter/CHANGELOG.md
@@ -2,20 +2,15 @@
 
 ### ✨ Features
 
-- Added `StreamAccessibilityAutofocus` — behavior-only wrapper that requests screen-reader focus on its child shortly after mount; useful for redirecting focus on route entry (bounded retries, SR-toggle reactive, per-route debug uniqueness assertion).
-- Added `StreamSemanticsAnnouncer` — imperative one-shot screen-reader announcement helper wrapping `SemanticsService.sendAnnouncement`.
-- Added `StreamSemanticsTransitionAnnouncer` — observes a `Listenable`, snapshots its value on each notification, derives a transition message via a resolver, and dispatches through `StreamSemanticsAnnouncer`.
+- Added `StreamAccessibilityAutofocus` — behavior-only wrapper that requests screen-reader focus on its child shortly after mount; useful for redirecting focus on route entry.
+- Added `StreamSemanticsAnnouncer` — imperative one-shot screen-reader announcement helper.
+- Added `StreamSemanticsTransitionAnnouncer` — observes a `Listenable` and dispatches transition announcements to the screen reader.
 - Added `labelText` and `helperAffinity` to `StreamTextInput` for a floating label above the field and helper text positioned inside or outside the bordered chassis.
 - Added `focusNode` and `autofocus` pass-through on `StreamListTile`.
-- Added optional `semanticLabel` to `StreamBadgeNotification` and `StreamFileTypeIcon`.
-- Added `onVisible` callback to `StreamSnackbar` — fires after the entrance animation completes (or synchronously when SR is active), enabling explicit a11y announcement hooks.
-- Improved `StreamSheet` a11y semantics: route scoping, semantic dismissal, hit-test-opaque wrap so barrier taps don't fall through.
-- Improved `StreamAppBar` and `StreamSheetHeader` a11y: title/subtitle merged as one announcement; wrapped in `Semantics(header: true, namesRoute: true)` by default (with `excludeHeaderSemantics` opt-out); auto-implied leading gets localized close/back tooltip.
-- Improved `StreamBottomAppBar` a11y: outer semantic container groups children; title/subtitle merged (no heading role, secondary toolbar).
-- Improved `StreamButton` a11y: `Semantics(selected)` and `Tooltip` moved outside `ElevatedButton` with a `MergeSemantics` wrap so a11y state merges cleanly with the button's own node.
-- Improved `StreamStepper` a11y: announces as a single `slider` node with `value`/`increasedValue`/`decreasedValue`/`onIncrease`/`onDecrease`; internal +/- buttons and text field excluded from SR. New optional `semanticLabel` prop.
-- Improved `StreamTextInput` a11y: desktop-only `onDidGainAccessibilityFocus` / `onDidLoseAccessibilityFocus` handlers (no more IME open on SR swipe on iOS/Android); error text moved to its own live-region container.
-- Improved `StreamMessageComposerAttachment` a11y: new `semanticLabel` and `mergeRemoveAction` props; content sub-trees excluded so the tile is one focus stop with a `remove` tap action. Forwarded through file, media, and unsupported attachment subclasses.
+- Added optional `semanticLabel` to `StreamBadgeNotification`, `StreamFileTypeIcon`, `StreamStepper`, `StreamMessageComposerAttachment`, and `StreamMessageComposerMediaAttachment`.
+- Added `mergeRemoveAction` to `StreamMessageComposerAttachment` — collapses the tile into a single screen-reader focus stop whose `tap` maps to the remove callback.
+- Added `excludeHeaderSemantics` to `StreamAppBar` and `StreamSheetHeader` for opting out of the default heading role and route naming on the title.
+- Added `onVisible` callback to `StreamSnackbar` — fires after the entrance animation completes (or synchronously when a screen reader is active).
 
 ## 0.4.0
 

--- a/packages/stream_core_flutter/lib/core.dart
+++ b/packages/stream_core_flutter/lib/core.dart
@@ -10,6 +10,7 @@ library;
 
 export 'package:svg_icon_widget/svg_icon_widget.dart';
 
+export 'src/a11y/stream_accessibility_autofocus.dart';
 export 'src/a11y/stream_semantics_announcer.dart';
 export 'src/components/accessories/stream_audio_waveform.dart';
 export 'src/components/accessories/stream_emoji.dart';

--- a/packages/stream_core_flutter/lib/core.dart
+++ b/packages/stream_core_flutter/lib/core.dart
@@ -10,6 +10,7 @@ library;
 
 export 'package:svg_icon_widget/svg_icon_widget.dart';
 
+export 'src/a11y/stream_semantics_announcer.dart';
 export 'src/components/accessories/stream_audio_waveform.dart';
 export 'src/components/accessories/stream_emoji.dart';
 export 'src/components/accessories/stream_file_type_icon.dart';

--- a/packages/stream_core_flutter/lib/core.dart
+++ b/packages/stream_core_flutter/lib/core.dart
@@ -12,6 +12,7 @@ export 'package:svg_icon_widget/svg_icon_widget.dart';
 
 export 'src/a11y/stream_accessibility_autofocus.dart';
 export 'src/a11y/stream_semantics_announcer.dart';
+export 'src/a11y/stream_semantics_transition_announcer.dart';
 export 'src/components/accessories/stream_audio_waveform.dart';
 export 'src/components/accessories/stream_emoji.dart';
 export 'src/components/accessories/stream_file_type_icon.dart';

--- a/packages/stream_core_flutter/lib/src/a11y/stream_accessibility_autofocus.dart
+++ b/packages/stream_core_flutter/lib/src/a11y/stream_accessibility_autofocus.dart
@@ -1,0 +1,214 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+
+/// A behavior-only wrapper that requests screen-reader focus on [child]
+/// shortly after mount.
+///
+/// Use this when the platform's automatic focus decision on route entry
+/// (typically the first interactive element in the toolbar) is not the
+/// element the user needs to interact with — for example, landing focus
+/// on a message input rather than the back button when a chat screen
+/// opens.
+///
+/// Only the screen-reader reading cursor is moved; input focus is not
+/// requested, so the soft keyboard stays closed.
+///
+/// The wrapper is a passthrough when [MediaQueryData.accessibleNavigation]
+/// is false, so it has no effect for sighted users. It also responds to the
+/// screen reader being turned on or off at runtime.
+///
+/// Only one [StreamAccessibilityAutofocus] should be active per route.
+/// When two instances compete for screen-reader focus, the reading cursor
+/// visibly bounces between their targets.
+///
+/// {@tool snippet}
+///
+/// Land SR focus on the composer input when the message screen opens:
+///
+/// ```dart
+/// StreamAccessibilityAutofocus(
+///   child: StreamMessageComposerInputField(...),
+/// )
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [FocusSemanticEvent], which this widget dispatches to move the SR
+///    reading cursor.
+class StreamAccessibilityAutofocus extends StatefulWidget {
+  /// Creates a screen-reader autofocus wrapper.
+  const StreamAccessibilityAutofocus({
+    super.key,
+    required this.child,
+    this.retryInterval = const Duration(milliseconds: 300),
+    this.window = const Duration(milliseconds: 1500),
+    this.enabled = true,
+  });
+
+  /// The widget whose semantic node should receive SR focus.
+  final Widget child;
+
+  /// How often the wrapper reattempts focus during [window].
+  final Duration retryInterval;
+
+  /// How long to keep reattempting focus after mount.
+  ///
+  /// The wrapper stops trying once the window elapses.
+  final Duration window;
+
+  /// Whether the wrapper should attempt to move SR focus at all.
+  ///
+  /// When `false`, the widget is a simple passthrough. Callers can use
+  /// this to conditionally opt into autofocus (e.g., only on the first
+  /// time a route is entered).
+  final bool enabled;
+
+  @override
+  State<StreamAccessibilityAutofocus> createState() => _StreamAccessibilityAutofocusState();
+}
+
+class _StreamAccessibilityAutofocusState extends State<StreamAccessibilityAutofocus> {
+  // Debug-only registry of currently-mounted instances, keyed by the
+  // enclosing route. Two widgets sharing a route would compete for the
+  // same SR cursor; widgets on different routes don't, because only the
+  // top-most route is SR-active at any time. Populated regardless of SR
+  // state so misuse surfaces in ordinary dev sessions. Empty in release
+  // builds — mutated only from within `assert` blocks.
+  static final Map<Route<dynamic>, _StreamAccessibilityAutofocusState> _debugMounted = {};
+
+  final _targetKey = GlobalKey();
+
+  Timer? _retryTimer;
+  Timer? _windowTimer;
+
+  // Tracked so we can distinguish an SR-off session from a session where SR
+  // was flipped on after mount; the latter starts a fresh attempt window.
+  var _accessibleNavigation = false;
+
+  // Route captured at first `didChangeDependencies` — kept so `dispose`
+  // can remove the exact entry we registered, even if the widget is
+  // rebuilt into a different subtree.
+  Route<dynamic>? _debugRegisteredRoute;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    if (widget.enabled) {
+      assert(_debugScheduleRouteCheck());
+    }
+
+    final wasOn = _accessibleNavigation;
+    _accessibleNavigation = MediaQuery.accessibleNavigationOf(context);
+
+    if (!widget.enabled) return;
+
+    // Start (or restart) the attempt window on any off→on transition —
+    // including the first read after mount when SR is already on. Cancel
+    // eagerly on on→off so a stale window doesn't keep ticking after SR
+    // is turned off.
+    if (_accessibleNavigation && !wasOn) {
+      _startAttemptWindow();
+    } else if (!_accessibleNavigation && wasOn) {
+      _stopAttemptWindow();
+    }
+  }
+
+  // Deferred to a postFrame callback so the per-route uniqueness check
+  // runs after the widget tree has settled. Throwing directly from
+  // didChangeDependencies would cascade into framework focus-tracking
+  // invariants ('_FocusInheritedScope._dependents.isEmpty').
+  bool _debugScheduleRouteCheck() {
+    if (_debugRegisteredRoute != null) return true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _debugCheckOnlyOneMountedPerRoute();
+    });
+    return true;
+  }
+
+  @override
+  void dispose() {
+    assert(() {
+      if (_debugRegisteredRoute case final route?) {
+        if (identical(_debugMounted[route], this)) {
+          _debugMounted.remove(route);
+        }
+      }
+      return true;
+    }());
+    _stopAttemptWindow();
+    super.dispose();
+  }
+
+  void _startAttemptWindow() {
+    _stopAttemptWindow();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _requestFocus());
+    _retryTimer = Timer.periodic(widget.retryInterval, (_) => _requestFocus());
+    _windowTimer = Timer(widget.window, _stopAttemptWindow);
+  }
+
+  void _stopAttemptWindow() {
+    _retryTimer?.cancel();
+    _retryTimer = null;
+    _windowTimer?.cancel();
+    _windowTimer = null;
+  }
+
+  bool _debugCheckOnlyOneMountedPerRoute() {
+    // Already registered — this call is from a later didChangeDependencies
+    // (e.g., MediaQuery change), not a fresh mount. Nothing to check.
+    if (_debugRegisteredRoute != null) return true;
+
+    // Widgets not enclosed by any route (e.g., in a test harness or
+    // widget-book style preview) skip the check — there's no "route
+    // scope" to enforce single-ownership within.
+    final route = ModalRoute.of(context);
+    if (route == null) return true;
+
+    if (_debugMounted[route] != null) {
+      throw FlutterError.fromParts([
+        ErrorSummary(
+          'Multiple StreamAccessibilityAutofocus widgets are mounted on the '
+          'same route at the same time.',
+        ),
+        ErrorDescription(
+          'Only one instance should attempt to claim screen-reader focus per '
+          'route. When multiple instances compete on the same route, the SR '
+          'reading cursor visibly bounces between their targets during their '
+          'overlapping attempt windows.',
+        ),
+        ErrorHint(
+          'Wrap only the primary focus target (typically the main input) in '
+          'StreamAccessibilityAutofocus. Instances on different routes (e.g., '
+          'a composer on the underlying page and a text field inside a bottom '
+          'sheet) are fine — the check is per-route.',
+        ),
+      ]);
+    }
+
+    _debugMounted[route] = this;
+    _debugRegisteredRoute = route;
+    return true;
+  }
+
+  void _requestFocus() {
+    if (!mounted) return;
+    if (!MediaQuery.accessibleNavigationOf(context)) return;
+    final target = _targetKey.currentContext?.findRenderObject();
+    if (target == null) return;
+    // Guard against a scheduled callback firing on a subtree that never
+    // fully mounted (e.g., a sibling widget threw during first build).
+    if (!target.attached) return;
+
+    return target.sendSemanticsEvent(const FocusSemanticEvent());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return KeyedSubtree(key: _targetKey, child: widget.child);
+  }
+}

--- a/packages/stream_core_flutter/lib/src/a11y/stream_accessibility_autofocus.dart
+++ b/packages/stream_core_flutter/lib/src/a11y/stream_accessibility_autofocus.dart
@@ -197,6 +197,7 @@ class _StreamAccessibilityAutofocusState extends State<StreamAccessibilityAutofo
 
   void _requestFocus() {
     if (!mounted) return;
+    if (!widget.enabled) return;
     if (!MediaQuery.accessibleNavigationOf(context)) return;
     final target = _targetKey.currentContext?.findRenderObject();
     if (target == null) return;

--- a/packages/stream_core_flutter/lib/src/a11y/stream_semantics_announcer.dart
+++ b/packages/stream_core_flutter/lib/src/a11y/stream_semantics_announcer.dart
@@ -1,0 +1,125 @@
+// ignore_for_file: avoid_classes_with_only_static_members
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+
+/// Dispatches screen-reader announcements with platform-aware delivery.
+///
+/// [StreamSemanticsAnnouncer] wraps [SemanticsService.sendAnnouncement] with
+/// behaviour the platform itself doesn't provide: a short delay on VoiceOver
+/// (iOS and macOS) for polite announcements that would otherwise be dropped,
+/// and cancellation of pending announcements when a new one arrives.
+///
+/// Polite announcements queue behind the screen reader's current speech and
+/// on VoiceOver may be dropped while another element is being read, so this
+/// helper schedules them after a short delay on those platforms as a
+/// workaround. Assertive announcements interrupt the current speech and are
+/// dispatched immediately on every platform.
+///
+/// A single timer is shared across the app — calling [announce] again
+/// cancels any pending delivery so rapid state changes only announce the
+/// latest message, regardless of which feature dispatched them.
+///
+/// {@tool snippet}
+///
+/// Polite announcement when a region changes state:
+///
+/// ```dart
+/// StreamSemanticsAnnouncer.announce(context, 'Picker expanded');
+/// ```
+/// {@end-tool}
+///
+/// {@tool snippet}
+///
+/// Assertive announcement that interrupts other screen-reader output:
+///
+/// ```dart
+/// StreamSemanticsAnnouncer.announce(
+///   context,
+///   'Recording started',
+///   assertiveness: Assertiveness.assertive,
+/// );
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [SemanticsService.sendAnnouncement], which this class wraps.
+///  * [Assertiveness], which controls whether the announcement queues
+///    behind or interrupts current speech.
+abstract final class StreamSemanticsAnnouncer {
+  static const _voiceOverDelay = Duration(seconds: 1);
+
+  static Timer? _timer;
+
+  /// Schedules [message] to be announced by the screen reader.
+  ///
+  /// Cancels any previously scheduled announcement that hasn't yet been
+  /// delivered, so the latest call wins when multiple announcements are
+  /// requested in quick succession.
+  ///
+  /// On VoiceOver (iOS and macOS) polite announcements are dispatched after
+  /// a short delay to work around a platform limitation where they can be
+  /// silently dropped. On other platforms — and for assertive announcements
+  /// regardless of platform — the dispatch is synchronous.
+  ///
+  /// Set [assertiveness] to [Assertiveness.assertive] for time-sensitive
+  /// state changes that should preempt other screen-reader output.
+  static void announce(
+    BuildContext context,
+    String message, {
+    Assertiveness assertiveness = .polite,
+  }) {
+    _timer?.cancel();
+
+    final view = View.of(context);
+    final textDirection = Directionality.of(context);
+
+    final platform = Theme.of(context).platform;
+    final usesVoiceOver = platform == .iOS || platform == .macOS;
+
+    void send() {
+      SemanticsService.sendAnnouncement(
+        view,
+        message,
+        textDirection,
+        assertiveness: assertiveness,
+      ).catchError((Object error, StackTrace stack) {
+        FlutterError.reportError(
+          FlutterErrorDetails(
+            exception: error,
+            stack: stack,
+            library: 'stream_core_flutter',
+            context: ErrorDescription('while sending a screen-reader announcement'),
+          ),
+        );
+      });
+    }
+
+    // Assertive announcements interrupt the screen reader directly, so the
+    // VoiceOver workaround isn't needed for them.
+    if (!usesVoiceOver || assertiveness == .assertive) {
+      return send();
+    }
+
+    _timer = Timer(_voiceOverDelay, send);
+  }
+
+  /// Sends a tooltip announcement for the screen reader to read.
+  ///
+  /// Currently only honored on Android, where TalkBack reads [message] as
+  /// a tooltip announcement. Does not interact with the pending [announce]
+  /// timer — tooltips are independent of regular announcements.
+  static Future<void> tooltip(String message) {
+    return SemanticsService.tooltip(message);
+  }
+
+  /// Cancels any pending announcement.
+  @visibleForTesting
+  static void cancel() {
+    _timer?.cancel();
+    _timer = null;
+  }
+}

--- a/packages/stream_core_flutter/lib/src/a11y/stream_semantics_transition_announcer.dart
+++ b/packages/stream_core_flutter/lib/src/a11y/stream_semantics_transition_announcer.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'stream_semantics_announcer.dart';
+
+/// A behavior-only wrapper that announces transitions on [listenable] to the
+/// screen reader.
+///
+/// [StreamSemanticsTransitionAnnouncer] observes [listenable] for changes,
+/// reads the current value via [snapshot] on each notification, derives a
+/// transition message via [resolveMessage], and dispatches it through
+/// [StreamSemanticsAnnouncer]. The visual tree is untouched — [build]
+/// returns [child] unchanged.
+///
+/// [snapshot] is called once during initialisation to capture the baseline
+/// and again on every notification, so the first transition compares
+/// against a real value rather than a synthetic default.
+///
+/// {@tool snippet}
+///
+/// Announce add/remove transitions on a value-listening source:
+///
+/// ```dart
+/// StreamSemanticsTransitionAnnouncer<List<Attachment>>(
+///   listenable: controller,
+///   snapshot: () => controller.attachments,
+///   resolveMessage: (previous, current) => _diffLabel(previous, current),
+///   child: AttachmentList(...),
+/// )
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [StreamSemanticsAnnouncer], which dispatches the resolved message.
+///  * [Assertiveness], which controls whether the announcement queues
+///    behind or interrupts current speech.
+class StreamSemanticsTransitionAnnouncer<T> extends StatefulWidget {
+  /// Creates an announcer that observes [listenable] and dispatches a
+  /// resolved message on each transition.
+  const StreamSemanticsTransitionAnnouncer({
+    super.key,
+    required this.listenable,
+    required this.snapshot,
+    required this.resolveMessage,
+    required this.child,
+    this.assertiveness = Assertiveness.polite,
+  });
+
+  /// The source whose notifications drive [snapshot] and [resolveMessage].
+  final Listenable listenable;
+
+  /// Reads the current value to compare against the previous one.
+  ///
+  /// Called once during initialisation and again on every notification
+  /// from [listenable].
+  final T Function() snapshot;
+
+  /// Resolves a screen-reader message for a transition, or returns `null`
+  /// to skip the announcement.
+  final String? Function(T previous, T current) resolveMessage;
+
+  /// The widget returned unchanged from [build].
+  final Widget child;
+
+  /// Priority used to dispatch the resolved announcement.
+  ///
+  /// Defaults to [Assertiveness.polite] so announcements queue behind any
+  /// current screen-reader speech. Use [Assertiveness.assertive] for
+  /// time-sensitive transitions that should preempt other output.
+  final Assertiveness assertiveness;
+
+  @override
+  State<StreamSemanticsTransitionAnnouncer<T>> createState() => _StreamSemanticsTransitionAnnouncerState<T>();
+}
+
+class _StreamSemanticsTransitionAnnouncerState<T> extends State<StreamSemanticsTransitionAnnouncer<T>> {
+  late T _current;
+
+  @override
+  void initState() {
+    super.initState();
+    _current = widget.snapshot();
+    widget.listenable.addListener(_onChanged);
+  }
+
+  @override
+  void didUpdateWidget(StreamSemanticsTransitionAnnouncer<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.listenable != widget.listenable) {
+      oldWidget.listenable.removeListener(_onChanged);
+      _current = widget.snapshot();
+      widget.listenable.addListener(_onChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.listenable.removeListener(_onChanged);
+    super.dispose();
+  }
+
+  void _onChanged() {
+    if (!mounted) return;
+    final previous = _current;
+    final current = widget.snapshot();
+    _current = current;
+    final message = widget.resolveMessage(previous, current);
+    if (message == null) return;
+    StreamSemanticsAnnouncer.announce(
+      context,
+      message,
+      assertiveness: widget.assertiveness,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/packages/stream_core_flutter/lib/src/components/accessories/stream_file_type_icon.dart
+++ b/packages/stream_core_flutter/lib/src/components/accessories/stream_file_type_icon.dart
@@ -138,7 +138,8 @@ class StreamFileTypeIcon extends StatelessWidget {
     required StreamFileType type,
     StreamFileTypeIconSize size = .lg,
     String? extension,
-  }) : props = .new(type: type, size: size, extension: extension);
+    String? semanticLabel,
+  }) : props = .new(type: type, size: size, extension: extension, semanticLabel: semanticLabel);
 
   /// Creates a file type icon from a MIME type string.
   ///
@@ -155,9 +156,10 @@ class StreamFileTypeIcon extends StatelessWidget {
     Key? key,
     String? mimeType,
     StreamFileTypeIconSize size = .lg,
+    String? semanticLabel,
   }) {
     final (type, extension) = _getFileTypeFromMimeType(mimeType);
-    return .new(key: key, type: type, size: size, extension: extension);
+    return .new(key: key, type: type, size: size, extension: extension, semanticLabel: semanticLabel);
   }
 
   /// The properties that configure this file type icon.
@@ -262,6 +264,7 @@ class StreamFileTypeIconProps {
     required this.type,
     required this.size,
     this.extension,
+    this.semanticLabel,
   });
 
   /// The file type to display.
@@ -279,6 +282,15 @@ class StreamFileTypeIconProps {
   /// When provided, this text is rendered on the icon (e.g., 'pdf', 'mp3').
   /// If null, no extension label is shown.
   final String? extension;
+
+  /// Semantic label for the icon.
+  ///
+  /// Announced in accessibility modes (e.g. TalkBack/VoiceOver). This
+  /// label does not show in the UI.
+  ///
+  ///  * [SemanticsProperties.label], which is set to [semanticLabel] in
+  ///    the underlying [Semantics] widget.
+  final String? semanticLabel;
 }
 
 /// The default implementation of [StreamFileTypeIcon].
@@ -303,7 +315,7 @@ class DefaultStreamFileTypeIcon extends StatelessWidget {
     final textTheme = context.streamTextTheme;
     final colorScheme = context.streamColorScheme;
 
-    return Stack(
+    final icon = Stack(
       alignment: .center,
       clipBehavior: .none,
       children: [
@@ -333,6 +345,12 @@ class DefaultStreamFileTypeIcon extends StatelessWidget {
           ),
       ],
     );
+
+    if (props.semanticLabel case final label?) {
+      return Semantics(label: label, excludeSemantics: true, child: icon);
+    }
+
+    return ExcludeSemantics(child: icon);
   }
 
   // Returns whether the given size renders an extension label overlay.

--- a/packages/stream_core_flutter/lib/src/components/badge/stream_badge_notification.dart
+++ b/packages/stream_core_flutter/lib/src/components/badge/stream_badge_notification.dart
@@ -96,6 +96,7 @@ class StreamBadgeNotification extends StatelessWidget {
     StreamBadgeNotificationType? type,
     StreamBadgeNotificationSize? size,
     required String label,
+    String? semanticLabel,
     Widget? child,
     AlignmentGeometry? alignment,
     Offset? offset,
@@ -103,6 +104,7 @@ class StreamBadgeNotification extends StatelessWidget {
          type: type,
          size: size,
          label: label,
+         semanticLabel: semanticLabel,
          child: child,
          alignment: alignment,
          offset: offset,
@@ -134,6 +136,7 @@ class StreamBadgeNotificationProps {
     this.type,
     this.size,
     required this.label,
+    this.semanticLabel,
     this.child,
     this.alignment,
     this.offset,
@@ -155,6 +158,13 @@ class StreamBadgeNotificationProps {
   /// Typically a numeric count (e.g., "5") or an overflow indicator
   /// (e.g., "99+").
   final String label;
+
+  /// An alternative label spoken by screen readers in place of [label].
+  ///
+  /// When null (the default), the visible [label] is announced as-is.
+  /// Provide a longer or more descriptive string (e.g. `"5 unread"`) when
+  /// the bare count would be ambiguous on its own.
+  final String? semanticLabel;
 
   /// The widget below this widget in the tree.
   ///
@@ -232,7 +242,7 @@ class DefaultStreamBadgeNotification extends StatelessWidget {
         ),
         child: DefaultTextStyle(
           style: textStyle,
-          child: Text(props.label),
+          child: Text(props.label, semanticsLabel: props.semanticLabel),
         ),
       ),
     );

--- a/packages/stream_core_flutter/lib/src/components/badge/stream_media_badge.dart
+++ b/packages/stream_core_flutter/lib/src/components/badge/stream_media_badge.dart
@@ -24,6 +24,7 @@ class StreamMediaBadge extends StatelessWidget {
     required this.type,
     this.duration,
     this.durationFormat = MediaBadgeDurationFormat.compact,
+    this.semanticsLabel,
   });
 
   final MediaBadgeType type;
@@ -31,6 +32,12 @@ class StreamMediaBadge extends StatelessWidget {
 
   /// How the [duration] value is formatted. Defaults to [MediaBadgeDurationFormat.compact].
   final MediaBadgeDurationFormat durationFormat;
+
+  /// An alternative semantics label for this badge.
+  ///
+  /// If present, the semantics of this widget will contain this value instead
+  /// of the rendered icon and duration.
+  final String? semanticsLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -41,7 +48,7 @@ class StreamMediaBadge extends StatelessWidget {
     final textTheme = context.streamTextTheme;
     final colorScheme = context.streamColorScheme;
 
-    return Container(
+    Widget badge = Container(
       decoration: BoxDecoration(
         color: colorScheme.backgroundInverse,
         borderRadius: .all(radius.max),
@@ -74,6 +81,15 @@ class StreamMediaBadge extends StatelessWidget {
         ],
       ),
     );
+
+    if (semanticsLabel case final label?) {
+      badge = Semantics(
+        label: label,
+        child: ExcludeSemantics(child: badge),
+      );
+    }
+
+    return badge;
   }
 }
 

--- a/packages/stream_core_flutter/lib/src/components/buttons/stream_button.dart
+++ b/packages/stream_core_flutter/lib/src/components/buttons/stream_button.dart
@@ -79,6 +79,7 @@ class StreamButton extends StatelessWidget {
     Widget? iconLeft,
     Widget? iconRight,
     bool? isSelected,
+    bool autofocus = false,
     StreamButtonThemeStyle? themeStyle,
   }) : props = .new(
          child: child,
@@ -89,6 +90,7 @@ class StreamButton extends StatelessWidget {
          iconLeft: iconLeft,
          iconRight: iconRight,
          isSelected: isSelected,
+         autofocus: autofocus,
          themeStyle: themeStyle,
        );
 
@@ -114,6 +116,8 @@ class StreamButton extends StatelessWidget {
     StreamButtonSize size = .medium,
     bool? isFloating,
     bool? isSelected,
+    bool autofocus = false,
+    String? tooltip,
     StreamButtonThemeStyle? themeStyle,
   }) : props = .new(
          onPressed: onPressed,
@@ -123,6 +127,8 @@ class StreamButton extends StatelessWidget {
          iconLeft: icon,
          isFloating: isFloating,
          isSelected: isSelected,
+         autofocus: autofocus,
+         tooltip: tooltip,
          themeStyle: themeStyle,
        );
 
@@ -165,6 +171,8 @@ class StreamButtonProps {
     this.iconRight,
     this.isFloating,
     this.isSelected,
+    this.autofocus = false,
+    this.tooltip,
     this.themeStyle,
   });
 
@@ -219,6 +227,21 @@ class StreamButtonProps {
   /// When true, the button displays selected styling.
   /// When false or null, the button is not selected.
   final bool? isSelected;
+
+  /// Whether the button should request focus when first mounted.
+  ///
+  /// When true, the button takes input focus as soon as it is inserted
+  /// into the tree.
+  /// When false, the button uses normal focus traversal.
+  final bool autofocus;
+
+  /// Text shown in a [Tooltip] on hover / long-press, and used as the
+  /// button's accessibility label.
+  ///
+  /// Only honoured by [StreamButton.icon]; the regular [StreamButton]
+  /// derives its label from its [child].
+  /// When null, the icon button has no tooltip.
+  final String? tooltip;
 
   /// Per-instance style overrides for this button.
   ///
@@ -378,6 +401,7 @@ class _DefaultStreamButtonState extends State<DefaultStreamButton> {
         };
 
     return ElevatedButton(
+      autofocus: props.autofocus,
       onPressed: props.onPressed,
       statesController: _statesController,
       style: ButtonStyle(
@@ -406,19 +430,25 @@ class _DefaultStreamButtonState extends State<DefaultStreamButton> {
           _ => null,
         },
       ),
-      child: switch (isIconButton) {
-        true => props.iconLeft,
-        false => Row(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.center,
-          spacing: spacing.xs,
-          children: [
-            ?props.iconLeft,
-            if (props.child case final child?) Flexible(child: child),
-            ?props.iconRight,
-          ],
-        ),
-      },
+      child: Semantics(
+        selected: props.isSelected,
+        child: switch (isIconButton) {
+          true => switch (props.tooltip) {
+            final tooltip? => Tooltip(message: tooltip, child: props.iconLeft),
+            null => props.iconLeft,
+          },
+          false => Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            spacing: spacing.xs,
+            children: [
+              ?props.iconLeft,
+              if (props.child case final child?) Flexible(child: child),
+              ?props.iconRight,
+            ],
+          ),
+        },
+      ),
     );
   }
 }

--- a/packages/stream_core_flutter/lib/src/components/buttons/stream_button.dart
+++ b/packages/stream_core_flutter/lib/src/components/buttons/stream_button.dart
@@ -400,43 +400,40 @@ class _DefaultStreamButtonState extends State<DefaultStreamButton> {
           false => WidgetStatePropertyAll(.symmetric(horizontal: spacing.md)),
         };
 
-    return ElevatedButton(
-      autofocus: props.autofocus,
-      onPressed: props.onPressed,
-      statesController: _statesController,
-      style: ButtonStyle(
-        tapTargetSize: effectiveTapTargetSize,
-        visualDensity: .standard,
-        textStyle: effectiveTextStyle,
-        iconSize: effectiveIconSize,
-        elevation: effectiveElevation,
-        backgroundColor: effectiveBackgroundColor,
-        foregroundColor: effectiveForegroundColor,
-        overlayColor: effectiveOverlayColor,
-        fixedSize: effectiveFixedSize,
-        minimumSize: effectiveMinimumSize,
-        maximumSize: effectiveMaximumSize,
-        padding: effectivePadding,
-        alignment: effectiveAlignment,
-        shape: effectiveShape,
-        side: switch (effectiveBorderColor) {
-          final color? => .resolveWith(
-            (states) {
-              final resolvedColor = color.resolve(states);
-              if (resolvedColor == null) return null;
-              return BorderSide(color: resolvedColor);
-            },
-          ),
-          _ => null,
-        },
-      ),
-      child: Semantics(
-        selected: props.isSelected,
-        child: switch (isIconButton) {
-          true => switch (props.tooltip) {
-            final tooltip? => Tooltip(message: tooltip, child: props.iconLeft),
-            null => props.iconLeft,
+    Widget button = Semantics(
+      selected: props.isSelected,
+      child: ElevatedButton(
+        autofocus: props.autofocus,
+        onPressed: props.onPressed,
+        statesController: _statesController,
+        style: ButtonStyle(
+          tapTargetSize: effectiveTapTargetSize,
+          visualDensity: .standard,
+          textStyle: effectiveTextStyle,
+          iconSize: effectiveIconSize,
+          elevation: effectiveElevation,
+          backgroundColor: effectiveBackgroundColor,
+          foregroundColor: effectiveForegroundColor,
+          overlayColor: effectiveOverlayColor,
+          fixedSize: effectiveFixedSize,
+          minimumSize: effectiveMinimumSize,
+          maximumSize: effectiveMaximumSize,
+          padding: effectivePadding,
+          alignment: effectiveAlignment,
+          shape: effectiveShape,
+          side: switch (effectiveBorderColor) {
+            final color? => .resolveWith(
+              (states) {
+                final resolvedColor = color.resolve(states);
+                if (resolvedColor == null) return null;
+                return BorderSide(color: resolvedColor);
+              },
+            ),
+            _ => null,
           },
+        ),
+        child: switch (isIconButton) {
+          true => props.iconLeft,
           false => Row(
             mainAxisSize: MainAxisSize.min,
             mainAxisAlignment: MainAxisAlignment.center,
@@ -450,6 +447,12 @@ class _DefaultStreamButtonState extends State<DefaultStreamButton> {
         },
       ),
     );
+
+    if (props.tooltip case final tooltip?) {
+      button = Tooltip(message: tooltip, child: button);
+    }
+
+    return MergeSemantics(child: button);
   }
 }
 

--- a/packages/stream_core_flutter/lib/src/components/common/stream_text_input.dart
+++ b/packages/stream_core_flutter/lib/src/components/common/stream_text_input.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 
 import '../../factory/stream_component_factory.dart';
@@ -324,12 +325,33 @@ class _DefaultStreamTextInputState extends State<DefaultStreamTextInput> {
   TextEditingController? _controller;
   FocusNode? _focusNode;
 
+  late final _leadingSortKey = OrdinalSortKey(0, name: hashCode.toString());
+  late final _trailingSortKey = OrdinalSortKey(1, name: hashCode.toString());
+  late final _helperSortKey = OrdinalSortKey(2, name: hashCode.toString());
+
   StreamTextInputProps get props => widget.props;
 
   TextEditingController get _effectiveController =>
       props.controller ?? (_controller ??= TextEditingController(text: props.initialValue));
 
   FocusNode get _effectiveFocusNode => props.focusNode ?? (_focusNode ??= FocusNode());
+
+  int get _currentLength => _effectiveController.value.text.characters.length;
+
+  int? get _semanticsMaxValueLength {
+    final maxLength = props.maxLength;
+    return (maxLength != null && maxLength > 0) ? maxLength : null;
+  }
+
+  void _handleDidGainAccessibilityFocus() {
+    if (_effectiveFocusNode.hasFocus) return;
+    if (!_effectiveFocusNode.canRequestFocus) return;
+    _effectiveFocusNode.requestFocus();
+  }
+
+  void _handleDidLoseAccessibilityFocus() {
+    _effectiveFocusNode.unfocus();
+  }
 
   @override
   void initState() {
@@ -418,82 +440,135 @@ class _DefaultStreamTextInputState extends State<DefaultStreamTextInput> {
       _ => style?.border ?? inputStyle?.border ?? defaults.border,
     };
 
-    return GestureDetector(
-      onTap: props.enabled ? _effectiveFocusNode.requestFocus : null,
-      child: Container(
-        clipBehavior: .hardEdge,
-        constraints: effectiveConstraints,
-        decoration: ShapeDecoration(
-          color: effectiveFillColor,
-          shape: RoundedSuperellipseBorder(
-            side: effectiveBorder,
-            borderRadius: effectiveBorderRadius,
-          ),
-        ),
-        child: Padding(
-          padding: effectiveContentPadding,
-          child: IconTheme(
-            data: IconThemeData(
-              size: effectiveIconSize,
-              color: effectiveIconColor,
+    return ListenableBuilder(
+      listenable: .merge([_effectiveFocusNode, _effectiveController]),
+      builder: (context, child) => Semantics(
+        container: true,
+        // Keep leading / trailing / helper as their own semantic siblings
+        // instead of merging into the field-level node.
+        explicitChildNodes: true,
+        textField: true,
+        focusable: true,
+        readOnly: props.readOnly,
+        enabled: props.enabled,
+        // Suppress the hint as the label once the user enters text — SR
+        // should announce the value alone, not the value + hint.
+        label: _effectiveController.text.isEmpty ? props.hintText : null,
+        value: _effectiveController.text,
+        // When the field has an error, surface its message as the semantic
+        // hint so SR users hear "<label>, edit box, <value>, <error>" rather
+        // than missing the validation feedback entirely.
+        hint: props.helperState == StreamHelperState.error ? props.helperText : null,
+        maxValueLength: _semanticsMaxValueLength,
+        currentValueLength: _currentLength,
+        onTap: switch (props.readOnly) {
+          true => null,
+          _ => () {
+            if (!_effectiveController.selection.isValid) {
+              _effectiveController.selection = TextSelection.collapsed(
+                offset: _effectiveController.text.length,
+              );
+            }
+            _effectiveFocusNode.requestFocus();
+          },
+        },
+        focused: _effectiveFocusNode.hasFocus,
+        onFocus: props.enabled ? _effectiveFocusNode.requestFocus : null,
+        onDidGainAccessibilityFocus: _handleDidGainAccessibilityFocus,
+        onDidLoseAccessibilityFocus: _handleDidLoseAccessibilityFocus,
+        child: child,
+      ),
+      child: GestureDetector(
+        onTap: props.enabled ? _effectiveFocusNode.requestFocus : null,
+        excludeFromSemantics: true,
+        child: Container(
+          clipBehavior: .hardEdge,
+          constraints: effectiveConstraints,
+          decoration: ShapeDecoration(
+            color: effectiveFillColor,
+            shape: RoundedSuperellipseBorder(
+              side: effectiveBorder,
+              borderRadius: effectiveBorderRadius,
             ),
-            child: StreamColumn(
-              spacing: spacing.sm,
-              mainAxisAlignment: .center,
-              crossAxisAlignment: .start,
-              children: [
-                StreamRow(
-                  spacing: spacing.xs,
-                  children: [
-                    ?props.leading,
-                    Expanded(
-                      child: TextField(
-                        autocorrect: props.autocorrect,
-                        controller: _effectiveController,
-                        focusNode: _effectiveFocusNode,
-                        onChanged: props.onChanged,
-                        onEditingComplete: props.onEditingComplete,
-                        onSubmitted: props.onSubmitted,
-                        onTap: props.onTap,
-                        style: effectiveTextStyle,
-                        cursorColor: effectiveCursorColor,
-                        cursorWidth: effectiveCursorWidth,
-                        cursorHeight: effectiveCursorHeight,
-                        cursorRadius: effectiveCursorRadius,
-                        keyboardType: props.keyboardType,
-                        textInputAction: props.textInputAction,
-                        inputFormatters: effectiveInputFormatters,
-                        autofocus: props.autofocus,
-                        readOnly: props.readOnly,
-                        textAlign: props.textAlign,
-                        textAlignVertical: props.textAlignVertical,
-                        textCapitalization: props.textCapitalization,
-                        maxLines: props.maxLines,
-                        minLines: props.minLines,
-                        maxLength: props.maxLength,
-                        enabled: props.enabled,
-                        decoration: InputDecoration(
-                          isCollapsed: true,
-                          filled: false,
-                          contentPadding: .zero,
-                          border: .none,
-                          enabledBorder: .none,
-                          focusedBorder: .none,
-                          disabledBorder: .none,
-                          errorBorder: .none,
-                          focusedErrorBorder: .none,
-                          enabled: props.enabled,
-                          hintText: props.hintText,
-                          hintStyle: effectiveHintStyle,
+          ),
+          child: Padding(
+            padding: effectiveContentPadding,
+            child: IconTheme(
+              data: IconThemeData(
+                size: effectiveIconSize,
+                color: effectiveIconColor,
+              ),
+              child: StreamColumn(
+                spacing: spacing.sm,
+                mainAxisAlignment: .center,
+                crossAxisAlignment: .start,
+                children: [
+                  StreamRow(
+                    spacing: spacing.xs,
+                    children: [
+                      if (props.leading case final leading?)
+                        Semantics(
+                          sortKey: _leadingSortKey,
+                          child: leading,
+                        ),
+                      Expanded(
+                        child: ExcludeSemantics(
+                          child: TextField(
+                            autocorrect: props.autocorrect,
+                            controller: _effectiveController,
+                            focusNode: _effectiveFocusNode,
+                            onChanged: props.onChanged,
+                            onEditingComplete: props.onEditingComplete,
+                            onSubmitted: props.onSubmitted,
+                            onTap: props.onTap,
+                            style: effectiveTextStyle,
+                            cursorColor: effectiveCursorColor,
+                            cursorWidth: effectiveCursorWidth,
+                            cursorHeight: effectiveCursorHeight,
+                            cursorRadius: effectiveCursorRadius,
+                            keyboardType: props.keyboardType,
+                            textInputAction: props.textInputAction,
+                            inputFormatters: effectiveInputFormatters,
+                            autofocus: props.autofocus,
+                            readOnly: props.readOnly,
+                            textAlign: props.textAlign,
+                            textAlignVertical: props.textAlignVertical,
+                            textCapitalization: props.textCapitalization,
+                            maxLines: props.maxLines,
+                            minLines: props.minLines,
+                            maxLength: props.maxLength,
+                            enabled: props.enabled,
+                            decoration: InputDecoration(
+                              isCollapsed: true,
+                              filled: false,
+                              contentPadding: .zero,
+                              border: .none,
+                              enabledBorder: .none,
+                              focusedBorder: .none,
+                              disabledBorder: .none,
+                              errorBorder: .none,
+                              focusedErrorBorder: .none,
+                              enabled: props.enabled,
+                              hintText: props.hintText,
+                              hintStyle: effectiveHintStyle,
+                            ),
+                          ),
                         ),
                       ),
+                      if (props.trailing case final trailing?)
+                        Semantics(
+                          sortKey: _trailingSortKey,
+                          child: trailing,
+                        ),
+                    ],
+                  ),
+                  if (props.helperText case final helperText?)
+                    Semantics(
+                      sortKey: _helperSortKey,
+                      child: StreamHelperText(text: helperText, state: props.helperState),
                     ),
-                    ?props.trailing,
-                  ],
-                ),
-                if (props.helperText case final helperText?)
-                  StreamHelperText(text: helperText, state: props.helperState),
-              ],
+                ],
+              ),
             ),
           ),
         ),
@@ -656,34 +731,40 @@ class _StreamHelperTextState extends State<StreamHelperText> with SingleTickerPr
       ),
     };
 
-    return FadeTransition(
-      opacity: _controller,
-      child: FractionalTranslation(
-        translation: Tween<Offset>(
-          begin: const Offset(0, -0.25),
-          end: Offset.zero,
-        ).evaluate(_controller.view),
-        child: IconTheme(
-          data: .new(
-            size: effectiveIconSize,
-            color: effectiveStyle.color,
-          ),
-          child: StreamRow(
-            spacing: spacing.xs,
-            mainAxisAlignment: .center,
-            crossAxisAlignment: .start,
-            children: [
-              effectiveIcon,
-              Expanded(
-                child: Text(
-                  widget.text,
-                  style: effectiveStyle,
-                  textAlign: widget.textAlign,
-                  maxLines: effectiveMaxLines,
-                  overflow: .ellipsis,
+    return Semantics(
+      container: true,
+      // Auto-announce error messages on appearance so SR users hear
+      // validation feedback without having to re-focus the field.
+      liveRegion: effectiveState == .error,
+      child: FadeTransition(
+        opacity: _controller,
+        child: FractionalTranslation(
+          translation: Tween<Offset>(
+            begin: const Offset(0, -0.25),
+            end: Offset.zero,
+          ).evaluate(_controller.view),
+          child: IconTheme(
+            data: .new(
+              size: effectiveIconSize,
+              color: effectiveStyle.color,
+            ),
+            child: StreamRow(
+              spacing: spacing.xs,
+              mainAxisAlignment: .center,
+              crossAxisAlignment: .start,
+              children: [
+                ExcludeSemantics(child: effectiveIcon),
+                Expanded(
+                  child: Text(
+                    widget.text,
+                    style: effectiveStyle,
+                    textAlign: widget.textAlign,
+                    maxLines: effectiveMaxLines,
+                    overflow: .ellipsis,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/packages/stream_core_flutter/lib/src/components/common/stream_text_input.dart
+++ b/packages/stream_core_flutter/lib/src/components/common/stream_text_input.dart
@@ -372,16 +372,6 @@ class _DefaultStreamTextInputState extends State<DefaultStreamTextInput> {
     return (maxLength != null && maxLength > 0) ? maxLength : null;
   }
 
-  void _handleDidGainAccessibilityFocus() {
-    if (_effectiveFocusNode.hasFocus) return;
-    if (!_effectiveFocusNode.canRequestFocus) return;
-    _effectiveFocusNode.requestFocus();
-  }
-
-  void _handleDidLoseAccessibilityFocus() {
-    _effectiveFocusNode.unfocus();
-  }
-
   @override
   void initState() {
     super.initState();
@@ -478,49 +468,64 @@ class _DefaultStreamTextInputState extends State<DefaultStreamTextInput> {
     final helperWidget = switch (props.helperText) {
       final helperText? => Semantics(
         sortKey: _helperSortKey,
+        liveRegion: hasError,
         child: StreamHelperText(text: helperText, state: props.helperState),
       ),
       _ => null,
     };
 
+    VoidCallback? handleDidGainAccessibilityFocus;
+    VoidCallback? handleDidLoseAccessibilityFocus;
+
+    final platform = Theme.of(context).platform;
+    if (platform == .macOS || platform == .linux || platform == .windows) {
+      // Automatically activate the TextField when it receives accessibility focus.
+      handleDidGainAccessibilityFocus = () {
+        if (_effectiveFocusNode.hasFocus) return;
+        if (!_effectiveFocusNode.canRequestFocus) return;
+        _effectiveFocusNode.requestFocus();
+      };
+
+      // Automatically unfocus the TextField when it loses accessibility focus.
+      handleDidLoseAccessibilityFocus = () {
+        _effectiveFocusNode.unfocus();
+      };
+    }
+
     return ListenableBuilder(
       listenable: .merge([_effectiveFocusNode, _effectiveController]),
-      builder: (context, child) => Semantics(
-        container: true,
-        // Keep leading / trailing / helper as their own semantic siblings
-        // instead of merging into the field-level node.
-        explicitChildNodes: true,
-        textField: true,
-        focusable: true,
-        readOnly: props.readOnly,
-        enabled: props.enabled,
-        // When a persistent label is provided it's always the semantic label;
-        // otherwise fall back to the hint while the field is empty so SR users hear *some* identifier.
-        label: props.labelText ?? (_effectiveController.text.isEmpty ? props.hintText : null),
-        value: _effectiveController.text,
-        // When the field has an error, surface its message as the semantic
-        // hint so SR users hear "<label>, edit box, <value>, <error>" rather
-        // than missing the validation feedback entirely.
-        hint: props.helperState == StreamHelperState.error ? props.helperText : null,
-        maxValueLength: _semanticsMaxValueLength,
-        currentValueLength: _currentLength,
-        onTap: switch (props.readOnly) {
-          true => null,
-          _ => () {
-            if (!_effectiveController.selection.isValid) {
-              _effectiveController.selection = TextSelection.collapsed(
-                offset: _effectiveController.text.length,
-              );
-            }
-            _effectiveFocusNode.requestFocus();
+      builder: (context, child) {
+        final hasLabel = props.labelText != null;
+        return Semantics(
+          container: true,
+          explicitChildNodes: true,
+          textField: true,
+          focusable: true,
+          readOnly: props.readOnly,
+          enabled: props.enabled,
+          label: hasLabel ? props.labelText : (_effectiveController.text.isEmpty ? props.hintText : null),
+          value: _effectiveController.text,
+          hint: hasLabel ? props.hintText : null,
+          maxValueLength: _semanticsMaxValueLength,
+          currentValueLength: _currentLength,
+          onTap: switch (props.readOnly) {
+            true => null,
+            _ => () {
+              if (!_effectiveController.selection.isValid) {
+                _effectiveController.selection = TextSelection.collapsed(
+                  offset: _effectiveController.text.length,
+                );
+              }
+              _effectiveFocusNode.requestFocus();
+            },
           },
-        },
-        focused: _effectiveFocusNode.hasFocus,
-        onFocus: props.enabled ? _effectiveFocusNode.requestFocus : null,
-        onDidGainAccessibilityFocus: _handleDidGainAccessibilityFocus,
-        onDidLoseAccessibilityFocus: _handleDidLoseAccessibilityFocus,
-        child: child,
-      ),
+          focused: _effectiveFocusNode.hasFocus,
+          onFocus: props.enabled ? _effectiveFocusNode.requestFocus : null,
+          onDidGainAccessibilityFocus: handleDidGainAccessibilityFocus,
+          onDidLoseAccessibilityFocus: handleDidLoseAccessibilityFocus,
+          child: child,
+        );
+      },
       child: StreamColumn(
         spacing: spacing.xs,
         mainAxisAlignment: .center,

--- a/packages/stream_core_flutter/lib/src/components/common/stream_text_input.dart
+++ b/packages/stream_core_flutter/lib/src/components/common/stream_text_input.dart
@@ -468,7 +468,6 @@ class _DefaultStreamTextInputState extends State<DefaultStreamTextInput> {
     final helperWidget = switch (props.helperText) {
       final helperText? => Semantics(
         sortKey: _helperSortKey,
-        liveRegion: hasError,
         child: StreamHelperText(text: helperText, state: props.helperState),
       ),
       _ => null,

--- a/packages/stream_core_flutter/lib/src/components/common/stream_text_input.dart
+++ b/packages/stream_core_flutter/lib/src/components/common/stream_text_input.dart
@@ -64,6 +64,19 @@ import 'stream_flex.dart';
 /// ```
 /// {@end-tool}
 ///
+/// {@tool snippet}
+///
+/// Labeled text input:
+///
+/// ```dart
+/// StreamTextInput(
+///   labelText: 'Email',
+///   hintText: 'name@example.com',
+///   keyboardType: TextInputType.emailAddress,
+/// )
+/// ```
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [StreamTextInputTheme], for customizing text input appearance.
@@ -81,6 +94,7 @@ class StreamTextInput extends StatelessWidget {
     bool enabled = true,
     Widget? leading,
     Widget? trailing,
+    String? labelText,
     String? hintText,
     String? helperText,
     StreamHelperState? helperState,
@@ -108,6 +122,7 @@ class StreamTextInput extends StatelessWidget {
          enabled: enabled,
          leading: leading,
          trailing: trailing,
+         labelText: labelText,
          hintText: hintText,
          helperText: helperText,
          helperState: helperState,
@@ -162,6 +177,7 @@ class StreamTextInputProps {
     this.enabled = true,
     this.leading,
     this.trailing,
+    this.labelText,
     this.hintText,
     this.helperText,
     this.helperState,
@@ -211,7 +227,20 @@ class StreamTextInputProps {
   /// An optional widget to display after the text input area.
   final Widget? trailing;
 
+  /// Persistent label rendered above the input area.
+  ///
+  /// When provided, also becomes the field's accessibility label —
+  /// announced by screen readers regardless of whether the field is empty
+  /// or filled.
+  ///
+  /// When null, no visible label is shown and the field falls back to
+  /// using [hintText] as the semantic label while empty.
+  final String? labelText;
+
   /// Placeholder text shown when the field is empty.
+  ///
+  /// When [labelText] is null, this also serves as the field's semantic
+  /// label while the field is empty.
   final String? hintText;
 
   /// Helper message displayed below the text input with animation.
@@ -415,6 +444,11 @@ class _DefaultStreamTextInputState extends State<DefaultStreamTextInput> {
       states,
     );
 
+    final effectiveLabelStyle = WidgetStateProperty.resolveAs(
+      style?.labelStyle ?? inputStyle?.labelStyle ?? defaults.labelStyle,
+      states,
+    );
+
     final effectiveContentPadding = style?.contentPadding ?? inputStyle?.contentPadding ?? defaults.contentPadding;
     final effectiveBorderRadius = style?.borderRadius ?? inputStyle?.borderRadius ?? defaults.borderRadius;
     final effectiveFillColor = style?.fillColor ?? inputStyle?.fillColor ?? defaults.fillColor;
@@ -440,6 +474,15 @@ class _DefaultStreamTextInputState extends State<DefaultStreamTextInput> {
       _ => style?.border ?? inputStyle?.border ?? defaults.border,
     };
 
+    final effectiveHelperAffinity = style?.helperAffinity ?? inputStyle?.helperAffinity ?? defaults.helperAffinity;
+    final helperWidget = switch (props.helperText) {
+      final helperText? => Semantics(
+        sortKey: _helperSortKey,
+        child: StreamHelperText(text: helperText, state: props.helperState),
+      ),
+      _ => null,
+    };
+
     return ListenableBuilder(
       listenable: .merge([_effectiveFocusNode, _effectiveController]),
       builder: (context, child) => Semantics(
@@ -451,9 +494,9 @@ class _DefaultStreamTextInputState extends State<DefaultStreamTextInput> {
         focusable: true,
         readOnly: props.readOnly,
         enabled: props.enabled,
-        // Suppress the hint as the label once the user enters text — SR
-        // should announce the value alone, not the value + hint.
-        label: _effectiveController.text.isEmpty ? props.hintText : null,
+        // When a persistent label is provided it's always the semantic label;
+        // otherwise fall back to the hint while the field is empty so SR users hear *some* identifier.
+        label: props.labelText ?? (_effectiveController.text.isEmpty ? props.hintText : null),
         value: _effectiveController.text,
         // When the field has an error, surface its message as the semantic
         // hint so SR users hear "<label>, edit box, <value>, <error>" rather
@@ -478,100 +521,113 @@ class _DefaultStreamTextInputState extends State<DefaultStreamTextInput> {
         onDidLoseAccessibilityFocus: _handleDidLoseAccessibilityFocus,
         child: child,
       ),
-      child: GestureDetector(
-        onTap: props.enabled ? _effectiveFocusNode.requestFocus : null,
-        excludeFromSemantics: true,
-        child: Container(
-          clipBehavior: .hardEdge,
-          constraints: effectiveConstraints,
-          decoration: ShapeDecoration(
-            color: effectiveFillColor,
-            shape: RoundedSuperellipseBorder(
-              side: effectiveBorder,
-              borderRadius: effectiveBorderRadius,
-            ),
-          ),
-          child: Padding(
-            padding: effectiveContentPadding,
-            child: IconTheme(
-              data: IconThemeData(
-                size: effectiveIconSize,
-                color: effectiveIconColor,
+      child: StreamColumn(
+        spacing: spacing.xs,
+        mainAxisAlignment: .center,
+        crossAxisAlignment: .start,
+        children: [
+          if (props.labelText case final labelText?)
+            ExcludeSemantics(
+              child: Text(
+                labelText,
+                maxLines: 1,
+                style: effectiveLabelStyle,
+                overflow: TextOverflow.ellipsis,
               ),
-              child: StreamColumn(
-                spacing: spacing.sm,
-                mainAxisAlignment: .center,
-                crossAxisAlignment: .start,
-                children: [
-                  StreamRow(
-                    spacing: spacing.xs,
+            ),
+          GestureDetector(
+            onTap: props.enabled ? _effectiveFocusNode.requestFocus : null,
+            excludeFromSemantics: true,
+            child: Container(
+              clipBehavior: .hardEdge,
+              constraints: effectiveConstraints,
+              decoration: ShapeDecoration(
+                color: effectiveFillColor,
+                shape: RoundedSuperellipseBorder(
+                  side: effectiveBorder,
+                  borderRadius: effectiveBorderRadius,
+                ),
+              ),
+              child: Padding(
+                padding: effectiveContentPadding,
+                child: IconTheme(
+                  data: IconThemeData(
+                    size: effectiveIconSize,
+                    color: effectiveIconColor,
+                  ),
+                  child: StreamColumn(
+                    spacing: spacing.sm,
+                    mainAxisAlignment: .center,
+                    crossAxisAlignment: .start,
                     children: [
-                      if (props.leading case final leading?)
-                        Semantics(
-                          sortKey: _leadingSortKey,
-                          child: leading,
-                        ),
-                      Expanded(
-                        child: ExcludeSemantics(
-                          child: TextField(
-                            autocorrect: props.autocorrect,
-                            controller: _effectiveController,
-                            focusNode: _effectiveFocusNode,
-                            onChanged: props.onChanged,
-                            onEditingComplete: props.onEditingComplete,
-                            onSubmitted: props.onSubmitted,
-                            onTap: props.onTap,
-                            style: effectiveTextStyle,
-                            cursorColor: effectiveCursorColor,
-                            cursorWidth: effectiveCursorWidth,
-                            cursorHeight: effectiveCursorHeight,
-                            cursorRadius: effectiveCursorRadius,
-                            keyboardType: props.keyboardType,
-                            textInputAction: props.textInputAction,
-                            inputFormatters: effectiveInputFormatters,
-                            autofocus: props.autofocus,
-                            readOnly: props.readOnly,
-                            textAlign: props.textAlign,
-                            textAlignVertical: props.textAlignVertical,
-                            textCapitalization: props.textCapitalization,
-                            maxLines: props.maxLines,
-                            minLines: props.minLines,
-                            maxLength: props.maxLength,
-                            enabled: props.enabled,
-                            decoration: InputDecoration(
-                              isCollapsed: true,
-                              filled: false,
-                              contentPadding: .zero,
-                              border: .none,
-                              enabledBorder: .none,
-                              focusedBorder: .none,
-                              disabledBorder: .none,
-                              errorBorder: .none,
-                              focusedErrorBorder: .none,
-                              enabled: props.enabled,
-                              hintText: props.hintText,
-                              hintStyle: effectiveHintStyle,
+                      StreamRow(
+                        spacing: spacing.xs,
+                        children: [
+                          if (props.leading case final leading?)
+                            Semantics(
+                              sortKey: _leadingSortKey,
+                              child: leading,
+                            ),
+                          Expanded(
+                            child: ExcludeSemantics(
+                              child: TextField(
+                                autocorrect: props.autocorrect,
+                                controller: _effectiveController,
+                                focusNode: _effectiveFocusNode,
+                                onChanged: props.onChanged,
+                                onEditingComplete: props.onEditingComplete,
+                                onSubmitted: props.onSubmitted,
+                                onTap: props.onTap,
+                                style: effectiveTextStyle,
+                                cursorColor: effectiveCursorColor,
+                                cursorWidth: effectiveCursorWidth,
+                                cursorHeight: effectiveCursorHeight,
+                                cursorRadius: effectiveCursorRadius,
+                                keyboardType: props.keyboardType,
+                                textInputAction: props.textInputAction,
+                                inputFormatters: effectiveInputFormatters,
+                                autofocus: props.autofocus,
+                                readOnly: props.readOnly,
+                                textAlign: props.textAlign,
+                                textAlignVertical: props.textAlignVertical,
+                                textCapitalization: props.textCapitalization,
+                                maxLines: props.maxLines,
+                                minLines: props.minLines,
+                                maxLength: props.maxLength,
+                                enabled: props.enabled,
+                                decoration: InputDecoration(
+                                  isCollapsed: true,
+                                  filled: false,
+                                  contentPadding: .zero,
+                                  border: .none,
+                                  enabledBorder: .none,
+                                  focusedBorder: .none,
+                                  disabledBorder: .none,
+                                  errorBorder: .none,
+                                  focusedErrorBorder: .none,
+                                  enabled: props.enabled,
+                                  hintText: props.hintText,
+                                  hintStyle: effectiveHintStyle,
+                                ),
+                              ),
                             ),
                           ),
-                        ),
+                          if (props.trailing case final trailing?)
+                            Semantics(
+                              sortKey: _trailingSortKey,
+                              child: trailing,
+                            ),
+                        ],
                       ),
-                      if (props.trailing case final trailing?)
-                        Semantics(
-                          sortKey: _trailingSortKey,
-                          child: trailing,
-                        ),
+                      if (effectiveHelperAffinity == .inside) ?helperWidget,
                     ],
                   ),
-                  if (props.helperText case final helperText?)
-                    Semantics(
-                      sortKey: _helperSortKey,
-                      child: StreamHelperText(text: helperText, state: props.helperState),
-                    ),
-                ],
+                ),
               ),
             ),
           ),
-        ),
+          if (effectiveHelperAffinity == .outside) ?helperWidget,
+        ],
       ),
     );
   }
@@ -829,7 +885,13 @@ class _StreamTextInputDefaults extends StreamTextInputStyle {
   });
 
   @override
+  TextStyle get labelStyle => _textTheme.headingSm.copyWith(color: _colorScheme.textPrimary);
+
+  @override
   EdgeInsetsGeometry get contentPadding => .symmetric(vertical: _spacing.sm, horizontal: _spacing.md);
+
+  @override
+  StreamHelperAffinity get helperAffinity => StreamHelperAffinity.inside;
 }
 
 // Default theme values for [StreamHelperText].

--- a/packages/stream_core_flutter/lib/src/components/controls/stream_stepper.dart
+++ b/packages/stream_core_flutter/lib/src/components/controls/stream_stepper.dart
@@ -72,12 +72,14 @@ class StreamStepper extends StatelessWidget {
     required ValueChanged<int>? onChanged,
     int min = 0,
     int max = 99,
+    String? semanticLabel,
     StreamStepperStyle? style,
   }) : props = .new(
          value: value,
          onChanged: onChanged,
          min: min,
          max: max,
+         semanticLabel: semanticLabel,
          style: style,
        );
 
@@ -108,6 +110,7 @@ class StreamStepperProps {
     required this.onChanged,
     this.min = 0,
     this.max = 99,
+    this.semanticLabel,
     this.style,
   }) : assert(min <= max, 'min must be <= max'),
        assert(value >= min && value <= max, 'value must be between min and max');
@@ -131,6 +134,14 @@ class StreamStepperProps {
   /// The increment button is disabled when [value] equals [max].
   /// Defaults to 99.
   final int max;
+
+  /// Semantic label announced when a screen reader focuses the stepper.
+  ///
+  /// Describes what the value represents (e.g. `"Quantity"`,
+  /// `"Number of items"`). Announced alongside the current [value], and
+  /// followed by the platform's adjustable hint ("Swipe up or down" on
+  /// iOS VoiceOver; "Use volume keys" on Android TalkBack).
+  final String? semanticLabel;
 
   /// Per-instance style overrides.
   ///
@@ -211,32 +222,43 @@ class _DefaultStreamStepperState extends State<DefaultStreamStepper> {
     final effectiveInputStyle = style?.inputStyle ?? themeStyle?.inputStyle ?? defaults.inputStyle;
     final effectiveSpacing = style?.spacing ?? themeStyle?.spacing ?? defaults.spacing;
 
-    return Row(
-      mainAxisSize: .min,
-      spacing: effectiveSpacing,
-      children: [
-        StreamButton.icon(
-          icon: Icon(icons.minus),
-          style: .secondary,
-          type: .outline,
-          themeStyle: effectiveButtonStyle,
-          onPressed: canDecrement ? _decrement : null,
-        ),
-        StreamTextInput(
-          controller: _controller,
-          readOnly: true,
-          enabled: _isEnabled,
-          textAlign: TextAlign.center,
-          style: effectiveInputStyle,
-        ),
-        StreamButton.icon(
-          icon: Icon(icons.plus),
-          style: .secondary,
-          type: .outline,
-          themeStyle: effectiveButtonStyle,
-          onPressed: canIncrement ? _increment : null,
-        ),
-      ],
+    return Semantics(
+      slider: true,
+      enabled: _isEnabled,
+      excludeSemantics: true,
+      label: props.semanticLabel,
+      value: props.value.toString(),
+      increasedValue: canIncrement ? (props.value + 1).toString() : null,
+      decreasedValue: canDecrement ? (props.value - 1).toString() : null,
+      onIncrease: canIncrement ? _increment : null,
+      onDecrease: canDecrement ? _decrement : null,
+      child: Row(
+        mainAxisSize: .min,
+        spacing: effectiveSpacing,
+        children: [
+          StreamButton.icon(
+            icon: Icon(icons.minus),
+            style: .secondary,
+            type: .outline,
+            themeStyle: effectiveButtonStyle,
+            onPressed: canDecrement ? _decrement : null,
+          ),
+          StreamTextInput(
+            controller: _controller,
+            readOnly: true,
+            enabled: _isEnabled,
+            textAlign: TextAlign.center,
+            style: effectiveInputStyle,
+          ),
+          StreamButton.icon(
+            icon: Icon(icons.plus),
+            style: .secondary,
+            type: .outline,
+            themeStyle: effectiveButtonStyle,
+            onPressed: canIncrement ? _increment : null,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/stream_core_flutter/lib/src/components/list/stream_list_tile.dart
+++ b/packages/stream_core_flutter/lib/src/components/list/stream_list_tile.dart
@@ -90,6 +90,8 @@ class StreamListTile extends StatelessWidget {
     EdgeInsetsGeometry? contentPadding,
     TextStyle? titleTextStyle,
     TextStyle? subtitleTextStyle,
+    FocusNode? focusNode,
+    bool autofocus = false,
   }) : props = .new(
          leading: leading,
          title: title,
@@ -103,6 +105,8 @@ class StreamListTile extends StatelessWidget {
          contentPadding: contentPadding,
          titleTextStyle: titleTextStyle,
          subtitleTextStyle: subtitleTextStyle,
+         focusNode: focusNode,
+         autofocus: autofocus,
        );
 
   /// The props controlling the appearance and behavior of this tile.
@@ -140,6 +144,8 @@ class StreamListTileProps {
     this.contentPadding,
     this.titleTextStyle,
     this.subtitleTextStyle,
+    this.focusNode,
+    this.autofocus = false,
   });
 
   /// A widget displayed before the title.
@@ -207,6 +213,12 @@ class StreamListTileProps {
   ///
   /// Overrides [StreamListTileThemeData.subtitleTextStyle] for this tile.
   final TextStyle? subtitleTextStyle;
+
+  /// {@macro flutter.widgets.Focus.focusNode}
+  final FocusNode? focusNode;
+
+  /// {@macro flutter.widgets.Focus.autofocus}
+  final bool autofocus;
 }
 
 /// The default implementation of [StreamListTile].
@@ -300,6 +312,8 @@ class DefaultStreamListTile extends StatelessWidget {
       onTap: props.onTap,
       onLongPress: props.onLongPress,
       contentPadding: props.contentPadding,
+      focusNode: props.focusNode,
+      autofocus: props.autofocus,
       child: IconTheme.merge(
         data: IconThemeData(color: effectiveIconColor),
         child: ConstrainedBox(
@@ -426,6 +440,8 @@ class StreamListTileContainer extends StatelessWidget {
     this.onTap,
     this.onLongPress,
     this.contentPadding,
+    this.focusNode,
+    this.autofocus = false,
   });
 
   /// The content to display inside the container.
@@ -460,6 +476,12 @@ class StreamListTileContainer extends StatelessWidget {
   /// Overrides [StreamListTileThemeData.contentPadding] for this tile.
   final EdgeInsetsGeometry? contentPadding;
 
+  /// {@macro flutter.widgets.Focus.focusNode}
+  final FocusNode? focusNode;
+
+  /// {@macro flutter.widgets.Focus.autofocus}
+  final bool autofocus;
+
   @override
   Widget build(BuildContext context) {
     final theme = context.streamListTileTheme;
@@ -493,6 +515,8 @@ class StreamListTileContainer extends StatelessWidget {
       onTap: enabled ? onTap : null,
       onLongPress: enabled ? onLongPress : null,
       canRequestFocus: enabled,
+      focusNode: focusNode,
+      autofocus: autofocus,
       mouseCursor: effectiveMouseCursor,
       overlayColor: effectiveOverlayColor,
       child: Semantics(

--- a/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_attachment.dart
+++ b/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_attachment.dart
@@ -62,10 +62,14 @@ class StreamMessageComposerAttachment extends StatelessWidget {
     super.key,
     required Widget child,
     VoidCallback? onRemovePressed,
+    String? semanticLabel,
+    bool mergeRemoveAction = true,
     StreamMessageComposerAttachmentThemeData? style,
   }) : props = .new(
          child: child,
          onRemovePressed: onRemovePressed,
+         semanticLabel: semanticLabel,
+         mergeRemoveAction: mergeRemoveAction,
          style: style,
        );
 
@@ -94,6 +98,8 @@ class StreamMessageComposerAttachmentProps {
   const StreamMessageComposerAttachmentProps({
     required this.child,
     this.onRemovePressed,
+    this.semanticLabel,
+    this.mergeRemoveAction = true,
     this.style,
   });
 
@@ -107,6 +113,26 @@ class StreamMessageComposerAttachmentProps {
   /// When non-null, a [StreamRemoveControl] is overlaid at the top-end corner of the
   /// container. When null, no remove control is shown.
   final VoidCallback? onRemovePressed;
+
+  /// Semantic label announced when a screen reader focuses the attachment.
+  ///
+  /// Typically a type prefix ("File", "Photo", "Video", …). When
+  /// [onRemovePressed] is non-null, the focused tile additionally exposes a
+  /// `tap` action whose hint reads "remove"; activating it calls
+  /// [onRemovePressed].
+  final String? semanticLabel;
+
+  /// Whether the entire tile (content + remove button) collapses into a
+  /// single screen-reader focus stop whose `tap` action maps to
+  /// [onRemovePressed].
+  ///
+  /// Defaults to `true` — appropriate for tiles whose [child] has no
+  /// interactive elements (file row, image thumbnail, unsupported chip).
+  /// Set to `false` when the [child] exposes its own actions (e.g. a voice
+  /// recording with play/pause and seek controls); the remove button then
+  /// stays as a separate stop and the outer tile contributes no `tap`
+  /// action.
+  final bool mergeRemoveAction;
 
   /// Per-instance style overrides.
   ///
@@ -141,7 +167,7 @@ class DefaultStreamMessageComposerAttachment extends StatelessWidget {
     final effectiveBackgroundColor = theme.backgroundColor ?? defaults.backgroundColor;
     final effectivePadding = theme.padding ?? defaults.padding;
 
-    final container = Padding(
+    final innerContent = Padding(
       padding: effectivePadding,
       child: Material(
         clipBehavior: .hardEdge,
@@ -151,7 +177,20 @@ class DefaultStreamMessageComposerAttachment extends StatelessWidget {
       ),
     );
 
+    final container = props.mergeRemoveAction
+        // TODO(localize): move "remove" hint to localizations.
+        ? MergeSemantics(
+            child: Semantics(
+              label: props.semanticLabel,
+              onTap: props.onRemovePressed,
+              onTapHint: 'remove',
+              child: innerContent,
+            ),
+          )
+        : innerContent;
+
     if (props.onRemovePressed case final onPressed?) {
+      final removeControl = StreamRemoveControl(onPressed: onPressed);
       return Stack(
         clipBehavior: .none,
         children: [
@@ -159,7 +198,9 @@ class DefaultStreamMessageComposerAttachment extends StatelessWidget {
           PositionedDirectional(
             top: 0,
             end: 0,
-            child: StreamRemoveControl(onPressed: onPressed),
+            child: props.mergeRemoveAction //
+                ? ExcludeSemantics(child: removeControl)
+                : removeControl,
           ),
         ],
       );

--- a/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_attachment.dart
+++ b/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_attachment.dart
@@ -113,10 +113,10 @@ class StreamMessageComposerAttachmentProps {
 
   /// Semantic label announced when a screen reader focuses the attachment.
   ///
-  /// Typically a type prefix ("File", "Photo", "Video", …). When
-  /// [onRemovePressed] is non-null, the focused tile additionally exposes a
-  /// `tap` action whose hint reads "remove"; activating it calls
-  /// [onRemovePressed].
+  /// Typically a localized type prefix (e.g. `"File"`, `"Photo"`, `"Video"`).
+  /// When [onRemovePressed] is non-null, the tile additionally exposes a
+  /// `tap` action hinted by [MaterialLocalizations.deleteButtonTooltip]
+  /// that invokes [onRemovePressed].
   final String? semanticLabel;
 
   /// Per-instance style overrides.
@@ -147,6 +147,8 @@ class DefaultStreamMessageComposerAttachment extends StatelessWidget {
     final theme = context.streamMessageComposerAttachmentTheme.merge(props.style);
     final defaults = _StreamMessageComposerAttachmentDefaults(context);
 
+    final localizations = MaterialLocalizations.of(context);
+
     final effectiveSide = theme.side ?? defaults.side;
     final effectiveShape = (theme.shape ?? defaults.shape).copyWith(side: effectiveSide);
     final effectiveBackgroundColor = theme.backgroundColor ?? defaults.backgroundColor;
@@ -165,13 +167,12 @@ class DefaultStreamMessageComposerAttachment extends StatelessWidget {
     // The whole tile is one SR focus stop that reads `semanticLabel` and
     // activates the remove callback on tap. The overlaid remove control is
     // hidden from SR since its behavior is already exposed on the merged
-    // node. Uses MaterialLocalizations.deleteButtonTooltip so the hint
-    // is localized alongside the rest of the Material widgets in the app.
+    // node.
     final container = MergeSemantics(
       child: Semantics(
         label: props.semanticLabel,
         onTap: props.onRemovePressed,
-        onTapHint: MaterialLocalizations.of(context).deleteButtonTooltip,
+        onTapHint: localizations.deleteButtonTooltip,
         child: innerContent,
       ),
     );

--- a/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_attachment.dart
+++ b/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_attachment.dart
@@ -198,7 +198,9 @@ class DefaultStreamMessageComposerAttachment extends StatelessWidget {
           PositionedDirectional(
             top: 0,
             end: 0,
-            child: props.mergeRemoveAction //
+            child:
+                props
+                    .mergeRemoveAction //
                 ? ExcludeSemantics(child: removeControl)
                 : removeControl,
           ),

--- a/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_attachment.dart
+++ b/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_attachment.dart
@@ -63,13 +63,11 @@ class StreamMessageComposerAttachment extends StatelessWidget {
     required Widget child,
     VoidCallback? onRemovePressed,
     String? semanticLabel,
-    bool mergeRemoveAction = true,
     StreamMessageComposerAttachmentThemeData? style,
   }) : props = .new(
          child: child,
          onRemovePressed: onRemovePressed,
          semanticLabel: semanticLabel,
-         mergeRemoveAction: mergeRemoveAction,
          style: style,
        );
 
@@ -99,7 +97,6 @@ class StreamMessageComposerAttachmentProps {
     required this.child,
     this.onRemovePressed,
     this.semanticLabel,
-    this.mergeRemoveAction = true,
     this.style,
   });
 
@@ -121,18 +118,6 @@ class StreamMessageComposerAttachmentProps {
   /// `tap` action whose hint reads "remove"; activating it calls
   /// [onRemovePressed].
   final String? semanticLabel;
-
-  /// Whether the entire tile (content + remove button) collapses into a
-  /// single screen-reader focus stop whose `tap` action maps to
-  /// [onRemovePressed].
-  ///
-  /// Defaults to `true` — appropriate for tiles whose [child] has no
-  /// interactive elements (file row, image thumbnail, unsupported chip).
-  /// Set to `false` when the [child] exposes its own actions (e.g. a voice
-  /// recording with play/pause and seek controls); the remove button then
-  /// stays as a separate stop and the outer tile contributes no `tap`
-  /// action.
-  final bool mergeRemoveAction;
 
   /// Per-instance style overrides.
   ///
@@ -177,23 +162,21 @@ class DefaultStreamMessageComposerAttachment extends StatelessWidget {
       ),
     );
 
-    final container = props.mergeRemoveAction
-        // TODO(localize): move "remove" hint to localizations.
-        ? MergeSemantics(
-            child: Semantics(
-              label: props.semanticLabel,
-              onTap: props.onRemovePressed,
-              onTapHint: 'remove',
-              child: innerContent,
-            ),
-          )
-        : Semantics(
-            label: props.semanticLabel,
-            child: innerContent,
-          );
+    // The whole tile is one SR focus stop that reads `semanticLabel` and
+    // activates the remove callback on tap. The overlaid remove control is
+    // hidden from SR since its behavior is already exposed on the merged
+    // node.
+    // TODO(localize): move "remove" hint to localizations.
+    final container = MergeSemantics(
+      child: Semantics(
+        label: props.semanticLabel,
+        onTap: props.onRemovePressed,
+        onTapHint: 'remove',
+        child: innerContent,
+      ),
+    );
 
     if (props.onRemovePressed case final onPressed?) {
-      final removeControl = StreamRemoveControl(onPressed: onPressed);
       return Stack(
         clipBehavior: .none,
         children: [
@@ -201,11 +184,7 @@ class DefaultStreamMessageComposerAttachment extends StatelessWidget {
           PositionedDirectional(
             top: 0,
             end: 0,
-            child:
-                props
-                    .mergeRemoveAction //
-                ? ExcludeSemantics(child: removeControl)
-                : removeControl,
+            child: ExcludeSemantics(child: StreamRemoveControl(onPressed: onPressed)),
           ),
         ],
       );

--- a/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_attachment.dart
+++ b/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_attachment.dart
@@ -165,13 +165,13 @@ class DefaultStreamMessageComposerAttachment extends StatelessWidget {
     // The whole tile is one SR focus stop that reads `semanticLabel` and
     // activates the remove callback on tap. The overlaid remove control is
     // hidden from SR since its behavior is already exposed on the merged
-    // node.
-    // TODO(localize): move "remove" hint to localizations.
+    // node. Uses MaterialLocalizations.deleteButtonTooltip so the hint
+    // is localized alongside the rest of the Material widgets in the app.
     final container = MergeSemantics(
       child: Semantics(
         label: props.semanticLabel,
         onTap: props.onRemovePressed,
-        onTapHint: 'remove',
+        onTapHint: MaterialLocalizations.of(context).deleteButtonTooltip,
         child: innerContent,
       ),
     );

--- a/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_attachment.dart
+++ b/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_attachment.dart
@@ -187,7 +187,10 @@ class DefaultStreamMessageComposerAttachment extends StatelessWidget {
               child: innerContent,
             ),
           )
-        : innerContent;
+        : Semantics(
+            label: props.semanticLabel,
+            child: innerContent,
+          );
 
     if (props.onRemovePressed case final onPressed?) {
       final removeControl = StreamRemoveControl(onPressed: onPressed);

--- a/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_file_attachment.dart
+++ b/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_file_attachment.dart
@@ -165,29 +165,33 @@ class DefaultStreamMessageComposerFileAttachment extends StatelessWidget {
       );
     }
 
-    return StreamMessageComposerAttachment(
-      onRemovePressed: props.onRemovePressed,
-      child: ConstrainedBox(
-        constraints: _kDefaultConstraints,
-        child: Padding(
-          padding: effectivePadding,
-          child: Row(
-            mainAxisSize: .min,
-            spacing: effectiveSpacing,
-            children: [
-              ?props.fileTypeIcon,
-              Expanded(
-                child: Column(
-                  spacing: spacing.xxs,
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [effectiveTitle, ?effectiveSubtitle],
-                ),
+    final content = ConstrainedBox(
+      constraints: _kDefaultConstraints,
+      child: Padding(
+        padding: effectivePadding,
+        child: Row(
+          mainAxisSize: .min,
+          spacing: effectiveSpacing,
+          children: [
+            ?props.fileTypeIcon,
+            Expanded(
+              child: Column(
+                spacing: spacing.xxs,
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [effectiveTitle, ?effectiveSubtitle],
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
+    );
+
+    return StreamMessageComposerAttachment(
+      onRemovePressed: props.onRemovePressed,
+      // TODO(localize): move "File" prefix to localizations.
+      semanticLabel: 'File',
+      child: content,
     );
   }
 }

--- a/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_file_attachment.dart
+++ b/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_file_attachment.dart
@@ -51,12 +51,14 @@ class StreamMessageComposerFileAttachment extends StatelessWidget {
     Widget? subtitle,
     StreamFileTypeIcon? fileTypeIcon,
     VoidCallback? onRemovePressed,
+    String? semanticLabel,
     StreamMessageComposerFileAttachmentThemeData? style,
   }) : props = .new(
          title: title,
          subtitle: subtitle,
          fileTypeIcon: fileTypeIcon,
          onRemovePressed: onRemovePressed,
+         semanticLabel: semanticLabel,
          style: style,
        );
 
@@ -87,6 +89,7 @@ class StreamMessageComposerFileAttachmentProps {
     this.subtitle,
     this.fileTypeIcon,
     this.onRemovePressed,
+    this.semanticLabel,
     this.style,
   });
 
@@ -111,6 +114,9 @@ class StreamMessageComposerFileAttachmentProps {
   ///
   /// When null, no remove control is shown on the surrounding container.
   final VoidCallback? onRemovePressed;
+
+  /// Semantic label announced when a screen reader focuses the attachment.
+  final String? semanticLabel;
 
   /// Per-instance style overrides.
   ///
@@ -189,8 +195,7 @@ class DefaultStreamMessageComposerFileAttachment extends StatelessWidget {
 
     return StreamMessageComposerAttachment(
       onRemovePressed: props.onRemovePressed,
-      // TODO(localize): move "File" prefix to localizations.
-      semanticLabel: 'File',
+      semanticLabel: props.semanticLabel,
       child: content,
     );
   }

--- a/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_file_attachment.dart
+++ b/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_file_attachment.dart
@@ -115,7 +115,14 @@ class StreamMessageComposerFileAttachmentProps {
   /// When null, no remove control is shown on the surrounding container.
   final VoidCallback? onRemovePressed;
 
-  /// Semantic label announced when a screen reader focuses the attachment.
+  /// Semantic label for the attachment.
+  ///
+  /// Announced in accessibility modes (e.g. TalkBack/VoiceOver). This label
+  /// does not show in the UI. Typically a type prefix ("File", "Document")
+  /// so screen-reader users can distinguish attachment kinds.
+  ///
+  ///  * [SemanticsProperties.label], which is set to [semanticLabel] in
+  ///    the underlying [Semantics] widget.
   final String? semanticLabel;
 
   /// Per-instance style overrides.

--- a/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_media_attachment.dart
+++ b/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_media_attachment.dart
@@ -62,11 +62,13 @@ class StreamMessageComposerMediaAttachment extends StatelessWidget {
     required Widget child,
     VoidCallback? onRemovePressed,
     Widget? mediaBadge,
+    String? semanticLabel,
     StreamMessageComposerMediaAttachmentThemeData? style,
   }) : props = .new(
          child: child,
          onRemovePressed: onRemovePressed,
          mediaBadge: mediaBadge,
+         semanticLabel: semanticLabel,
          style: style,
        );
 
@@ -96,6 +98,7 @@ class StreamMessageComposerMediaAttachmentProps {
     required this.child,
     this.onRemovePressed,
     this.mediaBadge,
+    this.semanticLabel,
     this.style,
   });
 
@@ -114,6 +117,16 @@ class StreamMessageComposerMediaAttachmentProps {
   ///
   /// When null, no remove control is shown on the surrounding container.
   final VoidCallback? onRemovePressed;
+
+  /// Semantic label for the attachment.
+  ///
+  /// Announced in accessibility modes (e.g. TalkBack/VoiceOver). This label
+  /// does not show in the UI. Typically the type prefix ("Photo", "Video",
+  /// "GIF") so screen-reader users can distinguish media kinds.
+  ///
+  ///  * [SemanticsProperties.label], which is set to [semanticLabel] in the
+  ///    underlying [Semantics] widget.
+  final String? semanticLabel;
 
   /// Per-instance style overrides.
   ///
@@ -149,26 +162,29 @@ class DefaultStreamMessageComposerMediaAttachment extends StatelessWidget {
     final effectiveBorderColor = theme.borderColor ?? defaults.borderColor;
     final effectiveSize = theme.size ?? defaults.size;
 
+    final content = SizedBox.fromSize(
+      size: effectiveSize,
+      child: Stack(
+        fit: .expand,
+        children: [
+          ExcludeSemantics(child: props.child),
+          if (props.mediaBadge case final badge?)
+            PositionedDirectional(
+              start: spacing.xxs,
+              bottom: spacing.xxs,
+              child: badge,
+            ),
+        ],
+      ),
+    );
+
     return StreamMessageComposerAttachment(
       onRemovePressed: props.onRemovePressed,
+      semanticLabel: props.semanticLabel,
       style: StreamMessageComposerAttachmentThemeData(
         side: BorderSide(color: effectiveBorderColor),
       ),
-      child: SizedBox.fromSize(
-        size: effectiveSize,
-        child: Stack(
-          fit: .expand,
-          children: [
-            props.child,
-            if (props.mediaBadge case final badge?)
-              PositionedDirectional(
-                start: spacing.xxs,
-                bottom: spacing.xxs,
-                child: badge,
-              ),
-          ],
-        ),
-      ),
+      child: content,
     );
   }
 }

--- a/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_unsupported_attachment.dart
+++ b/packages/stream_core_flutter/lib/src/components/message_composer/attachment/stream_message_composer_unsupported_attachment.dart
@@ -134,22 +134,24 @@ class DefaultStreamMessageComposerUnsupportedAttachment extends StatelessWidget 
       child: props.label,
     );
 
-    return StreamMessageComposerAttachment(
-      onRemovePressed: props.onRemovePressed,
-      child: ConstrainedBox(
-        constraints: _kDefaultConstraints,
-        child: Padding(
-          padding: effectivePadding,
-          child: Row(
-            mainAxisSize: .min,
-            spacing: effectiveSpacing,
-            children: [
-              Icon(icons.unsupportedAttachment, size: 20, color: effectiveLabelStyle.color),
-              Expanded(child: effectiveLabel),
-            ],
-          ),
+    final content = ConstrainedBox(
+      constraints: _kDefaultConstraints,
+      child: Padding(
+        padding: effectivePadding,
+        child: Row(
+          mainAxisSize: .min,
+          spacing: effectiveSpacing,
+          children: [
+            Icon(icons.unsupportedAttachment, size: 20, color: effectiveLabelStyle.color),
+            Expanded(child: effectiveLabel),
+          ],
         ),
       ),
+    );
+
+    return StreamMessageComposerAttachment(
+      onRemovePressed: props.onRemovePressed,
+      child: content,
     );
   }
 }

--- a/packages/stream_core_flutter/lib/src/components/sheet/stream_sheet.dart
+++ b/packages/stream_core_flutter/lib/src/components/sheet/stream_sheet.dart
@@ -168,6 +168,7 @@ Future<T?> showStreamSheet<T>({
   Color? backgroundColor,
   Color? barrierColor,
   String? barrierLabel,
+  String? barrierOnTapHint,
   ShapeBorder? shape,
   BorderRadiusGeometry? borderRadius,
   BoxConstraints? constraints,
@@ -215,6 +216,7 @@ Future<T?> showStreamSheet<T>({
       backgroundColor: backgroundColor,
       barrierColor: barrierColor ?? sheetTheme.barrierColor ?? defaults.barrierColor,
       barrierLabel: barrierLabel ?? localizations.scrimLabel,
+      barrierOnTapHint: barrierOnTapHint ?? localizations.scrimOnTapHint(localizations.bottomSheetLabel),
       shape: shape,
       borderRadius: borderRadius,
       constraints: constraints,
@@ -656,6 +658,7 @@ class StreamSheetRoute<T> extends PageRoute<T> {
     this.backgroundColor,
     Color? barrierColor,
     this.barrierLabel,
+    String? barrierOnTapHint,
     this.shape,
     this.borderRadius,
     this.constraints,
@@ -669,7 +672,8 @@ class StreamSheetRoute<T> extends PageRoute<T> {
     this.onDragEnd,
     this.parentSheet,
     this.capturedThemes,
-  }) : _barrierColor = barrierColor;
+  }) : _barrierColor = barrierColor,
+       _barrierOnTapHint = barrierOnTapHint;
 
   /// Builds the primary contents of the sheet. The provided [ScrollController]
   /// should be attached to the topmost scrollable widget inside the sheet.
@@ -683,6 +687,11 @@ class StreamSheetRoute<T> extends PageRoute<T> {
   // Private storage so we can override [ModalRoute.barrierColor] while still
   // accepting a constructor argument with the same name.
   final Color? _barrierColor;
+
+  // Backs the [barrierOnTapHint] override — read by the barrier's Semantics
+  // to give SR users a specific "double tap to <hint>" prompt (e.g. "close
+  // Bottom Sheet") instead of a generic "activate".
+  final String? _barrierOnTapHint;
 
   /// The shape applied to the sheet.
   ///
@@ -804,13 +813,20 @@ class StreamSheetRoute<T> extends PageRoute<T> {
   /// resolves [StreamSheetThemeData.barrierColor] (defaulting to
   /// [StreamColorScheme.backgroundScrim]) from the calling context.
   @override
-  Color? get barrierColor => _barrierColor ?? Colors.black54;
+  Color get barrierColor => _barrierColor ?? Colors.black54;
 
   @override
   bool get barrierDismissible => isDismissible;
 
   @override
+  bool get semanticsDismissible => isDismissible;
+
+  @override
   final String? barrierLabel;
+
+  /// Screen-reader hint spoken as `double tap to <hint>` when the barrier
+  /// is focused; e.g. `'close attachment picker'`.
+  String? get barrierOnTapHint => _barrierOnTapHint;
 
   @override
   bool get maintainState => true;
@@ -851,19 +867,23 @@ class StreamSheetRoute<T> extends PageRoute<T> {
     // route's outer SafeArea / DisplayFeatureSubScreen and are stable
     // across body rebuilds). The drag handlers read this — never the
     // rendered size, which can be dirty mid-gesture.
-    final content = LayoutBuilder(
-      builder: (context, constraints) {
-        _extent.availableHeight = constraints.maxHeight;
-        return _StreamDraggableScrollableSheet(
-          extent: _extent,
-          enableDrag: () => enableDrag,
-          popDragController: controller!,
-          navigator: navigator!,
-          getIsCurrent: () => isCurrent,
-          getIsActive: () => isActive,
-          builder: _buildBodyWithDragHandle,
-        );
-      },
+    final content = Semantics(
+      scopesRoute: true,
+      explicitChildNodes: true,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          _extent.availableHeight = constraints.maxHeight;
+          return _StreamDraggableScrollableSheet(
+            extent: _extent,
+            enableDrag: () => enableDrag,
+            popDragController: controller!,
+            navigator: navigator!,
+            getIsCurrent: () => isCurrent,
+            getIsActive: () => isActive,
+            builder: _buildBodyWithDragHandle,
+          );
+        },
+      ),
     );
 
     Widget sheet = StreamSheet(
@@ -875,6 +895,8 @@ class StreamSheetRoute<T> extends PageRoute<T> {
       constraints: constraints,
       child: _StreamSheetScope(route: this, child: content),
     );
+
+    sheet = DisplayFeatureSubScreen(anchorPoint: anchorPoint, child: sheet);
 
     // System-inset handling. A single `SafeArea(bottom: false)`
     // consumes the top, left, and right system insets *and* strips
@@ -890,16 +912,44 @@ class StreamSheetRoute<T> extends PageRoute<T> {
     // design-system peek (`topPadding`) plus the rubber-band stretch.
     sheet = SafeArea(bottom: false, child: sheet);
 
-    sheet = DisplayFeatureSubScreen(
-      anchorPoint: anchorPoint,
-      child: sheet,
-    );
+    // Prevent clicks inside the sheet from passing through to the barrier
+    sheet = Semantics(hitTestBehavior: .opaque, child: sheet);
 
     // Re-apply captured InheritedThemes (StreamTheme, Theme,
     // Directionality, etc.) so the sheet renders with the same
     // ambient theme as the calling context, even though it's pushed
     // onto the navigator's overlay above any local theme overrides.
     return capturedThemes?.wrap(sheet) ?? sheet;
+  }
+
+  @override
+  Widget buildModalBarrier() {
+    if (barrierColor.a != 0 && !offstage) {
+      // changedInternalState is called if barrierColor or offstage updates
+      assert(barrierColor != barrierColor.withValues(alpha: 0));
+      final color = animation!.drive(
+        ColorTween(
+          begin: barrierColor.withValues(alpha: 0),
+          end: barrierColor, // changedInternalState is called if barrierColor updates
+        ).chain(
+          CurveTween(curve: barrierCurve),
+        ), // changedInternalState is called if barrierCurve updates
+      );
+      return AnimatedModalBarrier(
+        color: color,
+        dismissible: barrierDismissible, // changedInternalState is called if barrierDismissible updates
+        semanticsLabel: barrierLabel, // changedInternalState is called if barrierLabel updates
+        barrierSemanticsDismissible: semanticsDismissible,
+        semanticsOnTapHint: barrierOnTapHint,
+      );
+    }
+
+    return ModalBarrier(
+      dismissible: barrierDismissible, // changedInternalState is called if barrierDismissible updates
+      semanticsLabel: barrierLabel, // changedInternalState is called if barrierLabel updates
+      barrierSemanticsDismissible: semanticsDismissible,
+      semanticsOnTapHint: barrierOnTapHint,
+    );
   }
 
   /// The nearest enclosing [StreamSheetRoute] for [context], or `null`

--- a/packages/stream_core_flutter/lib/src/components/snackbar/stream_snackbar.dart
+++ b/packages/stream_core_flutter/lib/src/components/snackbar/stream_snackbar.dart
@@ -137,12 +137,14 @@ class StreamSnackbar extends StatelessWidget {
     StreamSnackbarAction? action,
     Duration? duration,
     DismissDirection? dismissDirection,
+    VoidCallback? onVisible,
   }) : props = .new(
          message: message,
          variant: variant,
          action: action,
          duration: duration,
          dismissDirection: dismissDirection,
+         onVisible: onVisible,
        );
 
   /// The properties that configure this snackbar.
@@ -169,6 +171,7 @@ class StreamSnackbarProps {
     this.action,
     this.duration,
     this.dismissDirection,
+    this.onVisible,
   });
 
   /// The message displayed inside the snackbar.
@@ -201,6 +204,14 @@ class StreamSnackbarProps {
   /// [DismissDirection.none] to disable swipe-dismissal entirely. When
   /// null on both, defaults to [DismissDirection.down].
   final DismissDirection? dismissDirection;
+
+  /// Called once after the snackbar has fully animated in.
+  ///
+  /// When [MediaQuery.accessibleNavigationOf] is true the entrance animation
+  /// is skipped and this fires synchronously on display. Useful for pushing
+  /// an explicit [SemanticsService.sendAnnouncement] for screen readers that
+  /// don't reliably observe newly-mounted live regions.
+  final VoidCallback? onVisible;
 }
 
 /// The default implementation of [StreamSnackbar].

--- a/packages/stream_core_flutter/lib/src/components/snackbar/stream_snackbar.dart
+++ b/packages/stream_core_flutter/lib/src/components/snackbar/stream_snackbar.dart
@@ -240,7 +240,7 @@ class DefaultStreamSnackbar extends StatelessWidget {
     return Semantics(
       container: true,
       liveRegion: true,
-      onDismiss: () => StreamSnackbarMessenger.maybeOf(context)?.removeCurrent(),
+      onDismiss: () => StreamSnackbarMessenger.maybeOf(context)?.hideCurrent(),
       child: ConstrainedBox(
         constraints: effectiveConstraints,
         child: Material(

--- a/packages/stream_core_flutter/lib/src/components/snackbar/stream_snackbar_messenger.dart
+++ b/packages/stream_core_flutter/lib/src/components/snackbar/stream_snackbar_messenger.dart
@@ -703,7 +703,10 @@ class _SnackbarStageState extends State<_SnackbarStage> with SingleTickerProvide
   // of chaining whenComplete onto the forward future.
   void _handleAnimationStatus(AnimationStatus status) {
     if (!mounted) return;
-    if (status == AnimationStatus.completed) _startTimer();
+    if (status == AnimationStatus.completed) {
+      _startTimer();
+      _showing?.snackbar.props.onVisible?.call();
+    }
   }
 
   @override

--- a/packages/stream_core_flutter/lib/src/components/snackbar/stream_snackbar_messenger.dart
+++ b/packages/stream_core_flutter/lib/src/components/snackbar/stream_snackbar_messenger.dart
@@ -752,7 +752,13 @@ class _SnackbarStageState extends State<_SnackbarStage> with SingleTickerProvide
     _showing = next;
     _animation.value = 0;
     setState(() {});
-    if (next != null) _animation.forward(from: 0);
+    if (next != null) {
+      if (MediaQuery.accessibleNavigationOf(context)) {
+        _animation.value = 1;
+      } else {
+        _animation.forward(from: 0);
+      }
+    }
   }
 
   void _startTimer() {
@@ -777,7 +783,11 @@ class _SnackbarStageState extends State<_SnackbarStage> with SingleTickerProvide
     final messenger = widget.messenger;
     _exiting = true;
     _timer?.cancel();
-    await _animation.reverse();
+    if (MediaQuery.accessibleNavigationOf(context)) {
+      _animation.value = 0;
+    } else {
+      await _animation.reverse();
+    }
     if (!mounted) return;
     _showing = null;
     _exiting = false;

--- a/packages/stream_core_flutter/lib/src/components/toolbar/stream_app_bar.dart
+++ b/packages/stream_core_flutter/lib/src/components/toolbar/stream_app_bar.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../factory/stream_component_factory.dart';
@@ -71,6 +72,7 @@ class StreamAppBar extends StatelessWidget implements PreferredSizeWidget {
     Widget? subtitle,
     Widget? trailing,
     bool primary = true,
+    bool excludeHeaderSemantics = false,
     StreamAppBarStyle? style,
   }) : props = .new(
          leading: leading,
@@ -79,6 +81,7 @@ class StreamAppBar extends StatelessWidget implements PreferredSizeWidget {
          subtitle: subtitle,
          trailing: trailing,
          primary: primary,
+         excludeHeaderSemantics: excludeHeaderSemantics,
          style: style,
        );
 
@@ -114,6 +117,7 @@ class StreamAppBarProps {
     this.subtitle,
     this.trailing,
     this.primary = true,
+    this.excludeHeaderSemantics = false,
     this.style,
   });
 
@@ -166,6 +170,14 @@ class StreamAppBarProps {
   /// inside a sub-section of a page that has already consumed the top
   /// inset) so it doesn't double-pad.
   final bool primary;
+
+  /// Whether to omit the heading role from the [title].
+  ///
+  /// Defaults to false. When true, the bar doesn't mark the title as a
+  /// heading or claim the route's accessible name — useful when the title
+  /// widget carries its own heading semantics, or when the bar is shown in
+  /// a sub-section that shouldn't identify the route.
+  final bool excludeHeaderSemantics;
 
   /// The visual style applied to this app bar.
   ///
@@ -228,9 +240,11 @@ class DefaultStreamAppBar extends StatelessWidget {
           _ => icons.arrowLeft,
         };
         final useCloseIcon = parentRoute is PageRoute && parentRoute.fullscreenDialog;
+        final localizations = MaterialLocalizations.of(context);
         leading = StreamButton.icon(
           type: .ghost,
           style: .secondary,
+          tooltip: useCloseIcon ? localizations.closeButtonTooltip : localizations.backButtonTooltip,
           icon: Icon(useCloseIcon ? icons.xmark : backIcon),
           onPressed: Navigator.of(context).maybePop,
         );
@@ -278,11 +292,27 @@ class DefaultStreamAppBar extends StatelessWidget {
 
     Widget? middle;
     if (titleWidget != null || subtitleWidget != null) {
-      middle = Column(
+      // Title and subtitle read as a single announcement; when not
+      // excluded, the node is also marked as a heading and used as the
+      // route's accessible name on platforms that announce one.
+      Widget child = Column(
         mainAxisSize: .min,
         spacing: spacing.xxs,
         children: [?titleWidget, ?subtitleWidget],
       );
+
+      if (!props.excludeHeaderSemantics) {
+        child = Semantics(
+          header: true,
+          namesRoute: switch (defaultTargetPlatform) {
+            .android || .fuchsia || .linux || .windows => true,
+            _ => null,
+          },
+          child: child,
+        );
+      }
+
+      middle = MergeSemantics(child: child);
     }
 
     // The bar advertises a fixed height via [PreferredSizeWidget]; the
@@ -307,14 +337,24 @@ class DefaultStreamAppBar extends StatelessWidget {
     // The bar's bottom edge is intentionally a hairline border in the
     // design system's `borderSubtle` colour — part of the bar's identity,
     // not a configurable divider.
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: effectiveBackgroundColor,
-        border: Border(
-          bottom: BorderSide(color: context.streamColorScheme.borderSubtle),
+    //
+    // The outer [Semantics] keeps the bar's children grouped for screen
+    // readers, so leading, title, subtitle, and trailing aren't intermixed
+    // with surrounding page content. The inner [Semantics] forces each
+    // slot's semantics onto its own node — without it, a raw
+    // [GestureDetector] in a slot would attach its action to the outer
+    // container and collapse the bar into a single tappable focus stop.
+    return Semantics(
+      container: true,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: effectiveBackgroundColor,
+          border: Border(
+            bottom: BorderSide(color: context.streamColorScheme.borderSubtle),
+          ),
         ),
+        child: Semantics(explicitChildNodes: true, child: bar),
       ),
-      child: bar,
     );
   }
 }

--- a/packages/stream_core_flutter/lib/src/components/toolbar/stream_bottom_app_bar.dart
+++ b/packages/stream_core_flutter/lib/src/components/toolbar/stream_bottom_app_bar.dart
@@ -239,10 +239,15 @@ class DefaultStreamBottomAppBar extends StatelessWidget {
 
     Widget? middle;
     if (titleWidget != null || subtitleWidget != null) {
-      middle = Column(
-        mainAxisSize: .min,
-        spacing: spacing.xxs,
-        children: [?titleWidget, ?subtitleWidget],
+      // Title and subtitle read as a single announcement. The bottom bar
+      // is a secondary toolbar — it doesn't claim the route's accessible
+      // name or expose itself as a heading.
+      middle = MergeSemantics(
+        child: Column(
+          mainAxisSize: .min,
+          spacing: spacing.xxs,
+          children: [?titleWidget, ?subtitleWidget],
+        ),
       );
     }
 
@@ -268,14 +273,24 @@ class DefaultStreamBottomAppBar extends StatelessWidget {
     // The bar's top edge is intentionally a hairline border in the design
     // system's `borderSubtle` colour — part of the bar's identity, not a
     // configurable divider.
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: effectiveBackgroundColor,
-        border: Border(
-          top: BorderSide(color: context.streamColorScheme.borderSubtle),
+    //
+    // The outer [Semantics] keeps the bar's children grouped for screen
+    // readers, so leading, title, subtitle, and trailing aren't intermixed
+    // with surrounding page content. The inner [Semantics] forces each
+    // slot's semantics onto its own node — without it, a raw
+    // [GestureDetector] in a slot would attach its action to the outer
+    // container and collapse the bar into a single tappable focus stop.
+    return Semantics(
+      container: true,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: effectiveBackgroundColor,
+          border: Border(
+            top: BorderSide(color: context.streamColorScheme.borderSubtle),
+          ),
         ),
+        child: Semantics(explicitChildNodes: true, child: bar),
       ),
-      child: bar,
     );
   }
 }

--- a/packages/stream_core_flutter/lib/src/components/toolbar/stream_sheet_header.dart
+++ b/packages/stream_core_flutter/lib/src/components/toolbar/stream_sheet_header.dart
@@ -97,6 +97,7 @@ class StreamSheetHeader extends StatelessWidget implements PreferredSizeWidget {
     Widget? subtitle,
     Widget? trailing,
     bool primary = true,
+    bool excludeHeaderSemantics = false,
     StreamSheetHeaderStyle? style,
   }) : props = .new(
          leading: leading,
@@ -105,6 +106,7 @@ class StreamSheetHeader extends StatelessWidget implements PreferredSizeWidget {
          subtitle: subtitle,
          trailing: trailing,
          primary: primary,
+         excludeHeaderSemantics: excludeHeaderSemantics,
          style: style,
        );
 
@@ -140,6 +142,7 @@ class StreamSheetHeaderProps {
     this.subtitle,
     this.trailing,
     this.primary = true,
+    this.excludeHeaderSemantics = false,
     this.style,
   });
 
@@ -191,6 +194,14 @@ class StreamSheetHeaderProps {
   /// (e.g. inside a sub-section of a page that has already consumed
   /// the top inset) so it doesn't double-pad.
   final bool primary;
+
+  /// Whether to omit the heading role from the [title].
+  ///
+  /// Defaults to false. When true, the header doesn't mark the title as a
+  /// heading or claim the sheet's accessible name — useful when the title
+  /// widget carries its own heading semantics, or when the header is shown
+  /// in a sub-section that shouldn't identify the sheet.
+  final bool excludeHeaderSemantics;
 
   /// The visual style applied to this header.
   ///
@@ -297,9 +308,11 @@ class DefaultStreamSheetHeader extends StatelessWidget {
       }
 
       if (icon != null && onPressed != null) {
+        final localizations = MaterialLocalizations.of(context);
         leading = StreamButton.icon(
           type: .outline,
           style: .secondary,
+          tooltip: icon == icons.xmark ? localizations.closeButtonTooltip : localizations.backButtonTooltip,
           icon: Icon(icon),
           onPressed: onPressed,
         );
@@ -347,11 +360,24 @@ class DefaultStreamSheetHeader extends StatelessWidget {
 
     Widget? middle;
     if (titleWidget != null || subtitleWidget != null) {
-      middle = Column(
+      // Title and subtitle read as a single announcement; when not
+      // excluded, the node is also marked as a heading and used as the
+      // sheet's accessible name on platforms that announce one.
+      Widget child = Column(
         mainAxisSize: .min,
         spacing: spacing.xxs,
         children: [?titleWidget, ?subtitleWidget],
       );
+
+      if (!props.excludeHeaderSemantics) {
+        child = Semantics(
+          header: true,
+          namesRoute: true,
+          child: child,
+        );
+      }
+
+      middle = MergeSemantics(child: child);
     }
 
     // The header advertises a fixed height via [PreferredSizeWidget]; the
@@ -378,7 +404,16 @@ class DefaultStreamSheetHeader extends StatelessWidget {
       header = SafeArea(bottom: false, child: header);
     }
 
-    return header;
+    // The outer [Semantics] keeps the header's children grouped for screen
+    // readers, so leading, title, subtitle, and trailing aren't intermixed
+    // with surrounding sheet content. The inner [Semantics] forces each
+    // slot's semantics onto its own node — without it, a raw
+    // [GestureDetector] in a slot would attach its action to the outer
+    // container and collapse the bar into a single tappable focus stop.
+    return Semantics(
+      container: true,
+      child: Semantics(explicitChildNodes: true, child: header),
+    );
   }
 }
 

--- a/packages/stream_core_flutter/lib/src/theme/components/stream_text_input_theme.dart
+++ b/packages/stream_core_flutter/lib/src/theme/components/stream_text_input_theme.dart
@@ -107,6 +107,30 @@ class StreamTextInputThemeData with _$StreamTextInputThemeData {
   ) => _$StreamTextInputThemeData.lerp(a, b, t);
 }
 
+/// Where [StreamTextInput.helperText] is rendered relative to the bordered
+/// input area.
+///
+/// Describes which side of the field the helper text gravitates toward.
+///
+/// See also:
+///
+///  * [StreamTextInputStyle.helperAffinity], the theme-level setting.
+enum StreamHelperAffinity {
+  /// Helper text sits inside the bordered area, directly below the
+  /// input row.
+  ///
+  /// Useful when the design treats helper text as part of the field's
+  /// own chrome — visually contained, scoped to the input.
+  inside,
+
+  /// Helper text sits outside the bordered area, below the field.
+  ///
+  /// Useful when helper text should read as an external caption — for
+  /// fields with limited vertical space, or when the design calls for
+  /// stronger visual separation between input and feedback.
+  outside,
+}
+
 /// Visual styling properties for [StreamTextInput].
 ///
 /// Controls the border, colors, text styles, and helper text appearance.
@@ -129,6 +153,7 @@ class StreamTextInputStyle with _$StreamTextInputStyle {
   const StreamTextInputStyle({
     this.textStyle,
     this.hintStyle,
+    this.labelStyle,
     this.iconColor,
     this.iconSize,
     this.cursorColor,
@@ -139,6 +164,7 @@ class StreamTextInputStyle with _$StreamTextInputStyle {
     this.helperInfoStyle,
     this.helperErrorStyle,
     this.helperSuccessStyle,
+    this.helperAffinity,
     this.borderRadius,
     this.border,
     this.focusBorder,
@@ -161,6 +187,7 @@ class StreamTextInputStyle with _$StreamTextInputStyle {
   const StreamTextInputStyle.collapsed({
     this.textStyle,
     this.hintStyle,
+    this.labelStyle,
     this.iconColor,
     this.iconSize,
     this.cursorColor,
@@ -171,6 +198,7 @@ class StreamTextInputStyle with _$StreamTextInputStyle {
     this.helperInfoStyle,
     this.helperErrorStyle,
     this.helperSuccessStyle,
+    this.helperAffinity,
     this.borderRadius,
     this.fillColor,
     this.constraints,
@@ -200,6 +228,16 @@ class StreamTextInputStyle with _$StreamTextInputStyle {
   /// Defaults to [StreamTextTheme.bodyDefault] with
   /// [StreamColorScheme.textTertiary].
   final TextStyle? hintStyle;
+
+  /// The text style for the persistent label rendered above the input.
+  ///
+  /// Supports [WidgetStateTextStyle] for per-state styling (e.g. disabled).
+  /// When the input is disabled, the default resolves to
+  /// [StreamColorScheme.textDisabled].
+  ///
+  /// Defaults to [StreamTextTheme.captionEmphasis] with
+  /// [StreamColorScheme.textPrimary].
+  final TextStyle? labelStyle;
 
   /// The color for leading and trailing icons.
   ///
@@ -258,6 +296,14 @@ class StreamTextInputStyle with _$StreamTextInputStyle {
   /// Defaults to [StreamTextTheme.captionDefault] with
   /// [StreamColorScheme.accentSuccess].
   final TextStyle? helperSuccessStyle;
+
+  /// Where helper text is rendered relative to the bordered input area.
+  ///
+  /// Set globally via [StreamTextInputTheme]; overridable per-instance by
+  /// passing a [StreamTextInputStyle] to [StreamTextInput.style].
+  ///
+  /// Defaults to [StreamHelperAffinity.inside].
+  final StreamHelperAffinity? helperAffinity;
 
   /// The border radius of the text input.
   ///

--- a/packages/stream_core_flutter/lib/src/theme/components/stream_text_input_theme.g.theme.dart
+++ b/packages/stream_core_flutter/lib/src/theme/components/stream_text_input_theme.g.theme.dart
@@ -101,6 +101,7 @@ mixin _$StreamTextInputStyle {
     return StreamTextInputStyle(
       textStyle: TextStyle.lerp(a.textStyle, b.textStyle, t),
       hintStyle: TextStyle.lerp(a.hintStyle, b.hintStyle, t),
+      labelStyle: TextStyle.lerp(a.labelStyle, b.labelStyle, t),
       iconColor: Color.lerp(a.iconColor, b.iconColor, t),
       iconSize: lerpDouble$(a.iconSize, b.iconSize, t),
       cursorColor: Color.lerp(a.cursorColor, b.cursorColor, t),
@@ -119,6 +120,7 @@ mixin _$StreamTextInputStyle {
         b.helperSuccessStyle,
         t,
       ),
+      helperAffinity: t < 0.5 ? a.helperAffinity : b.helperAffinity,
       borderRadius: BorderRadiusGeometry.lerp(
         a.borderRadius,
         b.borderRadius,
@@ -154,6 +156,7 @@ mixin _$StreamTextInputStyle {
   StreamTextInputStyle copyWith({
     TextStyle? textStyle,
     TextStyle? hintStyle,
+    TextStyle? labelStyle,
     Color? iconColor,
     double? iconSize,
     Color? cursorColor,
@@ -164,6 +167,7 @@ mixin _$StreamTextInputStyle {
     TextStyle? helperInfoStyle,
     TextStyle? helperErrorStyle,
     TextStyle? helperSuccessStyle,
+    StreamHelperAffinity? helperAffinity,
     BorderRadiusGeometry? borderRadius,
     BorderSide? border,
     BorderSide? focusBorder,
@@ -179,6 +183,7 @@ mixin _$StreamTextInputStyle {
     return StreamTextInputStyle(
       textStyle: textStyle ?? _this.textStyle,
       hintStyle: hintStyle ?? _this.hintStyle,
+      labelStyle: labelStyle ?? _this.labelStyle,
       iconColor: iconColor ?? _this.iconColor,
       iconSize: iconSize ?? _this.iconSize,
       cursorColor: cursorColor ?? _this.cursorColor,
@@ -189,6 +194,7 @@ mixin _$StreamTextInputStyle {
       helperInfoStyle: helperInfoStyle ?? _this.helperInfoStyle,
       helperErrorStyle: helperErrorStyle ?? _this.helperErrorStyle,
       helperSuccessStyle: helperSuccessStyle ?? _this.helperSuccessStyle,
+      helperAffinity: helperAffinity ?? _this.helperAffinity,
       borderRadius: borderRadius ?? _this.borderRadius,
       border: border ?? _this.border,
       focusBorder: focusBorder ?? _this.focusBorder,
@@ -215,6 +221,7 @@ mixin _$StreamTextInputStyle {
     return copyWith(
       textStyle: _this.textStyle?.merge(other.textStyle) ?? other.textStyle,
       hintStyle: _this.hintStyle?.merge(other.hintStyle) ?? other.hintStyle,
+      labelStyle: _this.labelStyle?.merge(other.labelStyle) ?? other.labelStyle,
       iconColor: other.iconColor,
       iconSize: other.iconSize,
       cursorColor: other.cursorColor,
@@ -231,6 +238,7 @@ mixin _$StreamTextInputStyle {
       helperSuccessStyle:
           _this.helperSuccessStyle?.merge(other.helperSuccessStyle) ??
           other.helperSuccessStyle,
+      helperAffinity: other.helperAffinity,
       borderRadius: other.borderRadius,
       border: _this.border != null && other.border != null
           ? BorderSide.merge(_this.border!, other.border!)
@@ -264,6 +272,7 @@ mixin _$StreamTextInputStyle {
 
     return _other.textStyle == _this.textStyle &&
         _other.hintStyle == _this.hintStyle &&
+        _other.labelStyle == _this.labelStyle &&
         _other.iconColor == _this.iconColor &&
         _other.iconSize == _this.iconSize &&
         _other.cursorColor == _this.cursorColor &&
@@ -274,6 +283,7 @@ mixin _$StreamTextInputStyle {
         _other.helperInfoStyle == _this.helperInfoStyle &&
         _other.helperErrorStyle == _this.helperErrorStyle &&
         _other.helperSuccessStyle == _this.helperSuccessStyle &&
+        _other.helperAffinity == _this.helperAffinity &&
         _other.borderRadius == _this.borderRadius &&
         _other.border == _this.border &&
         _other.focusBorder == _this.focusBorder &&
@@ -293,6 +303,7 @@ mixin _$StreamTextInputStyle {
       runtimeType,
       _this.textStyle,
       _this.hintStyle,
+      _this.labelStyle,
       _this.iconColor,
       _this.iconSize,
       _this.cursorColor,
@@ -303,6 +314,7 @@ mixin _$StreamTextInputStyle {
       _this.helperInfoStyle,
       _this.helperErrorStyle,
       _this.helperSuccessStyle,
+      _this.helperAffinity,
       _this.borderRadius,
       _this.border,
       _this.focusBorder,

--- a/packages/stream_core_flutter/test/a11y/stream_accessibility_autofocus_test.dart
+++ b/packages/stream_core_flutter/test/a11y/stream_accessibility_autofocus_test.dart
@@ -317,6 +317,5 @@ void main() {
       await tester.pump(const Duration(seconds: 4));
       expect(focusEvents().length, countBeforeDispose);
     });
-
   });
 }

--- a/packages/stream_core_flutter/test/a11y/stream_accessibility_autofocus_test.dart
+++ b/packages/stream_core_flutter/test/a11y/stream_accessibility_autofocus_test.dart
@@ -1,0 +1,322 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show SystemChannels;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/core.dart';
+
+void main() {
+  // Semantic events sent by [RenderObject.sendSemanticsEvent] are delivered
+  // to the platform via [SystemChannels.accessibility]. Intercepting the
+  // channel lets us observe what — if anything — the widget dispatched.
+  late List<Map<dynamic, dynamic>> sentEvents;
+
+  Iterable<Map<dynamic, dynamic>> focusEvents() {
+    return sentEvents.where((e) => e['type'] == 'focus');
+  }
+
+  late SemanticsHandle semanticsHandle;
+
+  setUp(() {
+    sentEvents = <Map<dynamic, dynamic>>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockDecodedMessageHandler<dynamic>(
+      SystemChannels.accessibility,
+      (mockMessage) async => sentEvents.add(mockMessage as Map<dynamic, dynamic>),
+    );
+    // sendSemanticsEvent requires a live semantics owner. Enable it for all
+    // tests so dispatches don't null-check the missing owner.
+    semanticsHandle = TestWidgetsFlutterBinding.instance.ensureSemantics();
+  });
+
+  tearDown(() {
+    semanticsHandle.dispose();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockDecodedMessageHandler<dynamic>(
+      SystemChannels.accessibility,
+      null,
+    );
+  });
+
+  Widget host({
+    required bool accessibleNavigation,
+    required Widget child,
+  }) {
+    return MediaQuery(
+      data: MediaQueryData(accessibleNavigation: accessibleNavigation),
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: child,
+      ),
+    );
+  }
+
+  group('StreamAccessibilityAutofocus', () {
+    testWidgets('renders its child unchanged', (tester) async {
+      await tester.pumpWidget(
+        host(
+          accessibleNavigation: false,
+          child: const StreamAccessibilityAutofocus(child: Text('child')),
+        ),
+      );
+
+      expect(find.text('child'), findsOneWidget);
+    });
+
+    testWidgets('does not dispatch focus events when accessibleNavigation is off', (tester) async {
+      await tester.pumpWidget(
+        host(
+          accessibleNavigation: false,
+          child: const StreamAccessibilityAutofocus(child: SizedBox()),
+        ),
+      );
+
+      // Let the entire window elapse — nothing should have fired.
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 4));
+
+      expect(focusEvents(), isEmpty);
+    });
+
+    testWidgets('does not dispatch focus events when enabled is false', (tester) async {
+      await tester.pumpWidget(
+        host(
+          accessibleNavigation: true,
+          child: const StreamAccessibilityAutofocus(
+            enabled: false,
+            child: SizedBox(),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 4));
+
+      expect(focusEvents(), isEmpty);
+    });
+
+    testWidgets('dispatches focus events after mount when SR is on', (tester) async {
+      await tester.pumpWidget(
+        host(
+          accessibleNavigation: true,
+          child: const StreamAccessibilityAutofocus(child: SizedBox()),
+        ),
+      );
+
+      // Wait past the initial postFrame + a couple of retry ticks.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(focusEvents(), isNotEmpty);
+    });
+
+    testWidgets('retries at the configured cadence during the window', (tester) async {
+      // Use a short window with a short interval so we can count retries
+      // deterministically without slowing the test down.
+      await tester.pumpWidget(
+        host(
+          accessibleNavigation: true,
+          child: const StreamAccessibilityAutofocus(
+            retryInterval: Duration(milliseconds: 100),
+            window: Duration(milliseconds: 500),
+            child: SizedBox(),
+          ),
+        ),
+      );
+
+      // Drain the window. Expect at least 3 fires — one postFrame plus
+      // several 100ms retry ticks within the 500ms window.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(focusEvents().length, greaterThanOrEqualTo(3));
+    });
+
+    testWidgets('stops dispatching after the window closes', (tester) async {
+      await tester.pumpWidget(
+        host(
+          accessibleNavigation: true,
+          child: const StreamAccessibilityAutofocus(child: SizedBox()),
+        ),
+      );
+
+      // Drain past the default 3s window.
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 4));
+
+      final countAfterWindow = focusEvents().length;
+
+      // Wait an extra second beyond the window — no new events should fire.
+      await tester.pump(const Duration(seconds: 1));
+      expect(focusEvents().length, countAfterWindow);
+    });
+
+    testWidgets('starts an attempt window when SR is turned on after mount', (tester) async {
+      await tester.pumpWidget(
+        host(
+          accessibleNavigation: false,
+          child: const StreamAccessibilityAutofocus(child: SizedBox()),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+      expect(focusEvents(), isEmpty);
+
+      // Flip SR on — didChangeDependencies should trigger and start the window.
+      await tester.pumpWidget(
+        host(
+          accessibleNavigation: true,
+          child: const StreamAccessibilityAutofocus(child: SizedBox()),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(focusEvents(), isNotEmpty);
+    });
+
+    testWidgets('stops dispatching when SR is turned off mid-window', (tester) async {
+      await tester.pumpWidget(
+        host(
+          accessibleNavigation: true,
+          child: const StreamAccessibilityAutofocus(child: SizedBox()),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(focusEvents(), isNotEmpty);
+      final countBeforeToggle = focusEvents().length;
+
+      // Turn SR off before the window naturally elapses.
+      await tester.pumpWidget(
+        host(
+          accessibleNavigation: false,
+          child: const StreamAccessibilityAutofocus(child: SizedBox()),
+        ),
+      );
+
+      // Wait the rest of what would have been the window — nothing new.
+      await tester.pump(const Duration(seconds: 4));
+      expect(focusEvents().length, countBeforeToggle);
+    });
+
+    testWidgets('trips the debug assertion when two instances share a route', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(accessibleNavigation: true),
+            child: Scaffold(
+              body: Column(
+                children: const [
+                  StreamAccessibilityAutofocus(child: SizedBox()),
+                  StreamAccessibilityAutofocus(child: SizedBox()),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // The second instance's didChangeDependencies should have thrown.
+      expect(tester.takeException(), isA<FlutterError>());
+
+      // Unmount to cancel the surviving first instance's timers so the
+      // per-test invariant check does not see them still pending.
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('allows two instances on different routes', (tester) async {
+      final navigatorKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navigatorKey,
+          home: MediaQuery(
+            data: const MediaQueryData(accessibleNavigation: true),
+            child: const Scaffold(
+              body: StreamAccessibilityAutofocus(child: SizedBox()),
+            ),
+          ),
+        ),
+      );
+
+      // Push a second route with its own autofocus instance — simulates
+      // opening a bottom sheet that contains a text field.
+      unawaited(
+        navigatorKey.currentState!.push(
+          MaterialPageRoute<void>(
+            builder: (_) => MediaQuery(
+              data: const MediaQueryData(accessibleNavigation: true),
+              child: const Scaffold(
+                body: StreamAccessibilityAutofocus(child: SizedBox()),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('allows two instances outside any route', (tester) async {
+      await tester.pumpWidget(
+        host(
+          accessibleNavigation: true,
+          child: Column(
+            children: const [
+              StreamAccessibilityAutofocus(child: SizedBox()),
+              StreamAccessibilityAutofocus(child: SizedBox()),
+            ],
+          ),
+        ),
+      );
+
+      // No enclosing ModalRoute — the per-route check is a no-op.
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('allows a new instance after the previous disposes on the same route', (tester) async {
+      Widget hostWithRoute(Widget? autofocus) {
+        return MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(accessibleNavigation: true),
+            child: Scaffold(body: autofocus ?? const SizedBox()),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(hostWithRoute(const StreamAccessibilityAutofocus(child: SizedBox())));
+
+      // Unmount the first instance.
+      await tester.pumpWidget(hostWithRoute(null));
+
+      // Mount a second instance on the same route — should register cleanly.
+      await tester.pumpWidget(hostWithRoute(const StreamAccessibilityAutofocus(child: SizedBox())));
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('cancels timers on dispose', (tester) async {
+      await tester.pumpWidget(
+        host(
+          accessibleNavigation: true,
+          child: const StreamAccessibilityAutofocus(child: SizedBox()),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+      final countBeforeDispose = focusEvents().length;
+
+      // Unmount the widget.
+      await tester.pumpWidget(host(accessibleNavigation: true, child: const SizedBox()));
+
+      // Wait what remains of the window. If timers weren't cancelled we'd
+      // see more events; if they were, the count is stable.
+      await tester.pump(const Duration(seconds: 4));
+      expect(focusEvents().length, countBeforeDispose);
+    });
+
+  });
+}

--- a/packages/stream_core_flutter/test/a11y/stream_accessibility_autofocus_test.dart
+++ b/packages/stream_core_flutter/test/a11y/stream_accessibility_autofocus_test.dart
@@ -202,12 +202,12 @@ void main() {
 
     testWidgets('trips the debug assertion when two instances share a route', (tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        const MaterialApp(
           home: MediaQuery(
-            data: const MediaQueryData(accessibleNavigation: true),
+            data: MediaQueryData(accessibleNavigation: true),
             child: Scaffold(
               body: Column(
-                children: const [
+                children: [
                   StreamAccessibilityAutofocus(child: SizedBox()),
                   StreamAccessibilityAutofocus(child: SizedBox()),
                 ],
@@ -230,9 +230,9 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           navigatorKey: navigatorKey,
-          home: MediaQuery(
-            data: const MediaQueryData(accessibleNavigation: true),
-            child: const Scaffold(
+          home: const MediaQuery(
+            data: MediaQueryData(accessibleNavigation: true),
+            child: Scaffold(
               body: StreamAccessibilityAutofocus(child: SizedBox()),
             ),
           ),
@@ -244,9 +244,9 @@ void main() {
       unawaited(
         navigatorKey.currentState!.push(
           MaterialPageRoute<void>(
-            builder: (_) => MediaQuery(
-              data: const MediaQueryData(accessibleNavigation: true),
-              child: const Scaffold(
+            builder: (_) => const MediaQuery(
+              data: MediaQueryData(accessibleNavigation: true),
+              child: Scaffold(
                 body: StreamAccessibilityAutofocus(child: SizedBox()),
               ),
             ),
@@ -263,8 +263,8 @@ void main() {
       await tester.pumpWidget(
         host(
           accessibleNavigation: true,
-          child: Column(
-            children: const [
+          child: const Column(
+            children: [
               StreamAccessibilityAutofocus(child: SizedBox()),
               StreamAccessibilityAutofocus(child: SizedBox()),
             ],

--- a/packages/stream_core_flutter/test/a11y/stream_semantics_announcer_test.dart
+++ b/packages/stream_core_flutter/test/a11y/stream_semantics_announcer_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart' show SystemChannels;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/core.dart';
+
+void main() {
+  late List<Map<dynamic, dynamic>> sentMessages;
+
+  Map<dynamic, dynamic> dataOf(int index) {
+    return sentMessages[index]['data']! as Map<dynamic, dynamic>;
+  }
+
+  Future<BuildContext> pumpHost(WidgetTester tester, TargetPlatform platform) async {
+    late BuildContext capturedContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: platform),
+        home: Builder(
+          builder: (context) {
+            capturedContext = context;
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+    return capturedContext;
+  }
+
+  setUp(() {
+    sentMessages = <Map<dynamic, dynamic>>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockDecodedMessageHandler<dynamic>(
+      SystemChannels.accessibility,
+      (mockMessage) async {
+        sentMessages.add(mockMessage as Map<dynamic, dynamic>);
+      },
+    );
+  });
+
+  tearDown(() {
+    StreamSemanticsAnnouncer.cancel();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockDecodedMessageHandler<dynamic>(
+      SystemChannels.accessibility,
+      null,
+    );
+  });
+
+  group('StreamSemanticsAnnouncer.announce', () {
+    testWidgets('dispatches immediately on non-iOS platforms', (tester) async {
+      final context = await pumpHost(tester, TargetPlatform.android);
+
+      StreamSemanticsAnnouncer.announce(context, 'hello');
+      await tester.pump();
+
+      expect(sentMessages, hasLength(1));
+      expect(sentMessages.single['type'], 'announce');
+      expect(dataOf(0)['message'], 'hello');
+    });
+
+    testWidgets('delays by 1 second on iOS with polite assertiveness', (tester) async {
+      final context = await pumpHost(tester, TargetPlatform.iOS);
+
+      StreamSemanticsAnnouncer.announce(context, 'polite');
+      await tester.pump();
+      // Nothing dispatched yet — Timer hasn't fired.
+      expect(sentMessages, isEmpty);
+
+      await tester.pump(const Duration(seconds: 1));
+      expect(sentMessages, hasLength(1));
+      expect(dataOf(0)['message'], 'polite');
+    });
+
+    testWidgets('dispatches immediately on iOS with assertive assertiveness', (tester) async {
+      final context = await pumpHost(tester, TargetPlatform.iOS);
+
+      StreamSemanticsAnnouncer.announce(
+        context,
+        'urgent',
+        assertiveness: Assertiveness.assertive,
+      );
+      await tester.pump();
+
+      expect(sentMessages, hasLength(1));
+      expect(dataOf(0)['message'], 'urgent');
+      expect(dataOf(0)['assertiveness'], 1);
+    });
+
+    testWidgets('rapid polite calls on iOS only emit the latest message', (tester) async {
+      final context = await pumpHost(tester, TargetPlatform.iOS);
+
+      StreamSemanticsAnnouncer.announce(context, 'first');
+      await tester.pump(const Duration(milliseconds: 200));
+      StreamSemanticsAnnouncer.announce(context, 'second');
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(sentMessages, hasLength(1));
+      expect(dataOf(0)['message'], 'second');
+    });
+
+    testWidgets('cancel() clears the pending iOS timer', (tester) async {
+      final context = await pumpHost(tester, TargetPlatform.iOS);
+
+      StreamSemanticsAnnouncer.announce(context, 'discarded');
+      StreamSemanticsAnnouncer.cancel();
+      await tester.pump(const Duration(seconds: 2));
+
+      expect(sentMessages, isEmpty);
+    });
+
+    testWidgets('reports platform-channel errors via FlutterError', (tester) async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockDecodedMessageHandler<dynamic>(
+        SystemChannels.accessibility,
+        (_) async => throw StateError('channel down'),
+      );
+
+      final errors = <FlutterErrorDetails>[];
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = errors.add;
+      addTearDown(() => FlutterError.onError = originalOnError);
+
+      final context = await pumpHost(tester, TargetPlatform.android);
+      StreamSemanticsAnnouncer.announce(context, 'doomed');
+      await tester.pumpAndSettle();
+
+      expect(errors, hasLength(1));
+      expect(errors.single.exception, isA<StateError>());
+      expect(errors.single.context.toString(), contains('screen-reader announcement'));
+    });
+  });
+
+  group('StreamSemanticsAnnouncer.tooltip', () {
+    testWidgets('dispatches a tooltip event', (tester) async {
+      await StreamSemanticsAnnouncer.tooltip('tooltip text');
+
+      expect(sentMessages, hasLength(1));
+      expect(sentMessages.single['type'], 'tooltip');
+      expect(dataOf(0)['message'], 'tooltip text');
+    });
+  });
+}

--- a/packages/stream_core_flutter/test/components/badge/stream_media_badge_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/badge/stream_media_badge_semantics_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/core.dart';
+
+Widget _withStreamTheme(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [StreamTheme()]),
+    home: Scaffold(body: Center(child: child)),
+  );
+}
+
+void main() {
+  group('StreamMediaBadge.semanticsLabel', () {
+    testWidgets('when null, badge exposes its visual duration text to SR', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          const StreamMediaBadge(
+            type: MediaBadgeType.video,
+            duration: Duration(minutes: 1, seconds: 23),
+            durationFormat: MediaBadgeDurationFormat.exact,
+          ),
+        ),
+      );
+
+      // Visual text is announced verbatim — TalkBack/VoiceOver read '1:23'.
+      expect(find.bySemanticsLabel('1:23'), findsOneWidget);
+
+      handle.dispose();
+    });
+
+    testWidgets('when set, badge replaces the visual content in the semantic tree', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          const StreamMediaBadge(
+            type: MediaBadgeType.video,
+            duration: Duration(minutes: 1, seconds: 23),
+            durationFormat: MediaBadgeDurationFormat.exact,
+            semanticsLabel: '1 minute 23 seconds',
+          ),
+        ),
+      );
+
+      // The caller-supplied label is what the SR reads.
+      expect(find.bySemanticsLabel('1 minute 23 seconds'), findsOneWidget);
+
+      // The visual duration text is hidden from the semantic tree via
+      // ExcludeSemantics — the SR shouldn't announce both.
+      expect(find.bySemanticsLabel('1:23'), findsNothing);
+
+      handle.dispose();
+    });
+  });
+}

--- a/packages/stream_core_flutter/test/components/buttons/stream_button_color_resolution_test.dart
+++ b/packages/stream_core_flutter/test/components/buttons/stream_button_color_resolution_test.dart
@@ -17,7 +17,6 @@ void main() {
       'secondary outline icon button uses light textPrimary when supplied',
       (tester) async {
         final lightStreamTheme = StreamTheme(
-          brightness: Brightness.light,
           colorScheme: StreamColorScheme.light(),
         );
         final expectedTextPrimary = lightStreamTheme.colorScheme.textPrimary;
@@ -62,7 +61,6 @@ void main() {
       'secondary ghost icon button uses light textPrimary when supplied',
       (tester) async {
         final lightStreamTheme = StreamTheme(
-          brightness: Brightness.light,
           colorScheme: StreamColorScheme.light(),
         );
         final expectedTextPrimary = lightStreamTheme.colorScheme.textPrimary;

--- a/packages/stream_core_flutter/test/components/buttons/stream_button_color_resolution_test.dart
+++ b/packages/stream_core_flutter/test/components/buttons/stream_button_color_resolution_test.dart
@@ -1,0 +1,106 @@
+// Repro for stream-chat-flutter issue #2786:
+// "v10: composer / attachment-picker icons render white (invisible) in light
+//  mode despite a light StreamColorScheme".
+//
+// The user supplies a light StreamTheme via ThemeData.extensions, then renders
+// StreamButton.icon(style: secondary, type: outline) (the composer's leading +).
+// Expected: the icon's IconTheme color resolves to the supplied light scheme's
+// textPrimary (a dark color, ~0xFF1A1B25). Actually observed in the bug report:
+// the icon is white.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/core.dart';
+
+void main() {
+  group('StreamButton picks up StreamColorScheme from ThemeData extension', () {
+    testWidgets(
+      'secondary outline icon button uses light textPrimary when supplied',
+      (tester) async {
+        final lightStreamTheme = StreamTheme(
+          brightness: Brightness.light,
+          colorScheme: StreamColorScheme.light(),
+        );
+        final expectedTextPrimary = lightStreamTheme.colorScheme.textPrimary;
+
+        Color? capturedIconColor;
+        await tester.pumpWidget(
+          MaterialApp(
+            themeMode: ThemeMode.light,
+            theme: ThemeData.light().copyWith(extensions: [lightStreamTheme]),
+            home: Scaffold(
+              body: Center(
+                child: StreamButton.icon(
+                  icon: Builder(
+                    builder: (context) {
+                      capturedIconColor = IconTheme.of(context).color;
+                      return const Icon(Icons.add);
+                    },
+                  ),
+                  style: StreamButtonStyle.secondary,
+                  type: StreamButtonType.outline,
+                  size: StreamButtonSize.large,
+                  onPressed: () {},
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          capturedIconColor,
+          expectedTextPrimary,
+          reason:
+              'StreamButton.icon should resolve its IconTheme color from the '
+              'supplied light StreamColorScheme.textPrimary, but got '
+              '$capturedIconColor.',
+        );
+      },
+    );
+
+    testWidgets(
+      'secondary ghost icon button uses light textPrimary when supplied',
+      (tester) async {
+        final lightStreamTheme = StreamTheme(
+          brightness: Brightness.light,
+          colorScheme: StreamColorScheme.light(),
+        );
+        final expectedTextPrimary = lightStreamTheme.colorScheme.textPrimary;
+
+        Color? capturedIconColor;
+        await tester.pumpWidget(
+          MaterialApp(
+            themeMode: ThemeMode.light,
+            theme: ThemeData.light().copyWith(extensions: [lightStreamTheme]),
+            home: Scaffold(
+              body: Center(
+                child: StreamButton.icon(
+                  icon: Builder(
+                    builder: (context) {
+                      capturedIconColor = IconTheme.of(context).color;
+                      return const Icon(Icons.send);
+                    },
+                  ),
+                  style: StreamButtonStyle.secondary,
+                  type: StreamButtonType.ghost,
+                  size: StreamButtonSize.small,
+                  onPressed: () {},
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          capturedIconColor,
+          expectedTextPrimary,
+          reason:
+              'StreamButton.icon (secondary/ghost) should resolve its IconTheme '
+              'color from the supplied light StreamColorScheme.textPrimary, but '
+              'got $capturedIconColor.',
+        );
+      },
+    );
+  });
+}

--- a/packages/stream_core_flutter/test/components/buttons/stream_button_test.dart
+++ b/packages/stream_core_flutter/test/components/buttons/stream_button_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/core.dart';
+
+Widget _withStreamTheme(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [StreamTheme()]),
+    home: Scaffold(body: Center(child: child)),
+  );
+}
+
+void main() {
+  group('StreamButton.icon a11y', () {
+    testWidgets('enabled — label, isButton, isEnabled, hasTapAction', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamButton.icon(
+            icon: const Icon(Icons.add),
+            tooltip: 'Add',
+            onPressed: () {},
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.byType(StreamButton)),
+        isSemantics(
+          tooltip: 'Add',
+          isButton: true,
+          isEnabled: true,
+          hasEnabledState: true,
+          hasTapAction: true,
+        ),
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('disabled (onPressed: null) — no tap action, !isEnabled', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamButton.icon(
+            icon: const Icon(Icons.add),
+            tooltip: 'Add',
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.byType(StreamButton)),
+        isSemantics(
+          tooltip: 'Add',
+          isButton: true,
+          isEnabled: false,
+          hasEnabledState: true,
+          hasTapAction: false,
+        ),
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('selected — hasSelectedState, isSelected', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamButton.icon(
+            icon: const Icon(Icons.add),
+            tooltip: 'Add',
+            isSelected: true,
+            onPressed: () {},
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.byType(StreamButton)),
+        isSemantics(
+          tooltip: 'Add',
+          isButton: true,
+          isSelected: true,
+          hasSelectedState: true,
+        ),
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('renders a Material Tooltip for sighted users', (tester) async {
+      // Sighted users see the tooltip on hover / long-press; SR users get
+      // the label through Tooltip's internal Semantics merged into the
+      // button's tappable node (covered by the "enabled" test above).
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamButton.icon(
+            icon: const Icon(Icons.add),
+            tooltip: 'Add attachment',
+            onPressed: () {},
+          ),
+        ),
+      );
+
+      expect(find.byTooltip('Add attachment'), findsOneWidget);
+    });
+
+    testWidgets('meets tap-target guidelines', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamButton.icon(
+            icon: const Icon(Icons.add),
+            tooltip: 'Add',
+            onPressed: () {},
+          ),
+        ),
+      );
+
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+
+      handle.dispose();
+    });
+  });
+
+  group('StreamButton (with child) a11y', () {
+    testWidgets('label comes from child Text widget', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamButton(
+            onPressed: () {},
+            child: const Text('Submit'),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.byType(StreamButton)),
+        isSemantics(
+          label: 'Submit',
+          isButton: true,
+          isEnabled: true,
+          hasTapAction: true,
+        ),
+      );
+
+      handle.dispose();
+    });
+  });
+}

--- a/packages/stream_core_flutter/test/components/buttons/stream_button_vs_icon_button_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/buttons/stream_button_vs_icon_button_semantics_test.dart
@@ -16,7 +16,7 @@ String _fmt(SemanticsData d) {
   }
 
   final actions = SemanticsAction.values.where((a) => (d.actions & a.index) != 0).map((a) => a.name).toList();
-  final flags = SemanticsFlag.values.where((f) => d.hasFlag(f)).map((f) => f.name).toList();
+  final flags = d.flagsCollection.toStrings();
 
   add('actions', actions);
   add('flags', flags);

--- a/packages/stream_core_flutter/test/components/buttons/stream_button_vs_icon_button_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/buttons/stream_button_vs_icon_button_semantics_test.dart
@@ -1,0 +1,426 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/core.dart';
+
+// Pretty-prints the merge-effective SemanticsData for direct comparison —
+// strips rect/transform/traversalParentIdentifier noise, one field per line.
+String _fmt(SemanticsData d) {
+  final lines = <String>[];
+  void add(String key, Object? value) {
+    if (value == null) return;
+    if (value is String && value.isEmpty) return;
+    if (value is List && value.isEmpty) return;
+    lines.add('  $key: $value');
+  }
+
+  final actions = SemanticsAction.values.where((a) => (d.actions & a.index) != 0).map((a) => a.name).toList();
+  final flags = SemanticsFlag.values.where((f) => d.hasFlag(f)).map((f) => f.name).toList();
+
+  add('actions', actions);
+  add('flags', flags);
+  add('label', d.label);
+  add('value', d.value);
+  add('hint', d.hint);
+  add('tooltip', d.tooltip);
+  add('textDirection', d.textDirection?.name);
+  return '{\n${lines.join(',\n')}\n}';
+}
+
+Widget _withStreamTheme(Widget child, {bool useMaterial3 = true}) {
+  return MaterialApp(
+    theme: ThemeData(
+      useMaterial3: useMaterial3,
+      extensions: [StreamTheme()],
+    ),
+    home: Scaffold(body: Center(child: child)),
+  );
+}
+
+void main() {
+  group('Semantic tree comparison: IconButton vs StreamButton.icon', () {
+    testWidgets('with isSelected=true, tooltip, onPressed', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      // Flutter Material IconButton
+      await tester.pumpWidget(
+        _withStreamTheme(
+          IconButton(
+            isSelected: true,
+            tooltip: 'Photo Gallery',
+            onPressed: () {},
+            icon: const Icon(Icons.photo),
+          ),
+        ),
+      );
+
+      final iconButtonNode = tester.getSemantics(find.byType(IconButton));
+      debugPrint('--- IconButton (isSelected: true) ---');
+      debugPrint(_fmt(iconButtonNode.getSemanticsData()));
+
+      // Stream's StreamButton.icon
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamButton.icon(
+            isSelected: true,
+            tooltip: 'Photo Gallery',
+            onPressed: () {},
+            icon: const Icon(Icons.photo),
+          ),
+        ),
+      );
+
+      final streamButtonNode = tester.getSemantics(find.byType(StreamButton));
+      debugPrint('--- StreamButton.icon (isSelected: true) ---');
+      debugPrint(_fmt(streamButtonNode.getSemanticsData()));
+
+      handle.dispose();
+    });
+
+    testWidgets('with isSelected=false, tooltip, onPressed', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          IconButton(
+            isSelected: false,
+            tooltip: 'Photo Gallery',
+            onPressed: () {},
+            icon: const Icon(Icons.photo),
+          ),
+        ),
+      );
+
+      debugPrint('--- IconButton (isSelected: false) ---');
+      debugPrint(_fmt(tester.getSemantics(find.byType(IconButton)).getSemanticsData()));
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamButton.icon(
+            isSelected: false,
+            tooltip: 'Photo Gallery',
+            onPressed: () {},
+            icon: const Icon(Icons.photo),
+          ),
+        ),
+      );
+
+      debugPrint('--- StreamButton.icon (isSelected: false) ---');
+      debugPrint(_fmt(tester.getSemantics(find.byType(StreamButton)).getSemanticsData()));
+
+      handle.dispose();
+    });
+  });
+
+  group('ToggleButtons (Flutter) behavior', () {
+    testWidgets('semantic tree for selected toggle button', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          ToggleButtons(
+            isSelected: const [true, false, false],
+            onPressed: (_) {},
+            children: const [
+              Icon(Icons.photo),
+              Icon(Icons.camera_alt),
+              Icon(Icons.folder),
+            ],
+          ),
+        ),
+      );
+
+      debugPrint('--- ToggleButtons (first index selected) ---');
+      debugPrint(_fmt(tester.getSemantics(find.byType(ToggleButtons)).getSemanticsData()));
+      debugPrint('--- First button: ---');
+      debugPrint(_fmt(tester.getSemantics(find.byIcon(Icons.photo)).getSemanticsData()));
+      debugPrint('--- Second button: ---');
+      debugPrint(_fmt(tester.getSemantics(find.byIcon(Icons.camera_alt)).getSemanticsData()));
+
+      handle.dispose();
+    });
+
+    testWidgets('captures events when tapping a toggle button', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      final events = <String>[];
+      tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(
+        SystemChannels.accessibility,
+        (message) async {
+          if (message is Map) {
+            final type = message['type']?.toString();
+            if (type != null) events.add(type);
+          }
+          return null;
+        },
+      );
+
+      var pressedIndex = -1;
+      await tester.pumpWidget(
+        _withStreamTheme(
+          ToggleButtons(
+            isSelected: const [true, false, false],
+            onPressed: (i) => pressedIndex = i,
+            children: const [
+              Icon(Icons.photo),
+              Icon(Icons.camera_alt),
+              Icon(Icons.folder),
+            ],
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.camera_alt));
+      await tester.pumpAndSettle();
+
+      tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(
+        SystemChannels.accessibility,
+        null,
+      );
+
+      debugPrint('--- ToggleButtons tap fired events: $events');
+      debugPrint('--- pressedIndex: $pressedIndex');
+
+      handle.dispose();
+    });
+  });
+
+  group('Tap behavior: events fired on activation', () {
+    Future<List<String>> capturedEvents(
+      WidgetTester tester,
+      Widget widget,
+      Finder finder,
+    ) async {
+      final events = <String>[];
+      // Semantic events flow through SystemChannels.accessibility.
+      tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(
+        SystemChannels.accessibility,
+        (message) async {
+          if (message is Map) {
+            final type = message['type']?.toString();
+            if (type != null) events.add(type);
+          }
+          return null;
+        },
+      );
+      await tester.pumpWidget(widget);
+      await tester.tap(finder);
+      await tester.pumpAndSettle();
+      tester.binding.defaultBinaryMessenger.setMockDecodedMessageHandler<Object?>(
+        SystemChannels.accessibility,
+        null,
+      );
+      return events;
+    }
+
+    testWidgets('IconButton vs StreamButton.icon — events on tap', (tester) async {
+      final handle = tester.ensureSemantics();
+      var iconButtonPresses = 0;
+      var streamButtonPresses = 0;
+
+      final iconEvents = await capturedEvents(
+        tester,
+        _withStreamTheme(
+          IconButton(
+            isSelected: false,
+            tooltip: 'Photo Gallery',
+            onPressed: () => iconButtonPresses++,
+            icon: const Icon(Icons.photo),
+          ),
+        ),
+        find.byType(IconButton),
+      );
+
+      final streamEvents = await capturedEvents(
+        tester,
+        _withStreamTheme(
+          StreamButton.icon(
+            isSelected: false,
+            tooltip: 'Photo Gallery',
+            onPressed: () => streamButtonPresses++,
+            icon: const Icon(Icons.photo),
+          ),
+        ),
+        find.byType(StreamButton),
+      );
+
+      debugPrint('--- IconButton tap fired events: $iconEvents');
+      debugPrint('--- StreamButton.icon tap fired events: $streamEvents');
+      debugPrint('--- IconButton onPressed count: $iconButtonPresses');
+      debugPrint('--- StreamButton onPressed count: $streamButtonPresses');
+
+      handle.dispose();
+    });
+  });
+
+  group('Material 3 variants', () {
+    testWidgets('IconButton M2 vs M3 (isSelected: true)', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          useMaterial3: false,
+          IconButton(
+            isSelected: true,
+            tooltip: 'Photo Gallery',
+            onPressed: () {},
+            icon: const Icon(Icons.photo),
+          ),
+        ),
+      );
+
+      debugPrint('--- IconButton M2 (isSelected: true) ---');
+      debugPrint(_fmt(tester.getSemantics(find.byType(IconButton)).getSemanticsData()));
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          IconButton(
+            isSelected: true,
+            tooltip: 'Photo Gallery',
+            onPressed: () {},
+            icon: const Icon(Icons.photo),
+          ),
+        ),
+      );
+
+      debugPrint('--- IconButton M3 (isSelected: true) ---');
+      debugPrint(_fmt(tester.getSemantics(find.byType(IconButton)).getSemanticsData()));
+
+      handle.dispose();
+    });
+
+    testWidgets('IconButton.filled M3 (toggle) vs StreamButton.icon', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          IconButton.filled(
+            isSelected: true,
+            tooltip: 'Photo Gallery',
+            onPressed: () {},
+            icon: const Icon(Icons.photo),
+          ),
+        ),
+      );
+
+      debugPrint('--- IconButton.filled M3 (isSelected: true) ---');
+      debugPrint(_fmt(tester.getSemantics(find.byType(IconButton)).getSemanticsData()));
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamButton.icon(
+            isSelected: true,
+            tooltip: 'Photo Gallery',
+            onPressed: () {},
+            icon: const Icon(Icons.photo),
+          ),
+        ),
+      );
+
+      debugPrint('--- StreamButton.icon (isSelected: true) ---');
+      debugPrint(_fmt(tester.getSemantics(find.byType(StreamButton)).getSemanticsData()));
+
+      handle.dispose();
+    });
+
+    testWidgets('FilledButton M3 vs StreamButton (solid)', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          FilledButton(
+            onPressed: () {},
+            child: const Text('Submit'),
+          ),
+        ),
+      );
+
+      debugPrint('--- FilledButton M3 ---');
+      debugPrint(_fmt(tester.getSemantics(find.byType(FilledButton)).getSemanticsData()));
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamButton(
+            onPressed: () {},
+            child: const Text('Submit'),
+          ),
+        ),
+      );
+
+      debugPrint('--- StreamButton (solid) ---');
+      debugPrint(_fmt(tester.getSemantics(find.byType(StreamButton)).getSemanticsData()));
+
+      handle.dispose();
+    });
+  });
+
+  group('Semantic tree comparison: ElevatedButton vs StreamButton', () {
+    testWidgets('with text child, onPressed', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          ElevatedButton(
+            onPressed: () {},
+            child: const Text('Submit'),
+          ),
+        ),
+      );
+
+      debugPrint('--- ElevatedButton ---');
+      debugPrint(_fmt(tester.getSemantics(find.byType(ElevatedButton)).getSemanticsData()));
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamButton(
+            onPressed: () {},
+            child: const Text('Submit'),
+          ),
+        ),
+      );
+
+      debugPrint('--- StreamButton ---');
+      debugPrint(_fmt(tester.getSemantics(find.byType(StreamButton)).getSemanticsData()));
+
+      handle.dispose();
+    });
+
+    testWidgets('with text child, isSelected=true, onPressed', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      // ElevatedButton has no isSelected param, so we apply Semantics(selected:)
+      // externally to compare apples-to-apples with StreamButton's built-in
+      // isSelected handling.
+      await tester.pumpWidget(
+        _withStreamTheme(
+          Semantics(
+            selected: true,
+            child: ElevatedButton(
+              onPressed: () {},
+              child: const Text('Submit'),
+            ),
+          ),
+        ),
+      );
+
+      debugPrint('--- ElevatedButton + Semantics(selected: true) ---');
+      debugPrint(_fmt(tester.getSemantics(find.byType(ElevatedButton)).getSemanticsData()));
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamButton(
+            isSelected: true,
+            onPressed: () {},
+            child: const Text('Submit'),
+          ),
+        ),
+      );
+
+      debugPrint('--- StreamButton (isSelected: true) ---');
+      debugPrint(_fmt(tester.getSemantics(find.byType(StreamButton)).getSemanticsData()));
+
+      handle.dispose();
+    });
+  });
+}

--- a/packages/stream_core_flutter/test/components/common/stream_text_input_test.dart
+++ b/packages/stream_core_flutter/test/components/common/stream_text_input_test.dart
@@ -280,7 +280,7 @@ void main() {
         _withStreamTheme(
           StreamTextInput(
             helperText: 'Required',
-            style: StreamTextInputStyle(helperAffinity: StreamHelperAffinity.outside),
+            style: const StreamTextInputStyle(helperAffinity: StreamHelperAffinity.outside),
           ),
         ),
       );
@@ -297,7 +297,7 @@ void main() {
         MaterialApp(
           theme: ThemeData(extensions: [StreamTheme()]),
           home: StreamTextInputTheme(
-            data: StreamTextInputThemeData(
+            data: const StreamTextInputThemeData(
               style: StreamTextInputStyle(
                 helperAffinity: StreamHelperAffinity.outside,
               ),

--- a/packages/stream_core_flutter/test/components/common/stream_text_input_test.dart
+++ b/packages/stream_core_flutter/test/components/common/stream_text_input_test.dart
@@ -1,0 +1,323 @@
+import 'dart:ui' show SemanticsAction, Tristate;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/core.dart';
+
+Widget _withStreamTheme(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [StreamTheme()]),
+    home: Scaffold(body: child),
+  );
+}
+
+void main() {
+  group('StreamTextInput a11y', () {
+    testWidgets('meets accessibility guidelines', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(StreamTextInput(hintText: 'Email')),
+      );
+
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+
+      handle.dispose();
+    });
+
+    testWidgets('exposes isTextField with hintText as the label', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(StreamTextInput(hintText: 'Email')),
+      );
+
+      expect(
+        tester.getSemantics(find.byType(StreamTextInput)),
+        isSemantics(
+          isTextField: true,
+          label: 'Email',
+          hasTapAction: true,
+          isEnabled: true,
+          hasEnabledState: true,
+        ),
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('disabled — value is still announced; tap exposed but enabled=false', (tester) async {
+      final handle = tester.ensureSemantics();
+      final controller = TextEditingController(text: 'existing');
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamTextInput(hintText: 'Email', enabled: false, controller: controller),
+        ),
+      );
+
+      // A disabled field still announces its current text to SR users so
+      // they can read what's been entered. `tap` is exposed but the
+      // `enabled: false` flag tells the platform not to dispatch it.
+      expect(
+        tester.getSemantics(find.byType(StreamTextInput)),
+        isSemantics(
+          isTextField: true,
+          value: 'existing',
+          isEnabled: false,
+          hasEnabledState: true,
+          hasTapAction: true,
+          hasFocusAction: false,
+        ),
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('read-only — isReadOnly, no tap action, focus action exposed', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(StreamTextInput(hintText: 'Email', readOnly: true)),
+      );
+
+      // Read-only fields don't expose `tap` (tapping would normally request
+      // the keyboard which isn't applicable), but they remain focusable so
+      // SR users can navigate to them and read the value with selection
+      // gestures.
+      expect(
+        tester.getSemantics(find.byType(StreamTextInput)),
+        isSemantics(
+          isTextField: true,
+          isReadOnly: true,
+          label: 'Email',
+          isEnabled: true,
+          hasEnabledState: true,
+          hasTapAction: false,
+          hasFocusAction: true,
+        ),
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('hint is only the semantic label while the field is empty', (tester) async {
+      // Once the user enters text, the hint is hidden visually and should
+      // disappear from the semantic label so SR users don't hear it
+      // duplicated alongside the value.
+      final handle = tester.ensureSemantics();
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        _withStreamTheme(StreamTextInput(hintText: 'Email', controller: controller)),
+      );
+
+      var node = tester.getSemantics(find.byType(StreamTextInput));
+      expect(node.label, 'Email');
+      expect(node.value, '');
+
+      controller.text = 'user@example.com';
+      await tester.pump();
+
+      node = tester.getSemantics(find.byType(StreamTextInput));
+      expect(node.label, '');
+      expect(node.value, 'user@example.com');
+
+      handle.dispose();
+    });
+
+    testWidgets('focused flag tracks the focus node state', (tester) async {
+      final handle = tester.ensureSemantics();
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        _withStreamTheme(StreamTextInput(hintText: 'Email', focusNode: focusNode)),
+      );
+
+      expect(
+        tester.getSemantics(find.byType(StreamTextInput)).getSemanticsData().flagsCollection.isFocused,
+        Tristate.isFalse,
+      );
+
+      focusNode.requestFocus();
+      await tester.pump();
+
+      expect(
+        tester.getSemantics(find.byType(StreamTextInput)).getSemanticsData().flagsCollection.isFocused,
+        Tristate.isTrue,
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('SemanticsAction.tap actually focuses the field', (tester) async {
+      // Verifies the wiring — not just that the action is exposed, but that
+      // invoking it (the way TalkBack/VoiceOver would) actually moves focus
+      // to the underlying editable.
+      final handle = tester.ensureSemantics();
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        _withStreamTheme(StreamTextInput(hintText: 'Email', focusNode: focusNode)),
+      );
+
+      expect(focusNode.hasFocus, isFalse);
+
+      tester.semantics.performAction(
+        find.semantics.byLabel('Email'),
+        SemanticsAction.tap,
+      );
+      await tester.pumpAndSettle();
+
+      expect(focusNode.hasFocus, isTrue);
+
+      handle.dispose();
+    });
+
+    testWidgets('helperText with error state surfaces as the semantic hint', (tester) async {
+      // The error lands on the field's semantic `hint` and the helper
+      // container becomes a live region so SR auto-fires on appearance.
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamTextInput(
+            hintText: 'Email',
+            helperText: 'Invalid email address',
+            helperState: StreamHelperState.error,
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.byType(StreamTextInput)).hint,
+        'Invalid email address',
+      );
+      expect(
+        tester.getSemantics(find.byType(StreamHelperText)).getSemanticsData().flagsCollection.isLiveRegion,
+        isTrue,
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('helperText with info state does not become the semantic hint', (tester) async {
+      // Info / success helpers should NOT appear as the field's hint —
+      // hint is reserved for validation errors. They still get their own
+      // semantic node (not a live region) for users navigating the tree.
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamTextInput(
+            hintText: 'Email',
+            helperText: 'We never share your email.',
+            helperState: StreamHelperState.info,
+          ),
+        ),
+      );
+
+      expect(tester.getSemantics(find.byType(StreamTextInput)).hint, '');
+      expect(
+        tester.getSemantics(find.byType(StreamHelperText)).getSemanticsData().flagsCollection.isLiveRegion,
+        isFalse,
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('maxLength surfaces as maxValueLength / currentValueLength', (tester) async {
+      final handle = tester.ensureSemantics();
+      final controller = TextEditingController(text: 'hi');
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        _withStreamTheme(StreamTextInput(hintText: 'Code', controller: controller, maxLength: 6)),
+      );
+
+      final node = tester.getSemantics(find.byType(StreamTextInput));
+      expect(node.maxValueLength, 6);
+      expect(node.currentValueLength, 2);
+
+      handle.dispose();
+    });
+
+    testWidgets('leading → trailing traversal order is logical, not visual', (tester) async {
+      // Without sort keys, RTL flips the row's visual order so SR would
+      // traverse trailing-then-leading. The sort keys force logical order
+      // regardless of text direction.
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(extensions: [StreamTheme()]),
+          home: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Scaffold(
+              body: StreamTextInput(
+                hintText: 'Email',
+                leading: const Icon(Icons.alternate_email, semanticLabel: 'leading-mail'),
+                trailing: StreamButton.icon(
+                  icon: const Icon(Icons.close),
+                  tooltip: 'Clear',
+                  onPressed: () {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final order = tester.semantics.simulatedAccessibilityTraversal().map((n) => '${n.label}|${n.tooltip}').toList();
+      final leadingIndex = order.indexWhere((s) => s.contains('leading-mail'));
+      final trailingIndex = order.indexWhere((s) => s.contains('Clear'));
+
+      expect(leadingIndex, isNonNegative, reason: 'leading should be in traversal');
+      expect(trailingIndex, greaterThan(leadingIndex), reason: 'leading must precede trailing logically, not visually');
+
+      handle.dispose();
+    });
+
+    testWidgets(
+      'interactive trailing widget is not merged into the input chassis',
+      (tester) async {
+        final handle = tester.ensureSemantics();
+
+        await tester.pumpWidget(
+          _withStreamTheme(
+            StreamTextInput(
+              hintText: 'Search',
+              trailing: StreamButton.icon(
+                icon: const Icon(Icons.close),
+                tooltip: 'Clear',
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        final buttonNode = tester.semantics.find(find.byType(StreamButton));
+        final inputNode = tester.semantics.find(find.byType(StreamTextInput));
+        expect(buttonNode.id, isNot(inputNode.id));
+
+        expect(
+          buttonNode,
+          isSemantics(
+            tooltip: 'Clear',
+            isButton: true,
+            hasTapAction: true,
+          ),
+        );
+
+        handle.dispose();
+      },
+    );
+  });
+}

--- a/packages/stream_core_flutter/test/components/common/stream_text_input_test.dart
+++ b/packages/stream_core_flutter/test/components/common/stream_text_input_test.dart
@@ -231,9 +231,10 @@ void main() {
       handle.dispose();
     });
 
-    testWidgets('helperText with error state surfaces as the semantic hint', (tester) async {
-      // The error lands on the field's semantic `hint` and the helper
-      // container becomes a live region so SR auto-fires on appearance.
+    testWidgets('helperText with error state announces via a live region, not on the field hint', (tester) async {
+      // The error sits in its own live-region semantics container so SR
+      // auto-fires on appearance, and is not duplicated onto the field's
+      // own hint.
       final handle = tester.ensureSemantics();
 
       await tester.pumpWidget(
@@ -248,7 +249,7 @@ void main() {
 
       expect(
         tester.getSemantics(find.byType(StreamTextInput)).hint,
-        'Invalid email address',
+        isNot(contains('Invalid email address')),
       );
       expect(
         tester.getSemantics(find.byType(StreamHelperText)).getSemanticsData().flagsCollection.isLiveRegion,

--- a/packages/stream_core_flutter/test/components/common/stream_text_input_test.dart
+++ b/packages/stream_core_flutter/test/components/common/stream_text_input_test.dart
@@ -105,6 +105,56 @@ void main() {
       handle.dispose();
     });
 
+    testWidgets('labelText becomes the persistent semantic label', (tester) async {
+      // When labelText is provided it's the semantic label regardless of
+      // whether the field is empty or filled, and the hint stops
+      // contributing to the label.
+      final handle = tester.ensureSemantics();
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamTextInput(
+            labelText: 'Email',
+            hintText: 'name@example.com',
+            controller: controller,
+          ),
+        ),
+      );
+
+      var node = tester.getSemantics(find.byType(StreamTextInput));
+      expect(node.label, 'Email');
+      expect(node.value, '');
+
+      controller.text = 'user@example.com';
+      await tester.pump();
+
+      node = tester.getSemantics(find.byType(StreamTextInput));
+      expect(node.label, 'Email');
+      expect(node.value, 'user@example.com');
+
+      handle.dispose();
+    });
+
+    testWidgets('labelText renders a visible label widget above the field', (tester) async {
+      await tester.pumpWidget(
+        _withStreamTheme(StreamTextInput(labelText: 'Email')),
+      );
+
+      expect(find.text('Email'), findsOneWidget);
+    });
+
+    testWidgets('no visible label widget when labelText is null', (tester) async {
+      await tester.pumpWidget(
+        _withStreamTheme(StreamTextInput(hintText: 'visible-hint')),
+      );
+
+      // The hint renders exactly once via the inner editable. If a label
+      // were also rendering, we'd see two Text widgets with this string.
+      expect(find.text('visible-hint'), findsOneWidget);
+    });
+
     testWidgets('hint is only the semantic label while the field is empty', (tester) async {
       // Once the user enters text, the hint is hidden visually and should
       // disappear from the semantic label so SR users don't hear it
@@ -206,6 +256,61 @@ void main() {
       );
 
       handle.dispose();
+    });
+
+    testWidgets('helperAffinity.inside renders helper inside the bordered area (default)', (tester) async {
+      // Inside affinity: the helper text is inset by the container's
+      // contentPadding, so its left edge sits to the right of the
+      // StreamTextInput's left edge.
+      await tester.pumpWidget(
+        _withStreamTheme(StreamTextInput(helperText: 'Required')),
+      );
+
+      final inputLeft = tester.getTopLeft(find.byType(StreamTextInput)).dx;
+      final helperLeft = tester.getTopLeft(find.byType(StreamHelperText)).dx;
+      expect(helperLeft, greaterThan(inputLeft));
+    });
+
+    testWidgets('helperAffinity.outside renders helper below the bordered area', (tester) async {
+      // Outside affinity: the helper text sits at the column root, flush
+      // with the input's left edge (no internal padding offset).
+      // Passed via per-instance style — there is no widget-level prop.
+      await tester.pumpWidget(
+        _withStreamTheme(
+          StreamTextInput(
+            helperText: 'Required',
+            style: StreamTextInputStyle(helperAffinity: StreamHelperAffinity.outside),
+          ),
+        ),
+      );
+
+      final inputLeft = tester.getTopLeft(find.byType(StreamTextInput)).dx;
+      final helperLeft = tester.getTopLeft(find.byType(StreamHelperText)).dx;
+      expect(helperLeft, equals(inputLeft));
+    });
+
+    testWidgets('helperAffinity inherits from StreamTextInputTheme', (tester) async {
+      // Theme sets outside, prop is null — resolution chain should pick
+      // up the theme value, not fall back to the .inside default.
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(extensions: [StreamTheme()]),
+          home: StreamTextInputTheme(
+            data: StreamTextInputThemeData(
+              style: StreamTextInputStyle(
+                helperAffinity: StreamHelperAffinity.outside,
+              ),
+            ),
+            child: Scaffold(
+              body: StreamTextInput(helperText: 'Required'),
+            ),
+          ),
+        ),
+      );
+
+      final inputLeft = tester.getTopLeft(find.byType(StreamTextInput)).dx;
+      final helperLeft = tester.getTopLeft(find.byType(StreamHelperText)).dx;
+      expect(helperLeft, equals(inputLeft));
     });
 
     testWidgets('helperText with info state does not become the semantic hint', (tester) async {

--- a/packages/stream_core_flutter/test/components/controls/stream_stepper_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/controls/stream_stepper_semantics_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_core_flutter/core.dart';
 
@@ -30,7 +29,7 @@ void main() {
 
   void invoke(WidgetTester tester, SemanticsAction action) {
     final id = tester.getSemantics(find.byType(StreamStepper)).id;
-    tester.binding.pipelineOwner.semanticsOwner!.performAction(id, action);
+    tester.binding.rootPipelineOwner.semanticsOwner!.performAction(id, action);
   }
 
   group('semantic shape', () {
@@ -60,7 +59,7 @@ void main() {
 
     testWidgets('disabled (onChanged null) drops actions', (tester) async {
       final handle = tester.ensureSemantics();
-      await tester.pumpWidget(buildSubject(value: 5, onChanged: null));
+      await tester.pumpWidget(buildSubject(value: 5));
 
       expect(
         tester.getSemantics(find.byType(StreamStepper)),
@@ -89,7 +88,7 @@ void main() {
   group('boundaries', () {
     testWidgets('at min: no decrease action exposed', (tester) async {
       final handle = tester.ensureSemantics();
-      await tester.pumpWidget(buildSubject(value: 0, min: 0, max: 10, onChanged: (_) {}));
+      await tester.pumpWidget(buildSubject(value: 0, onChanged: (_) {}));
 
       expect(
         tester.getSemantics(find.byType(StreamStepper)),
@@ -108,7 +107,7 @@ void main() {
 
     testWidgets('at max: no increase action exposed', (tester) async {
       final handle = tester.ensureSemantics();
-      await tester.pumpWidget(buildSubject(value: 10, min: 0, max: 10, onChanged: (_) {}));
+      await tester.pumpWidget(buildSubject(value: 10, onChanged: (_) {}));
 
       expect(
         tester.getSemantics(find.byType(StreamStepper)),
@@ -165,7 +164,7 @@ void main() {
       final handle = tester.ensureSemantics();
       int? received;
       await tester.pumpWidget(
-        buildSubject(value: 10, min: 0, max: 10, onChanged: (v) => received = v),
+        buildSubject(value: 10, onChanged: (v) => received = v),
       );
 
       invoke(tester, SemanticsAction.increase);
@@ -178,7 +177,7 @@ void main() {
       final handle = tester.ensureSemantics();
       int? received;
       await tester.pumpWidget(
-        buildSubject(value: 0, min: 0, max: 10, onChanged: (v) => received = v),
+        buildSubject(value: 0, onChanged: (v) => received = v),
       );
 
       invoke(tester, SemanticsAction.decrease);
@@ -197,14 +196,12 @@ void main() {
 
       final traversal = tester.semantics.simulatedAccessibilityTraversal().toList();
       final interactive = traversal.where((node) {
-        final data = node.getSemanticsData();
-        return data.hasFlag(SemanticsFlag.isButton) ||
-            data.hasFlag(SemanticsFlag.isTextField) ||
-            data.hasFlag(SemanticsFlag.isSlider);
+        final flags = node.getSemanticsData().flagsCollection;
+        return flags.isButton || flags.isTextField || flags.isSlider;
       }).toList();
 
       expect(interactive, hasLength(1));
-      expect(interactive.single.getSemanticsData().hasFlag(SemanticsFlag.isSlider), isTrue);
+      expect(interactive.single.getSemanticsData().flagsCollection.isSlider, isTrue);
 
       handle.dispose();
     });

--- a/packages/stream_core_flutter/test/components/controls/stream_stepper_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/controls/stream_stepper_semantics_test.dart
@@ -1,0 +1,279 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/core.dart';
+
+void main() {
+  Widget buildSubject({
+    required int value,
+    int min = 0,
+    int max = 10,
+    ValueChanged<int>? onChanged,
+    String? semanticLabel,
+  }) {
+    return MaterialApp(
+      theme: ThemeData(extensions: [StreamTheme()]),
+      home: Scaffold(
+        body: Center(
+          child: StreamStepper(
+            value: value,
+            min: min,
+            max: max,
+            onChanged: onChanged,
+            semanticLabel: semanticLabel,
+          ),
+        ),
+      ),
+    );
+  }
+
+  void invoke(WidgetTester tester, SemanticsAction action) {
+    final id = tester.getSemantics(find.byType(StreamStepper)).id;
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(id, action);
+  }
+
+  group('semantic shape', () {
+    testWidgets('mid-range exposes slider + both directions', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        buildSubject(value: 5, semanticLabel: 'Quantity', onChanged: (_) {}),
+      );
+
+      expect(
+        tester.getSemantics(find.byType(StreamStepper)),
+        matchesSemantics(
+          isSlider: true,
+          isEnabled: true,
+          hasEnabledState: true,
+          label: 'Quantity',
+          value: '5',
+          increasedValue: '6',
+          decreasedValue: '4',
+          hasIncreaseAction: true,
+          hasDecreaseAction: true,
+        ),
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('disabled (onChanged null) drops actions', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(buildSubject(value: 5, onChanged: null));
+
+      expect(
+        tester.getSemantics(find.byType(StreamStepper)),
+        matchesSemantics(
+          isSlider: true,
+          hasEnabledState: true,
+          value: '5',
+        ),
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('no semanticLabel → label is empty', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(buildSubject(value: 5, onChanged: (_) {}));
+
+      final data = tester.getSemantics(find.byType(StreamStepper)).getSemanticsData();
+      expect(data.label, isEmpty);
+      expect(data.value, equals('5'));
+
+      handle.dispose();
+    });
+  });
+
+  group('boundaries', () {
+    testWidgets('at min: no decrease action exposed', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(buildSubject(value: 0, min: 0, max: 10, onChanged: (_) {}));
+
+      expect(
+        tester.getSemantics(find.byType(StreamStepper)),
+        matchesSemantics(
+          isSlider: true,
+          isEnabled: true,
+          hasEnabledState: true,
+          value: '0',
+          increasedValue: '1',
+          hasIncreaseAction: true,
+        ),
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('at max: no increase action exposed', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(buildSubject(value: 10, min: 0, max: 10, onChanged: (_) {}));
+
+      expect(
+        tester.getSemantics(find.byType(StreamStepper)),
+        matchesSemantics(
+          isSlider: true,
+          isEnabled: true,
+          hasEnabledState: true,
+          value: '10',
+          decreasedValue: '9',
+          hasDecreaseAction: true,
+        ),
+      );
+
+      handle.dispose();
+    });
+
+    testWidgets('single-value range (min == max): no actions', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(buildSubject(value: 5, min: 5, max: 5, onChanged: (_) {}));
+
+      final data = tester.getSemantics(find.byType(StreamStepper)).getSemanticsData();
+      expect(data.value, equals('5'));
+      expect(data.hasAction(SemanticsAction.increase), isFalse);
+      expect(data.hasAction(SemanticsAction.decrease), isFalse);
+
+      handle.dispose();
+    });
+  });
+
+  group('actions', () {
+    testWidgets('increase action calls onChanged with value + 1', (tester) async {
+      final handle = tester.ensureSemantics();
+      int? received;
+      await tester.pumpWidget(buildSubject(value: 5, onChanged: (v) => received = v));
+
+      invoke(tester, SemanticsAction.increase);
+      expect(received, equals(6));
+
+      handle.dispose();
+    });
+
+    testWidgets('decrease action calls onChanged with value - 1', (tester) async {
+      final handle = tester.ensureSemantics();
+      int? received;
+      await tester.pumpWidget(buildSubject(value: 5, onChanged: (v) => received = v));
+
+      invoke(tester, SemanticsAction.decrease);
+      expect(received, equals(4));
+
+      handle.dispose();
+    });
+
+    testWidgets('at max: invoking increase is a no-op (action absent)', (tester) async {
+      final handle = tester.ensureSemantics();
+      int? received;
+      await tester.pumpWidget(
+        buildSubject(value: 10, min: 0, max: 10, onChanged: (v) => received = v),
+      );
+
+      invoke(tester, SemanticsAction.increase);
+      expect(received, isNull);
+
+      handle.dispose();
+    });
+
+    testWidgets('at min: invoking decrease is a no-op (action absent)', (tester) async {
+      final handle = tester.ensureSemantics();
+      int? received;
+      await tester.pumpWidget(
+        buildSubject(value: 0, min: 0, max: 10, onChanged: (v) => received = v),
+      );
+
+      invoke(tester, SemanticsAction.decrease);
+      expect(received, isNull);
+
+      handle.dispose();
+    });
+  });
+
+  group('exclusion', () {
+    testWidgets('child buttons + text input do not produce extra focus stops', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        buildSubject(value: 5, semanticLabel: 'Quantity', onChanged: (_) {}),
+      );
+
+      final traversal = tester.semantics.simulatedAccessibilityTraversal().toList();
+      final interactive = traversal.where((node) {
+        final data = node.getSemanticsData();
+        return data.hasFlag(SemanticsFlag.isButton) ||
+            data.hasFlag(SemanticsFlag.isTextField) ||
+            data.hasFlag(SemanticsFlag.isSlider);
+      }).toList();
+
+      expect(interactive, hasLength(1));
+      expect(interactive.single.getSemanticsData().hasFlag(SemanticsFlag.isSlider), isTrue);
+
+      handle.dispose();
+    });
+  });
+
+  group('focus isolation', () {
+    testWidgets('inner FocusScope blocks descendant focus traversal', (tester) async {
+      await tester.pumpWidget(buildSubject(value: 5, onChanged: (_) {}));
+
+      final scope = tester.widget<FocusScope>(
+        find.descendant(
+          of: find.byType(StreamStepper),
+          matching: find.byType(FocusScope),
+        ),
+      );
+      expect(scope.canRequestFocus, isFalse);
+      expect(scope.descendantsAreFocusable, isFalse);
+    });
+
+    testWidgets('Tab traversal skips the stepper subtree', (tester) async {
+      final beforeFocus = FocusNode(debugLabel: 'before');
+      final afterFocus = FocusNode(debugLabel: 'after');
+      addTearDown(beforeFocus.dispose);
+      addTearDown(afterFocus.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(extensions: [StreamTheme()]),
+          home: Scaffold(
+            body: Column(
+              children: [
+                Focus(focusNode: beforeFocus, child: const SizedBox(width: 1, height: 1)),
+                StreamStepper(value: 5, onChanged: (_) {}),
+                Focus(focusNode: afterFocus, child: const SizedBox(width: 1, height: 1)),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      beforeFocus.requestFocus();
+      await tester.pump();
+      expect(beforeFocus.hasFocus, isTrue);
+
+      beforeFocus.nextFocus();
+      await tester.pump();
+
+      expect(afterFocus.hasFocus, isTrue);
+    });
+
+    testWidgets('inner value display does not hit-test (IgnorePointer)', (tester) async {
+      await tester.pumpWidget(buildSubject(value: 5, onChanged: (_) {}));
+
+      final stepperRect = tester.getRect(find.byType(StreamStepper));
+      final hits = HitTestResult();
+      tester.binding.hitTestInView(hits, stepperRect.center, tester.view.viewId);
+      final hitTextField = hits.path.any((entry) => entry.target is RenderEditable);
+      expect(hitTextField, isFalse);
+    });
+
+    testWidgets('semantic increase action still drives the value through the FocusScope', (tester) async {
+      final handle = tester.ensureSemantics();
+      int? received;
+      await tester.pumpWidget(buildSubject(value: 5, onChanged: (v) => received = v));
+
+      invoke(tester, SemanticsAction.increase);
+      expect(received, equals(6));
+
+      handle.dispose();
+    });
+  });
+}

--- a/packages/stream_core_flutter/test/components/controls/stream_stepper_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/controls/stream_stepper_semantics_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
+import 'package:flutter/semantics.dart' show SemanticsAction;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_core_flutter/core.dart';
 
@@ -28,8 +28,10 @@ void main() {
   }
 
   void invoke(WidgetTester tester, SemanticsAction action) {
-    final id = tester.getSemantics(find.byType(StreamStepper)).id;
-    tester.binding.rootPipelineOwner.semanticsOwner!.performAction(id, action);
+    tester.semantics.performAction(
+      find.semantics.byPredicate((n) => n.getSemanticsData().hasAction(action)),
+      action,
+    );
   }
 
   group('semantic shape', () {
@@ -160,28 +162,22 @@ void main() {
       handle.dispose();
     });
 
-    testWidgets('at max: invoking increase is a no-op (action absent)', (tester) async {
+    testWidgets('at max: increase action is absent', (tester) async {
       final handle = tester.ensureSemantics();
-      int? received;
-      await tester.pumpWidget(
-        buildSubject(value: 10, onChanged: (v) => received = v),
-      );
+      await tester.pumpWidget(buildSubject(value: 10, onChanged: (_) {}));
 
-      invoke(tester, SemanticsAction.increase);
-      expect(received, isNull);
+      final data = tester.getSemantics(find.byType(StreamStepper)).getSemanticsData();
+      expect(data.hasAction(SemanticsAction.increase), isFalse);
 
       handle.dispose();
     });
 
-    testWidgets('at min: invoking decrease is a no-op (action absent)', (tester) async {
+    testWidgets('at min: decrease action is absent', (tester) async {
       final handle = tester.ensureSemantics();
-      int? received;
-      await tester.pumpWidget(
-        buildSubject(value: 0, onChanged: (v) => received = v),
-      );
+      await tester.pumpWidget(buildSubject(value: 0, onChanged: (_) {}));
 
-      invoke(tester, SemanticsAction.decrease);
-      expect(received, isNull);
+      final data = tester.getSemantics(find.byType(StreamStepper)).getSemanticsData();
+      expect(data.hasAction(SemanticsAction.decrease), isFalse);
 
       handle.dispose();
     });
@@ -202,73 +198,6 @@ void main() {
 
       expect(interactive, hasLength(1));
       expect(interactive.single.getSemanticsData().flagsCollection.isSlider, isTrue);
-
-      handle.dispose();
-    });
-  });
-
-  group('focus isolation', () {
-    testWidgets('inner FocusScope blocks descendant focus traversal', (tester) async {
-      await tester.pumpWidget(buildSubject(value: 5, onChanged: (_) {}));
-
-      final scope = tester.widget<FocusScope>(
-        find.descendant(
-          of: find.byType(StreamStepper),
-          matching: find.byType(FocusScope),
-        ),
-      );
-      expect(scope.canRequestFocus, isFalse);
-      expect(scope.descendantsAreFocusable, isFalse);
-    });
-
-    testWidgets('Tab traversal skips the stepper subtree', (tester) async {
-      final beforeFocus = FocusNode(debugLabel: 'before');
-      final afterFocus = FocusNode(debugLabel: 'after');
-      addTearDown(beforeFocus.dispose);
-      addTearDown(afterFocus.dispose);
-
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(extensions: [StreamTheme()]),
-          home: Scaffold(
-            body: Column(
-              children: [
-                Focus(focusNode: beforeFocus, child: const SizedBox(width: 1, height: 1)),
-                StreamStepper(value: 5, onChanged: (_) {}),
-                Focus(focusNode: afterFocus, child: const SizedBox(width: 1, height: 1)),
-              ],
-            ),
-          ),
-        ),
-      );
-
-      beforeFocus.requestFocus();
-      await tester.pump();
-      expect(beforeFocus.hasFocus, isTrue);
-
-      beforeFocus.nextFocus();
-      await tester.pump();
-
-      expect(afterFocus.hasFocus, isTrue);
-    });
-
-    testWidgets('inner value display does not hit-test (IgnorePointer)', (tester) async {
-      await tester.pumpWidget(buildSubject(value: 5, onChanged: (_) {}));
-
-      final stepperRect = tester.getRect(find.byType(StreamStepper));
-      final hits = HitTestResult();
-      tester.binding.hitTestInView(hits, stepperRect.center, tester.view.viewId);
-      final hitTextField = hits.path.any((entry) => entry.target is RenderEditable);
-      expect(hitTextField, isFalse);
-    });
-
-    testWidgets('semantic increase action still drives the value through the FocusScope', (tester) async {
-      final handle = tester.ensureSemantics();
-      int? received;
-      await tester.pumpWidget(buildSubject(value: 5, onChanged: (v) => received = v));
-
-      invoke(tester, SemanticsAction.increase);
-      expect(received, equals(6));
 
       handle.dispose();
     });

--- a/packages/stream_core_flutter/test/components/message_composer/attachment/file_attachment_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/message_composer/attachment/file_attachment_semantics_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_core_flutter/chat.dart';
 
@@ -11,7 +10,7 @@ Widget _withStreamTheme(Widget child) {
 }
 
 void main() {
-  testWidgets('file attachment — semantic tree', (tester) async {
+  testWidgets('file attachment — single merged SR node with delete affordance', (tester) async {
     final handle = tester.ensureSemantics();
 
     await tester.pumpWidget(
@@ -25,22 +24,16 @@ void main() {
       ),
     );
 
-    debugPrint('=== ACCESSIBILITY TRAVERSAL ORDER (what SR walks) ===');
-    final order = tester.semantics.simulatedAccessibilityTraversal();
-    var i = 0;
-    for (final node in order) {
-      final data = node.getSemanticsData();
-      final actions = SemanticsAction.values.where((a) => (data.actions & a.index) != 0).map((a) => a.name).toList();
-      final flags = data.flagsCollection.toStrings();
-      if (data.label.isEmpty && actions.isEmpty && flags.isEmpty) continue;
-      debugPrint('[$i] rect=${node.rect}  label="${data.label}"  flags=$flags  actions=$actions');
-      i++;
-    }
+    // MergeSemantics rolls up the title + subtitle Text nodes into one SR
+    // focus stop that reads the joined label.
+    final semantics = tester.getSemantics(find.bySemanticsLabel(RegExp('report\\.pdf')));
 
-    debugPrint('\n=== FULL SEMANTIC TREE ===');
-    final owner = RendererBinding.instance.rootPipelineOwner.semanticsOwner;
-    final root = owner?.rootSemanticsNode;
-    debugPrint(root?.toStringDeep() ?? '(no root semantic node)');
+    expect(semantics.label, contains('report.pdf'));
+    expect(semantics.label, contains('2 MB'));
+
+    // Tap on the merged node invokes the remove callback (VoiceOver says
+    // "double-tap to Delete" via onTapHint).
+    expect(semantics, containsSemantics(hasTapAction: true, onTapHint: 'Delete'));
 
     handle.dispose();
   });

--- a/packages/stream_core_flutter/test/components/message_composer/attachment/file_attachment_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/message_composer/attachment/file_attachment_semantics_test.dart
@@ -1,29 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_core_flutter/chat.dart';
-import 'package:stream_core_flutter/core.dart';
-
-String _fmt(SemanticsData d) {
-  final lines = <String>[];
-  void add(String key, Object? value) {
-    if (value == null) return;
-    if (value is String && value.isEmpty) return;
-    if (value is List && value.isEmpty) return;
-    lines.add('  $key: $value');
-  }
-
-  final actions = SemanticsAction.values.where((a) => (d.actions & a.index) != 0).map((a) => a.name).toList();
-  final flags = SemanticsFlag.values.where((f) => d.hasFlag(f)).map((f) => f.name).toList();
-
-  add('actions', actions);
-  add('flags', flags);
-  add('label', d.label);
-  add('value', d.value);
-  add('hint', d.hint);
-  add('tooltip', d.tooltip);
-  return '{\n${lines.join(',\n')}\n}';
-}
 
 Widget _withStreamTheme(Widget child) {
   return MaterialApp(
@@ -53,14 +31,14 @@ void main() {
     for (final node in order) {
       final data = node.getSemanticsData();
       final actions = SemanticsAction.values.where((a) => (data.actions & a.index) != 0).map((a) => a.name).toList();
-      final flags = SemanticsFlag.values.where((f) => data.hasFlag(f)).map((f) => f.name).toList();
+      final flags = data.flagsCollection.toStrings();
       if (data.label.isEmpty && actions.isEmpty && flags.isEmpty) continue;
       debugPrint('[$i] rect=${node.rect}  label="${data.label}"  flags=$flags  actions=$actions');
       i++;
     }
 
     debugPrint('\n=== FULL SEMANTIC TREE ===');
-    final owner = tester.binding.pipelineOwner.semanticsOwner;
+    final owner = RendererBinding.instance.rootPipelineOwner.semanticsOwner;
     final root = owner?.rootSemanticsNode;
     debugPrint(root?.toStringDeep() ?? '(no root semantic node)');
 

--- a/packages/stream_core_flutter/test/components/message_composer/attachment/file_attachment_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/message_composer/attachment/file_attachment_semantics_test.dart
@@ -26,14 +26,14 @@ void main() {
 
     // MergeSemantics rolls up the title + subtitle Text nodes into one SR
     // focus stop that reads the joined label.
-    final semantics = tester.getSemantics(find.bySemanticsLabel(RegExp('report\\.pdf')));
+    final semantics = tester.getSemantics(find.bySemanticsLabel(RegExp(r'report\.pdf')));
 
     expect(semantics.label, contains('report.pdf'));
     expect(semantics.label, contains('2 MB'));
 
     // Tap on the merged node invokes the remove callback (VoiceOver says
     // "double-tap to Delete" via onTapHint).
-    expect(semantics, containsSemantics(hasTapAction: true, onTapHint: 'Delete'));
+    expect(semantics, isSemantics(hasTapAction: true, onTapHint: 'Delete'));
 
     handle.dispose();
   });

--- a/packages/stream_core_flutter/test/components/message_composer/attachment/file_attachment_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/message_composer/attachment/file_attachment_semantics_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/chat.dart';
+import 'package:stream_core_flutter/core.dart';
+
+String _fmt(SemanticsData d) {
+  final lines = <String>[];
+  void add(String key, Object? value) {
+    if (value == null) return;
+    if (value is String && value.isEmpty) return;
+    if (value is List && value.isEmpty) return;
+    lines.add('  $key: $value');
+  }
+
+  final actions = SemanticsAction.values.where((a) => (d.actions & a.index) != 0).map((a) => a.name).toList();
+  final flags = SemanticsFlag.values.where((f) => d.hasFlag(f)).map((f) => f.name).toList();
+
+  add('actions', actions);
+  add('flags', flags);
+  add('label', d.label);
+  add('value', d.value);
+  add('hint', d.hint);
+  add('tooltip', d.tooltip);
+  return '{\n${lines.join(',\n')}\n}';
+}
+
+Widget _withStreamTheme(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [StreamTheme()]),
+    home: Scaffold(body: Center(child: child)),
+  );
+}
+
+void main() {
+  testWidgets('file attachment — semantic tree', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      _withStreamTheme(
+        StreamMessageComposerFileAttachment(
+          title: const Text('report.pdf'),
+          subtitle: const Text('2 MB'),
+          fileTypeIcon: StreamFileTypeIcon(type: StreamFileType.pdf, extension: 'PDF'),
+          onRemovePressed: () {},
+        ),
+      ),
+    );
+
+    debugPrint('=== ACCESSIBILITY TRAVERSAL ORDER (what SR walks) ===');
+    final order = tester.semantics.simulatedAccessibilityTraversal();
+    var i = 0;
+    for (final node in order) {
+      final data = node.getSemanticsData();
+      final actions = SemanticsAction.values.where((a) => (data.actions & a.index) != 0).map((a) => a.name).toList();
+      final flags = SemanticsFlag.values.where((f) => data.hasFlag(f)).map((f) => f.name).toList();
+      if (data.label.isEmpty && actions.isEmpty && flags.isEmpty) continue;
+      debugPrint('[$i] rect=${node.rect}  label="${data.label}"  flags=$flags  actions=$actions');
+      i++;
+    }
+
+    debugPrint('\n=== FULL SEMANTIC TREE ===');
+    final owner = tester.binding.pipelineOwner.semanticsOwner;
+    final root = owner?.rootSemanticsNode;
+    debugPrint(root?.toStringDeep() ?? '(no root semantic node)');
+
+    handle.dispose();
+  });
+}

--- a/packages/stream_core_flutter/test/components/message_composer/attachment/media_attachment_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/message_composer/attachment/media_attachment_semantics_test.dart
@@ -37,7 +37,7 @@ void main() {
     final photo2 = tester.getSemantics(find.bySemanticsLabel('Photo 2'));
 
     for (final tile in [photo1, photo2]) {
-      expect(tile, containsSemantics(hasTapAction: true, onTapHint: 'Delete'));
+      expect(tile, isSemantics(hasTapAction: true, onTapHint: 'Delete'));
     }
 
     // The remove control is ExcludeSemantics'd — no separate button node.

--- a/packages/stream_core_flutter/test/components/message_composer/attachment/media_attachment_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/message_composer/attachment/media_attachment_semantics_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_core_flutter/chat.dart';
 
@@ -11,7 +10,7 @@ Widget _withStreamTheme(Widget child) {
 }
 
 void main() {
-  testWidgets('media attachment — semantic tree', (tester) async {
+  testWidgets('media attachments — one merged SR node per tile, correct traversal order', (tester) async {
     final handle = tester.ensureSemantics();
 
     await tester.pumpWidget(
@@ -34,21 +33,23 @@ void main() {
       ),
     );
 
-    debugPrint('=== TRAVERSAL ===');
-    final order = tester.semantics.simulatedAccessibilityTraversal();
-    var i = 0;
-    for (final node in order) {
-      final data = node.getSemanticsData();
-      final actions = SemanticsAction.values.where((a) => (data.actions & a.index) != 0).map((a) => a.name).toList();
-      final flags = data.flagsCollection.toStrings();
-      if (data.label.isEmpty && actions.isEmpty && flags.isEmpty) continue;
-      debugPrint('[$i] rect=${node.rect}  label="${data.label}"  flags=$flags  actions=$actions');
-      i++;
+    final photo1 = tester.getSemantics(find.bySemanticsLabel('Photo 1'));
+    final photo2 = tester.getSemantics(find.bySemanticsLabel('Photo 2'));
+
+    for (final tile in [photo1, photo2]) {
+      expect(tile, containsSemantics(hasTapAction: true, onTapHint: 'Delete'));
     }
 
-    debugPrint('\n=== FULL TREE ===');
-    final root = RendererBinding.instance.rootPipelineOwner.semanticsOwner?.rootSemanticsNode;
-    debugPrint(root?.toStringDeep() ?? '(none)');
+    // The remove control is ExcludeSemantics'd — no separate button node.
+    expect(find.bySemanticsLabel('Delete'), findsNothing);
+
+    // SR walks Photo 1 before Photo 2.
+    final labels = tester.semantics
+        .simulatedAccessibilityTraversal()
+        .map((n) => n.getSemanticsData().label)
+        .where((l) => l == 'Photo 1' || l == 'Photo 2')
+        .toList();
+    expect(labels, ['Photo 1', 'Photo 2']);
 
     handle.dispose();
   });

--- a/packages/stream_core_flutter/test/components/message_composer/attachment/media_attachment_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/message_composer/attachment/media_attachment_semantics_test.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_core_flutter/chat.dart';
-import 'package:stream_core_flutter/core.dart';
 
 Widget _withStreamTheme(Widget child) {
   return MaterialApp(
@@ -41,14 +40,14 @@ void main() {
     for (final node in order) {
       final data = node.getSemanticsData();
       final actions = SemanticsAction.values.where((a) => (data.actions & a.index) != 0).map((a) => a.name).toList();
-      final flags = SemanticsFlag.values.where((f) => data.hasFlag(f)).map((f) => f.name).toList();
+      final flags = data.flagsCollection.toStrings();
       if (data.label.isEmpty && actions.isEmpty && flags.isEmpty) continue;
       debugPrint('[$i] rect=${node.rect}  label="${data.label}"  flags=$flags  actions=$actions');
       i++;
     }
 
     debugPrint('\n=== FULL TREE ===');
-    final root = tester.binding.pipelineOwner.semanticsOwner?.rootSemanticsNode;
+    final root = RendererBinding.instance.rootPipelineOwner.semanticsOwner?.rootSemanticsNode;
     debugPrint(root?.toStringDeep() ?? '(none)');
 
     handle.dispose();

--- a/packages/stream_core_flutter/test/components/message_composer/attachment/media_attachment_semantics_test.dart
+++ b/packages/stream_core_flutter/test/components/message_composer/attachment/media_attachment_semantics_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/chat.dart';
+import 'package:stream_core_flutter/core.dart';
+
+Widget _withStreamTheme(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [StreamTheme()]),
+    home: Scaffold(body: Center(child: child)),
+  );
+}
+
+void main() {
+  testWidgets('media attachment — semantic tree', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      _withStreamTheme(
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            StreamMessageComposerMediaAttachment(
+              semanticLabel: 'Photo 1',
+              onRemovePressed: () {},
+              child: Container(color: Colors.grey),
+            ),
+            StreamMessageComposerMediaAttachment(
+              semanticLabel: 'Photo 2',
+              onRemovePressed: () {},
+              child: Container(color: Colors.blue),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    debugPrint('=== TRAVERSAL ===');
+    final order = tester.semantics.simulatedAccessibilityTraversal();
+    var i = 0;
+    for (final node in order) {
+      final data = node.getSemanticsData();
+      final actions = SemanticsAction.values.where((a) => (data.actions & a.index) != 0).map((a) => a.name).toList();
+      final flags = SemanticsFlag.values.where((f) => data.hasFlag(f)).map((f) => f.name).toList();
+      if (data.label.isEmpty && actions.isEmpty && flags.isEmpty) continue;
+      debugPrint('[$i] rect=${node.rect}  label="${data.label}"  flags=$flags  actions=$actions');
+      i++;
+    }
+
+    debugPrint('\n=== FULL TREE ===');
+    final root = tester.binding.pipelineOwner.semanticsOwner?.rootSemanticsNode;
+    debugPrint(root?.toStringDeep() ?? '(none)');
+
+    handle.dispose();
+  });
+}

--- a/packages/stream_core_flutter/test/components/sheet/stream_sheet_test.dart
+++ b/packages/stream_core_flutter/test/components/sheet/stream_sheet_test.dart
@@ -615,7 +615,7 @@ void main() {
         });
       }
 
-      walk(tester.binding.pipelineOwner.semanticsOwner!.rootSemanticsNode!);
+      walk(tester.binding.rootPipelineOwner.semanticsOwner!.rootSemanticsNode!);
       return found;
     }
 
@@ -627,7 +627,7 @@ void main() {
           _SheetLauncher(
             onPushed: (context) => showStreamSheet<void>(
               context: context,
-              builder: (_, __) => const Text('body'),
+              builder: (_, _) => const Text('body'),
             ),
           ),
         ),
@@ -657,7 +657,7 @@ void main() {
           _SheetLauncher(
             onPushed: (context) => showStreamSheet<void>(
               context: context,
-              builder: (_, __) => Column(
+              builder: (_, _) => Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   StreamSheetHeader(title: const Text('Create Poll')),
@@ -689,7 +689,7 @@ void main() {
           _SheetLauncher(
             onPushed: (context) => showStreamSheet<void>(
               context: context,
-              builder: (_, __) => const Text('body'),
+              builder: (_, _) => const Text('body'),
             ),
           ),
         ),
@@ -705,7 +705,7 @@ void main() {
       expect(dragHandleNode, isNotNull);
       expect(dragHandleNode!.getSemanticsData().hasAction(SemanticsAction.tap), isTrue);
 
-      tester.binding.pipelineOwner.semanticsOwner!.performAction(
+      tester.binding.rootPipelineOwner.semanticsOwner!.performAction(
         dragHandleNode.id,
         SemanticsAction.tap,
       );

--- a/packages/stream_core_flutter/test/components/sheet/stream_sheet_test.dart
+++ b/packages/stream_core_flutter/test/components/sheet/stream_sheet_test.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_core_flutter/core.dart';
 
-Widget _withStreamTheme(Widget child) {
+Widget _withStreamTheme(Widget child, {TargetPlatform? platform}) {
   return MaterialApp(
-    theme: ThemeData(extensions: [StreamTheme()]),
+    theme: ThemeData(platform: platform, extensions: [StreamTheme()]),
     home: child,
   );
 }
@@ -595,5 +596,125 @@ void main() {
         expect(find.text('Open'), findsOneWidget);
       },
     );
+  });
+
+  group('semantics', () {
+    // Walks the semantics subtree looking for the first node where [test]
+    // returns true. Returns null when no such node exists.
+    SemanticsNode? findSemanticsNode(WidgetTester tester, bool Function(SemanticsData) test) {
+      SemanticsNode? found;
+      void walk(SemanticsNode node) {
+        if (found != null) return;
+        if (test(node.getSemanticsData())) {
+          found = node;
+          return;
+        }
+        node.visitChildren((c) {
+          walk(c);
+          return true;
+        });
+      }
+
+      walk(tester.binding.pipelineOwner.semanticsOwner!.rootSemanticsNode!);
+      return found;
+    }
+
+    testWidgets('sheet route is scoped for focus management', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          _SheetLauncher(
+            onPushed: (context) => showStreamSheet<void>(
+              context: context,
+              builder: (_, __) => const Text('body'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final routeNode = findSemanticsNode(
+        tester,
+        (d) => d.flagsCollection.scopesRoute,
+      );
+      expect(routeNode, isNotNull);
+      final data = routeNode!.getSemanticsData();
+      expect(data.flagsCollection.namesRoute, isFalse, reason: 'descendants own the name');
+      expect(data.label, isEmpty);
+
+      handle.dispose();
+    });
+
+    testWidgets('StreamSheetHeader title provides the route name on Android', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          platform: TargetPlatform.android,
+          _SheetLauncher(
+            onPushed: (context) => showStreamSheet<void>(
+              context: context,
+              builder: (_, __) => Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  StreamSheetHeader(title: const Text('Create Poll')),
+                  const Text('body'),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final headerRouteNode = findSemanticsNode(
+        tester,
+        (d) => d.flagsCollection.namesRoute && d.label == 'Create Poll',
+      );
+      expect(headerRouteNode, isNotNull);
+
+      handle.dispose();
+    });
+
+    testWidgets('drag handle exposes a Dismiss button that pops the route', (tester) async {
+      final handle = tester.ensureSemantics();
+
+      await tester.pumpWidget(
+        _withStreamTheme(
+          _SheetLauncher(
+            onPushed: (context) => showStreamSheet<void>(
+              context: context,
+              builder: (_, __) => const Text('body'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      final dragHandleNode = findSemanticsNode(
+        tester,
+        (d) => d.flagsCollection.isButton && d.label == 'Dismiss',
+      );
+      expect(dragHandleNode, isNotNull);
+      expect(dragHandleNode!.getSemanticsData().hasAction(SemanticsAction.tap), isTrue);
+
+      tester.binding.pipelineOwner.semanticsOwner!.performAction(
+        dragHandleNode.id,
+        SemanticsAction.tap,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('body'), findsNothing);
+      expect(find.text('Open'), findsOneWidget);
+
+      handle.dispose();
+    });
   });
 }

--- a/packages/stream_core_flutter/test/components/sheet/stream_sheet_test.dart
+++ b/packages/stream_core_flutter/test/components/sheet/stream_sheet_test.dart
@@ -615,7 +615,10 @@ void main() {
         });
       }
 
-      walk(tester.binding.rootPipelineOwner.semanticsOwner!.rootSemanticsNode!);
+      // rootPipelineOwner.semanticsOwner is null in test env; the deprecated
+      // pipelineOwner path still points at the semantic root.
+      // ignore: deprecated_member_use
+      walk(tester.binding.pipelineOwner.semanticsOwner!.rootSemanticsNode!);
       return found;
     }
 
@@ -705,7 +708,9 @@ void main() {
       expect(dragHandleNode, isNotNull);
       expect(dragHandleNode!.getSemanticsData().hasAction(SemanticsAction.tap), isTrue);
 
-      tester.binding.rootPipelineOwner.semanticsOwner!.performAction(
+      // See comment above; test env only.
+      // ignore: deprecated_member_use
+      tester.binding.pipelineOwner.semanticsOwner!.performAction(
         dragHandleNode.id,
         SemanticsAction.tap,
       );

--- a/packages/stream_core_flutter/test/components/snackbar/stream_snackbar_test.dart
+++ b/packages/stream_core_flutter/test/components/snackbar/stream_snackbar_test.dart
@@ -432,10 +432,10 @@ void main() {
 
       expect(
         tester.getSemantics(find.byType(StreamSnackbar)),
-        matchesSemantics(
+        isSemantics(
           isLiveRegion: true,
           hasDismissAction: true,
-          children: [matchesSemantics(label: 'Saved')],
+          children: [isSemantics(label: 'Saved')],
         ),
       );
 
@@ -845,6 +845,72 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
 
       expect(find.text('Auto-managed'), findsOneWidget);
+    });
+  });
+
+  group('accessibleNavigation', () {
+    Widget hostScaffold(StreamSnackbarMessenger messenger) {
+      return MaterialApp(
+        theme: ThemeData(extensions: [StreamTheme.light()]),
+        home: Stack(
+          children: [
+            Positioned(
+              bottom: 0,
+              left: 0,
+              right: 0,
+              child: StreamSnackbarHost(messenger: messenger),
+            ),
+          ],
+        ),
+      );
+    }
+
+    FadeTransition fadeOf(WidgetTester tester) {
+      return tester.widget<FadeTransition>(
+        find.descendant(
+          of: find.byType(StreamSnackbarHost),
+          matching: find.byType(FadeTransition),
+        ),
+      );
+    }
+
+    testWidgets('on — entry skips animation (opacity 1.0 after one frame)', (tester) async {
+      tester.platformDispatcher.accessibilityFeaturesTestValue = const FakeAccessibilityFeatures(
+        accessibleNavigation: true,
+      );
+      addTearDown(tester.platformDispatcher.clearAccessibilityFeaturesTestValue);
+
+      final messenger = StreamSnackbarMessenger();
+      addTearDown(messenger.dispose);
+
+      await tester.pumpWidget(hostScaffold(messenger));
+
+      messenger.show(StreamSnackbar(message: const Text('Hello')));
+      await tester.pump();
+
+      expect(fadeOf(tester).opacity.value, equals(1.0));
+    });
+
+    testWidgets('on — exit skips animation and resolves controller after one frame', (tester) async {
+      tester.platformDispatcher.accessibilityFeaturesTestValue = const FakeAccessibilityFeatures(
+        accessibleNavigation: true,
+      );
+      addTearDown(tester.platformDispatcher.clearAccessibilityFeaturesTestValue);
+
+      final messenger = StreamSnackbarMessenger();
+      addTearDown(messenger.dispose);
+
+      await tester.pumpWidget(hostScaffold(messenger));
+
+      final controller = messenger.show(StreamSnackbar(message: const Text('Bye')));
+      await tester.pump();
+      expect(find.text('Bye'), findsOneWidget);
+
+      controller.close();
+      await tester.pump();
+
+      expect(find.text('Bye'), findsNothing);
+      expect(await controller.closed, StreamSnackbarClosedReason.dismiss);
     });
   });
 }

--- a/packages/stream_core_flutter/test/components/toolbar/stream_app_bar_focus_isolation_test.dart
+++ b/packages/stream_core_flutter/test/components/toolbar/stream_app_bar_focus_isolation_test.dart
@@ -61,7 +61,7 @@ void main() {
       });
     }
 
-    visit(tester.binding.pipelineOwner.semanticsOwner!.rootSemanticsNode!);
+    visit(tester.binding.rootPipelineOwner.semanticsOwner!.rootSemanticsNode!);
     expect(barNode, isNotNull);
 
     // The outer bar node must have NO actions. A leak from a slot would

--- a/packages/stream_core_flutter/test/components/toolbar/stream_app_bar_focus_isolation_test.dart
+++ b/packages/stream_core_flutter/test/components/toolbar/stream_app_bar_focus_isolation_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/core.dart';
+
+// Each slot of [StreamAppBar] must produce its own focus stop. A raw
+// [GestureDetector] in a slot must not leak its tap action up to the
+// bar's outer [Semantics] container — that would collapse the bar into
+// a single tappable region. The fix is [explicitChildNodes: true] on
+// the outer Semantics, matching Flutter's inner Semantics inside
+// Material (app_bar.dart line 1246).
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [StreamTheme()]),
+    home: child,
+  );
+}
+
+void main() {
+  testWidgets('slots stay isolated; trailing tap does not leak up', (tester) async {
+    final handle = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      _wrap(
+        Scaffold(
+          appBar: StreamAppBar(
+            leading: Builder(
+              builder: (context) => IconButton(
+                tooltip: 'Back',
+                icon: const Icon(Icons.arrow_back),
+                onPressed: () => Navigator.of(context).maybePop(),
+              ),
+            ),
+            automaticallyImplyLeading: false,
+            title: const Text('John Doe'),
+            subtitle: const Text('Online'),
+            trailing: SizedBox.square(
+              dimension: 48,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {},
+                child: const Center(child: CircleAvatar(radius: 16)),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Walk the semantics tree and find the outer bar node (the one whose
+    // bounds match the toolbar height).
+    SemanticsNode? barNode;
+    void visit(SemanticsNode node) {
+      if (node.rect.height == kStreamToolbarHeight && node.rect.width >= 500) {
+        barNode = node;
+      }
+      node.visitChildren((child) {
+        visit(child);
+        return true;
+      });
+    }
+
+    visit(tester.binding.pipelineOwner.semanticsOwner!.rootSemanticsNode!);
+    expect(barNode, isNotNull);
+
+    // The outer bar node must have NO actions. A leak from a slot would
+    // surface here and collapse the bar to one focus stop.
+    final barActions = barNode!.getSemanticsData().actions;
+    expect(barActions, equals(0), reason: 'Outer bar must not carry leaked actions');
+
+    // Three children: leading, merged title+subtitle, trailing.
+    final children = <SemanticsNode>[];
+    barNode!.visitChildren((child) {
+      children.add(child);
+      return true;
+    });
+    expect(children.length, equals(3));
+
+    // Trailing slot has its own tap-action node.
+    expect(
+      children.last.getSemanticsData().hasAction(SemanticsAction.tap),
+      isTrue,
+    );
+
+    handle.dispose();
+  });
+}

--- a/packages/stream_core_flutter/test/components/toolbar/stream_app_bar_focus_isolation_test.dart
+++ b/packages/stream_core_flutter/test/components/toolbar/stream_app_bar_focus_isolation_test.dart
@@ -61,7 +61,10 @@ void main() {
       });
     }
 
-    visit(tester.binding.rootPipelineOwner.semanticsOwner!.rootSemanticsNode!);
+    // rootPipelineOwner.semanticsOwner is null in test env; the deprecated
+    // pipelineOwner path still points at the semantic root in tests.
+    // ignore: deprecated_member_use
+    visit(tester.binding.pipelineOwner.semanticsOwner!.rootSemanticsNode!);
     expect(barNode, isNotNull);
 
     // The outer bar node must have NO actions. A leak from a slot would

--- a/packages/stream_core_flutter/test/components/toolbar/stream_app_bar_test.dart
+++ b/packages/stream_core_flutter/test/components/toolbar/stream_app_bar_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_core_flutter/core.dart';
 
@@ -79,6 +80,140 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(StreamButton), findsNothing);
+    });
+  });
+
+  group('StreamAppBar semantics', () {
+    testWidgets('auto-implied back button carries the localized Back tooltip', (tester) async {
+      await tester.pumpWidget(_withStreamTheme(const _LauncherScreen()));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip('Back'), findsOneWidget);
+    });
+
+    testWidgets('auto-implied close button carries the localized Close tooltip', (tester) async {
+      await tester.pumpWidget(_withStreamTheme(const _LauncherScreen(fullscreenDialog: true)));
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip('Close'), findsOneWidget);
+    });
+
+    testWidgets('title is marked as a heading by default', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        _withStreamTheme(
+          Scaffold(
+            appBar: StreamAppBar(
+              automaticallyImplyLeading: false,
+              title: const Text('Title'),
+            ),
+          ),
+        ),
+      );
+
+      final data = tester.getSemantics(find.text('Title')).getSemanticsData();
+      expect(data.label, equals('Title'));
+      expect(data.hasFlag(SemanticsFlag.isHeader), isTrue);
+
+      handle.dispose();
+    });
+
+    testWidgets('title names the route on Android', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final handle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(
+          _withStreamTheme(
+            Scaffold(
+              appBar: StreamAppBar(
+                automaticallyImplyLeading: false,
+                title: const Text('Title'),
+              ),
+            ),
+          ),
+        );
+
+        expect(
+          tester.getSemantics(find.text('Title')),
+          matchesSemantics(label: 'Title', isHeader: true, namesRoute: true),
+        );
+      } finally {
+        handle.dispose();
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('title does not name the route on iOS', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      final handle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(
+          _withStreamTheme(
+            Scaffold(
+              appBar: StreamAppBar(
+                automaticallyImplyLeading: false,
+                title: const Text('Title'),
+              ),
+            ),
+          ),
+        );
+
+        // isHeader is set but namesRoute is not — iOS-style platforms
+        // don't expect a route name announcement on entry.
+        final data = tester.getSemantics(find.text('Title')).getSemanticsData();
+        expect(data.hasFlag(SemanticsFlag.isHeader), isTrue);
+        expect(data.hasFlag(SemanticsFlag.namesRoute), isFalse);
+      } finally {
+        handle.dispose();
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('excludeHeaderSemantics omits the heading role', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        _withStreamTheme(
+          Scaffold(
+            appBar: StreamAppBar(
+              automaticallyImplyLeading: false,
+              title: const Text('Title'),
+              excludeHeaderSemantics: true,
+            ),
+          ),
+        ),
+      );
+
+      final data = tester.getSemantics(find.text('Title')).getSemanticsData();
+      expect(data.hasFlag(SemanticsFlag.isHeader), isFalse);
+      expect(data.hasFlag(SemanticsFlag.namesRoute), isFalse);
+
+      handle.dispose();
+    });
+
+    testWidgets('title and subtitle resolve to a single merged semantic node', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        _withStreamTheme(
+          Scaffold(
+            appBar: StreamAppBar(
+              automaticallyImplyLeading: false,
+              title: const Text('John Doe'),
+              subtitle: const Text('Online'),
+            ),
+          ),
+        ),
+      );
+
+      // Both Text widgets project into the same merged node because
+      // MergeSemantics flattens the title + subtitle column.
+      final titleNode = tester.getSemantics(find.text('John Doe'));
+      final subtitleNode = tester.getSemantics(find.text('Online'));
+      expect(identical(titleNode, subtitleNode), isTrue);
+      expect(titleNode.label, equals('John Doe\nOnline'));
+
+      handle.dispose();
     });
   });
 

--- a/packages/stream_core_flutter/test/components/toolbar/stream_app_bar_test.dart
+++ b/packages/stream_core_flutter/test/components/toolbar/stream_app_bar_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stream_core_flutter/core.dart';
 
@@ -115,7 +114,7 @@ void main() {
 
       final data = tester.getSemantics(find.text('Title')).getSemanticsData();
       expect(data.label, equals('Title'));
-      expect(data.hasFlag(SemanticsFlag.isHeader), isTrue);
+      expect(data.flagsCollection.isHeader, isTrue);
 
       handle.dispose();
     });
@@ -163,8 +162,8 @@ void main() {
         // isHeader is set but namesRoute is not — iOS-style platforms
         // don't expect a route name announcement on entry.
         final data = tester.getSemantics(find.text('Title')).getSemanticsData();
-        expect(data.hasFlag(SemanticsFlag.isHeader), isTrue);
-        expect(data.hasFlag(SemanticsFlag.namesRoute), isFalse);
+        expect(data.flagsCollection.isHeader, isTrue);
+        expect(data.flagsCollection.namesRoute, isFalse);
       } finally {
         handle.dispose();
         debugDefaultTargetPlatformOverride = null;
@@ -186,8 +185,8 @@ void main() {
       );
 
       final data = tester.getSemantics(find.text('Title')).getSemanticsData();
-      expect(data.hasFlag(SemanticsFlag.isHeader), isFalse);
-      expect(data.hasFlag(SemanticsFlag.namesRoute), isFalse);
+      expect(data.flagsCollection.isHeader, isFalse);
+      expect(data.flagsCollection.namesRoute, isFalse);
 
       handle.dispose();
     });


### PR DESCRIPTION
## Summary

Design-system-wide accessibility pass touching most reusable primitives in `stream_core_flutter`. Focus areas: screen-reader announcement, focus management, and semantic tree structure. No product/chat-domain code — all changes are generic.

New generic a11y primitives:

- **`StreamAccessibilityAutofocus`** — behavior-only wrapper that requests SR entry focus on its child, with bounded retry, SR-toggle reactivity, and a per-route uniqueness debug assertion.
- **`StreamSemanticsTransitionAnnouncer`** — observes a Listenable, computes a transition message, dispatches via `StreamSemanticsAnnouncer`.

Component updates (each in its own commit):

- `StreamButton` — Semantics + Tooltip moved outside `ElevatedButton`, wrapped in `MergeSemantics` so `selected`/`tooltip` merge cleanly with the button's own node.
- `StreamStepper` — announces as a single `slider` node with `value`/`increasedValue`/`decreasedValue`/`onIncrease`/`onDecrease`; internal +/- buttons and text field are excluded from SR.
- `StreamListTile` — exposes `focusNode` / `autofocus` (mirrors Material `ListTile`).
- `StreamBadgeNotification`, `StreamFileTypeIcon` — accept optional `semanticLabel`.
- `StreamSnackbar` — new `onVisible` callback (fires after entrance, or synchronously when SR is active) for SR announcement hooks.
- `StreamAppBar`, `StreamSheetHeader` — title/subtitle merged; wrapped in `Semantics(header: true, namesRoute: true)` by default with `excludeHeaderSemantics` opt-out; auto-implied leading icon gets `MaterialLocalizations` back/close tooltip.
- `StreamBottomAppBar` — grouped in an outer `Semantics(container: true)`; title/subtitle merge without heading/namesRoute (secondary toolbar).
- `StreamTextInput` — auto-focus-on-a11y-focus behavior gated to desktop platforms; error text moved to its own live-region container.
- Message composer attachment components — new `semanticLabel` + `mergeRemoveAction` props; content sub-trees excluded so the tile is one focus stop with a `remove` tap action.

Skill doc:

- `chore(claude): expand flutter-a11y skill with focus, dispatch, role-annotation guidance` — adds guidance on role-annotation vs. container wrapping, `FocusTraversalGroup` being keyboard-only, and `FocusSemanticEvent` platform mapping / `onDidGainAccessibilityFocus` non-round-trip.

## Test plan

- [ ] `melos run test:flutter` from the core repo passes
- [ ] `melos run analyze` passes
- [ ] `melos run format` passes
- [ ] Manual TalkBack sweep on Android: verify no regression in swipe-nav announcement across the button, stepper, app bar, sheet header, snackbar, and attachment surfaces
- [ ] Manual VoiceOver sweep on iOS: same as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessibility-focused improvements across core components, including optional labels, tooltips, autofocus, focus handling, and better screen-reader announcements.
  * Added a semantics debugger toggle in the gallery to help inspect accessibility behavior.
  * Added support for more accessible sheets, snackbars, app bars, buttons, text inputs, steppers, list tiles, badges, and message attachments.

* **Bug Fixes**
  * Improved screen-reader behavior for selected, disabled, and live-updating content.
  * Refined focus and traversal order so interactive elements are announced more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->