### PR TITLE
feat(ui): add chipStyle to StreamReactionsThemeData

### DIFF
--- a/packages/stream_core_flutter/CHANGELOG.md
+++ b/packages/stream_core_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+### ✨ Features
+
+- Added `chipStyle` to `StreamReactionsThemeData` for overriding the per-reaction chip appearance (background, size, etc.); it is merged over the default reaction chip style.
+
 ## 0.4.1
 
 ### ✨ Features

--- a/packages/stream_core_flutter/lib/src/components/reaction/stream_reactions.dart
+++ b/packages/stream_core_flutter/lib/src/components/reaction/stream_reactions.dart
@@ -157,28 +157,7 @@ class StreamReactions extends StatelessWidget {
   Widget build(BuildContext context) {
     final builder = StreamComponentFactory.of(context).reactions;
     if (builder != null) return builder(context, props);
-
-    final spacing = context.streamSpacing;
-    final textTheme = context.streamTextTheme;
-
-    return StreamEmojiChipTheme(
-      data: StreamEmojiChipThemeData(
-        style: StreamEmojiChipThemeStyle(
-          // Reaction chips must shrink to their content width so that multiple
-          // chips fit side-by-side within the bubble bounds. The global default
-          // (64px minimum) is designed for stand-alone emoji chip bars and is
-          // too wide for a segmented reaction row.
-          minimumSize: const Size(32, 24),
-          maximumSize: const Size.fromHeight(24),
-          emojiSize: StreamEmojiSize.sm.value,
-          elevation: .all(props.overlap ? 3 : 0),
-          backgroundColor: .all(context.streamColorScheme.backgroundElevation2),
-          textStyle: .all(textTheme.numericMd.copyWith(fontFeatures: const [.tabularFigures()])),
-          padding: EdgeInsetsGeometry.symmetric(vertical: spacing.xxxs, horizontal: spacing.xs),
-        ),
-      ),
-      child: DefaultStreamReactions(props: props),
-    );
+    return DefaultStreamReactions(props: props);
   }
 }
 
