### PR TITLE
ci(repo): grant contents:write to publish_gallery workflow

### DIFF
--- a/.github/workflows/publish_gallery.yml
+++ b/.github/workflows/publish_gallery.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build_and_deploy_gallery:


### PR DESCRIPTION
## Summary
- The `Publish Design System Gallery` workflow force-pushes to `gh-pages` via `bluefireteam/flutter-gh-pages@v9`, which authenticates with `GITHUB_TOKEN`. #127 tightened its permissions to `contents: read`, so pushes now 403.
- Bumps the workflow-level scope to `contents: write` (implies read) to restore the deploy.

## Other workflows reviewed
Audited every workflow in `.github/workflows/`; only `publish_gallery.yml` is affected. `update_goldens.yml` also pushes but authenticates via `BOT_SSH_PRIVATE_KEY`, so its `contents: read` is correct. All other workflows are analyze/test only.

## Test plan
- [ ] Merge and confirm the next `main` push publishes the gallery successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)