@@ -300,11 +279,14 @@ class DefaultStreamReactions extends StatelessWidget {
     if (props.items.isEmpty) return props.child ?? const SizedBox.shrink();
 
     final reactionTheme = context.streamReactionsTheme;
-    final defaults = _StreamReactionsThemeDefaults(context);
+    final defaults = _StreamReactionsThemeDefaults(context, overlap: props.overlap);
 
     final effectiveSpacing = reactionTheme.spacing ?? defaults.spacing;
     final effectiveGap = reactionTheme.gap ?? defaults.gap;
     final effectiveOverlapExtent = reactionTheme.overlapExtent ?? defaults.overlapExtent;
+    // A composite style, so the theme override is merged over the default
+    // rather than replacing it wholesale (unlike the scalar values above).
+    final effectiveChipStyle = defaults.chipStyle.merge(reactionTheme.chipStyle);
     // Limit is only applied when reactions overlap the child; otherwise show all.
     final maxVisible = props.overlap ? (props.max ?? _kMaxVisibleSegments) : props.items.length;
 
@@ -330,7 +312,12 @@ class DefaultStreamReactions extends StatelessWidget {
     };
 
     // Standalone mode — no child to position relative to.
-    if (props.child == null) return reactionStrip;
+    if (props.child == null) {
+      return StreamEmojiChipTheme(
+        data: .new(style: effectiveChipStyle),
+        child: reactionStrip,
+      );
+    }
 
     // Negative spacing when overlapping makes reactions overlap the child edge.
     final columnSpacing = props.overlap ? -effectiveOverlapExtent : effectiveGap;
@@ -370,18 +357,21 @@ class DefaultStreamReactions extends StatelessWidget {
     // like ListView(shrinkWrap: true) inside it receive a bounded width.
     // Resolution still treats it as a regular child — column width remains
     // max(bubble, strip).
-    return StreamIntrinsicColumn(
-      spacing: columnSpacing,
-      crossAxisAlignment: effectiveCrossAxisAlignment,
-      clipBehavior: props.clipBehavior,
-      verticalDirection: switch (effectivePosition) {
-        .header => VerticalDirection.up,
-        .footer => VerticalDirection.down,
-      },
-      children: [
-        StreamIntrinsicBoundedCrossAxis(child: props.child!),
-        alignedStrip,
-      ],
+    return StreamEmojiChipTheme(
+      data: .new(style: effectiveChipStyle),
+      child: StreamIntrinsicColumn(
+        spacing: columnSpacing,
+        crossAxisAlignment: effectiveCrossAxisAlignment,
+        clipBehavior: props.clipBehavior,
+        verticalDirection: switch (effectivePosition) {
+          .header => VerticalDirection.up,
+          .footer => VerticalDirection.down,
+        },
+        children: [
+          StreamIntrinsicBoundedCrossAxis(child: props.child!),
+          alignedStrip,
+        ],
+      ),
     );
   }
 
@@ -433,11 +423,14 @@ class DefaultStreamReactions extends StatelessWidget {
 // Used by [DefaultStreamReactions] as a fallback when a property is not
 // explicitly set in the inherited theme.
 class _StreamReactionsThemeDefaults extends StreamReactionsThemeData {
-  _StreamReactionsThemeDefaults(this._context);
+  _StreamReactionsThemeDefaults(this._context, {required this.overlap});
 
   final BuildContext _context;
 
+  final bool overlap;
+
   late final _spacing = _context.streamSpacing;
+  late final _textTheme = _context.streamTextTheme;
 
   @override
   double get spacing => _spacing.xxs;
@@ -447,6 +440,21 @@ class _StreamReactionsThemeDefaults extends StreamReactionsThemeData {
 
   @override
   double get overlapExtent => _spacing.xs;
+
+  @override
+  StreamEmojiChipThemeStyle get chipStyle => StreamEmojiChipThemeStyle(
+    // Reaction chips must shrink to their content width so that multiple
+    // chips fit side-by-side within the bubble bounds. The global default
+    // (64px minimum) is designed for stand-alone emoji chip bars and is
+    // too wide for a segmented reaction row.
+    minimumSize: const Size(32, 24),
+    maximumSize: const Size.fromHeight(24),
+    emojiSize: StreamEmojiSize.sm.value,
+    elevation: .all(overlap ? 3 : 0),
+    backgroundColor: .all(_context.streamColorScheme.backgroundElevation2),
+    textStyle: .all(_textTheme.numericMd.copyWith(fontFeatures: const [.tabularFigures()])),
+    padding: .symmetric(vertical: _spacing.xxxs, horizontal: _spacing.xs),
+  );
 }
 
 /// Adapts an [Offset] for the current [TextDirection].

--- a/packages/stream_core_flutter/lib/src/theme/components/stream_reactions_theme.dart
+++ b/packages/stream_core_flutter/lib/src/theme/components/stream_reactions_theme.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:theme_extensions_builder_annotation/theme_extensions_builder_annotation.dart';
 
 import '../stream_theme.dart';
+import 'stream_emoji_chip_theme.dart';
 
 part 'stream_reactions_theme.g.theme.dart';
 
@@ -128,6 +129,7 @@ class StreamReactionsThemeData with _$StreamReactionsThemeData {
     this.spacing,
     this.gap,
     this.overlapExtent,
+    this.chipStyle,
   });
 
   /// The gap between adjacent reaction chips.
@@ -142,6 +144,12 @@ class StreamReactionsThemeData with _$StreamReactionsThemeData {
   ///
   /// Higher values move the reactions further into the child.
   final double? overlapExtent;
+
+  /// The style applied to each reaction chip.
+  ///
+  /// Merged over the default reaction chip appearance, so unset properties
+  /// fall back to those defaults.
+  final StreamEmojiChipThemeStyle? chipStyle;
 
   /// Linearly interpolate between two [StreamReactionsThemeData] objects.
   static StreamReactionsThemeData? lerp(

--- a/packages/stream_core_flutter/lib/src/theme/components/stream_reactions_theme.g.theme.dart
+++ b/packages/stream_core_flutter/lib/src/theme/components/stream_reactions_theme.g.theme.dart
@@ -33,6 +33,7 @@ mixin _$StreamReactionsThemeData {
       spacing: lerpDouble$(a.spacing, b.spacing, t),
       gap: lerpDouble$(a.gap, b.gap, t),
       overlapExtent: lerpDouble$(a.overlapExtent, b.overlapExtent, t),
+      chipStyle: StreamEmojiChipThemeStyle.lerp(a.chipStyle, b.chipStyle, t),
     );
   }
 
@@ -40,6 +41,7 @@ mixin _$StreamReactionsThemeData {
     double? spacing,
     double? gap,
     double? overlapExtent,
+    StreamEmojiChipThemeStyle? chipStyle,
   }) {
     final _this = (this as StreamReactionsThemeData);
 
@@ -47,6 +49,7 @@ mixin _$StreamReactionsThemeData {
       spacing: spacing ?? _this.spacing,
       gap: gap ?? _this.gap,
       overlapExtent: overlapExtent ?? _this.overlapExtent,
+      chipStyle: chipStyle ?? _this.chipStyle,
     );
   }
 
@@ -65,6 +68,7 @@ mixin _$StreamReactionsThemeData {
       spacing: other.spacing,
       gap: other.gap,
       overlapExtent: other.overlapExtent,
+      chipStyle: _this.chipStyle?.merge(other.chipStyle) ?? other.chipStyle,
     );
   }
 
@@ -83,7 +87,8 @@ mixin _$StreamReactionsThemeData {
 
     return _other.spacing == _this.spacing &&
         _other.gap == _this.gap &&
-        _other.overlapExtent == _this.overlapExtent;
+        _other.overlapExtent == _this.overlapExtent &&
+        _other.chipStyle == _this.chipStyle;
   }
 
   @override
@@ -95,6 +100,7 @@ mixin _$StreamReactionsThemeData {
       _this.spacing,
       _this.gap,
       _this.overlapExtent,
+      _this.chipStyle,
     );
   }
 }

--- a/packages/stream_core_flutter/test/components/reaction/stream_reactions_test.dart
+++ b/packages/stream_core_flutter/test/components/reaction/stream_reactions_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/chat.dart';
+
+void main() {
+  Widget buildSubject({
+    StreamEmojiChipThemeData? emojiChipTheme,
+    StreamReactionsThemeData? reactionsTheme,
+    StreamReactionsThemeData? localReactionsTheme,
+  }) {
+    Widget reactions = StreamReactions.segmented(
+      items: const [
+        StreamReactionsItem(emoji: StreamUnicodeEmoji('👍'), count: 3),
+        StreamReactionsItem(emoji: StreamUnicodeEmoji('❤️'), count: 2),
+      ],
+    );
+
+    if (localReactionsTheme case final data?) {
+      reactions = StreamReactionsTheme(data: data, child: reactions);
+    }
+
+    return MaterialApp(
+      home: Theme(
+        data: ThemeData(
+          extensions: [
+            StreamTheme(
+              emojiChipTheme: emojiChipTheme ?? const StreamEmojiChipThemeData(),
+              reactionsTheme: reactionsTheme ?? const StreamReactionsThemeData(),
+            ),
+          ],
+        ),
+        child: Scaffold(body: reactions),
+      ),
+    );
+  }
+
+  ButtonStyle chipStyle(WidgetTester tester) {
+    final button = tester.widgetList<IconButton>(find.byType(IconButton)).first;
+    return button.style!;
+  }
+
+  Color? resolvedChipBackground(WidgetTester tester) {
+    return chipStyle(tester).backgroundColor?.resolve(<WidgetState>{});
+  }
+
+  group('reaction chip background resolution', () {
+    testWidgets('falls back to the elevated reaction default', (tester) async {
+      await tester.pumpWidget(buildSubject());
+
+      final context = tester.element(find.byType(DefaultStreamReactions));
+      expect(
+        resolvedChipBackground(tester),
+        context.streamColorScheme.backgroundElevation2,
+      );
+    });
+
+    testWidgets('honors a reactionsTheme.chipStyle override', (tester) async {
+      const green = Color(0xFF4CAF50);
+      await tester.pumpWidget(
+        buildSubject(
+          reactionsTheme: const StreamReactionsThemeData(
+            chipStyle: StreamEmojiChipThemeStyle(
+              backgroundColor: WidgetStatePropertyAll(green),
+            ),
+          ),
+        ),
+      );
+
+      expect(resolvedChipBackground(tester), green);
+    });
+
+    testWidgets('does not leak a generic emoji chip background into reactions', (
+      tester,
+    ) async {
+      const amber = Color(0xFFFFC107);
+      await tester.pumpWidget(
+        buildSubject(
+          emojiChipTheme: const StreamEmojiChipThemeData(
+            style: StreamEmojiChipThemeStyle(
+              backgroundColor: WidgetStatePropertyAll(amber),
+            ),
+          ),
+        ),
+      );
+
+      // Reaction chips are themed only via reactionsTheme, so a generic emoji
+      // chip theme must not leak into their background.
+      final context = tester.element(find.byType(DefaultStreamReactions));
+      expect(
+        resolvedChipBackground(tester),
+        context.streamColorScheme.backgroundElevation2,
+      );
+    });
+
+    testWidgets('merges a partial override over the reaction defaults', (
+      tester,
+    ) async {
+      const green = Color(0xFF4CAF50);
+      await tester.pumpWidget(
+        buildSubject(
+          reactionsTheme: const StreamReactionsThemeData(
+            chipStyle: StreamEmojiChipThemeStyle(
+              backgroundColor: WidgetStatePropertyAll(green),
+            ),
+          ),
+        ),
+      );
+
+      // Background is overridden, but the reaction-specific sizing default
+      // survives because chipStyle is merged, not replaced.
+      expect(resolvedChipBackground(tester), green);
+      expect(
+        chipStyle(tester).minimumSize?.resolve(<WidgetState>{}),
+        const Size(32, 24),
+      );
+    });
+
+    testWidgets('honors a chipStyle override from a wrapping StreamReactionsTheme', (
+      tester,
+    ) async {
+      const blue = Color(0xFF2196F3);
+      await tester.pumpWidget(
+        buildSubject(
+          localReactionsTheme: const StreamReactionsThemeData(
+            chipStyle: StreamEmojiChipThemeStyle(
+              backgroundColor: WidgetStatePropertyAll(blue),
+            ),
+          ),
+        ),
+      );
+
+      expect(resolvedChipBackground(tester), blue);
+    });
+
+    testWidgets('local StreamReactionsTheme wins over the global reactionsTheme', (
+      tester,
+    ) async {
+      const green = Color(0xFF4CAF50);
+      const blue = Color(0xFF2196F3);
+      await tester.pumpWidget(
+        buildSubject(
+          reactionsTheme: const StreamReactionsThemeData(
+            chipStyle: StreamEmojiChipThemeStyle(
+              backgroundColor: WidgetStatePropertyAll(green),
+            ),
+          ),
+          localReactionsTheme: const StreamReactionsThemeData(
+            chipStyle: StreamEmojiChipThemeStyle(
+              backgroundColor: WidgetStatePropertyAll(blue),
+            ),
+          ),
+        ),
+      );
+
+      expect(resolvedChipBackground(tester), blue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Reaction chip appearance (background, size, elevation, …) was hardcoded inside `StreamReactions` and could not be overridden. The documented `StreamEmojiChipTheme` was silently shadowed for reaction chips, so integrators had no supported way to, e.g., recolor the per-emoji chip background.

This adds a first-class `chipStyle` to `StreamReactionsThemeData`, giving reactions their own scoped styling surface — the same shape Flutter uses for `AppBarTheme.actionsIconTheme` / `DatePickerThemeData.*ButtonStyle` (a component theme carrying a child sub-style).

## What changed

- **`StreamReactionsThemeData.chipStyle: StreamEmojiChipThemeStyle?`** — new field (+ regenerated `.g.theme.dart` for `copyWith`/`merge`/`lerp`/`==`/`hashCode`).
- **`_StreamReactionsThemeDefaults.chipStyle`** — the reaction-specific default (32×24 sizing, elevated background, etc.), now a context-aware default like `spacing`/`gap`/`overlapExtent` instead of a hardcoded block.
- **`DefaultStreamReactions`** — resolves `defaults.chipStyle.merge(reactionTheme.chipStyle)` and injects the scoped `StreamEmojiChipTheme`. `StreamReactions.build` is now a thin factory-or-default switch.
- `merge` (not `??`) so a **partial** override — e.g. only `backgroundColor` — keeps the reaction-specific sizing defaults instead of falling back to the generic 64px chip defaults.

## Behavior / usage

Reactions are self-contained: styled via `reactionsTheme`, not the generic `StreamEmojiChipTheme`.

```dart
// Global
StreamTheme(
  reactionsTheme: StreamReactionsThemeData(
    chipStyle: StreamEmojiChipThemeStyle(
      backgroundColor: WidgetStatePropertyAll(myColor),
    ),
  ),
);

// Or scoped to a subtree
StreamReactionsTheme(
  data: StreamReactionsThemeData(chipStyle: ...),
  child: ...,
);
```

Additive, non-breaking (new nullable field; defaults unchanged).

## Tests

New `test/components/reaction/stream_reactions_test.dart` (6 cases), all asserting the actual rendered `IconButton` `ButtonStyle`:

- default falls back to the elevated reaction background
- global `reactionsTheme.chipStyle` override applies
- wrapping `StreamReactionsTheme` override applies
- local `StreamReactionsTheme` wins over global `reactionsTheme`
- partial override merges over defaults (background changes, `minimumSize` 32×24 survives)
- a generic `StreamEmojiChipTheme` background does not leak into reactions

## Notes for reviewer

- Not run through `dart format`: the local toolchain (Dart 3.12.0) reflows the file to tall-style and diverges from the rest of the repo's committed style. Edits are hand-matched to the surrounding style; please run the repo's formatter if CI expects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable reaction chip styling through the reactions theme.
  * Supports partial style overrides while preserving default reaction-specific settings.
  * Local reaction theme overrides take precedence over global settings.
  * Reaction chip styling now adapts consistently across standalone and attached layouts.

* **Bug Fixes**
  * Improved theme resolution so unrelated emoji chip themes do not unintentionally affect reaction chips.

* **Tests**
  * Added coverage for default styling, custom overrides, style merging, and theme precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->