### PR TITLE
feat(ui): configure `StreamNetworkImage` cache manager with LRU eviction

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -18,7 +18,7 @@ command:
 
     # List of all the dependencies used in the project.
     dependencies:
-      cached_network_image: ^3.4.1
+      cached_network_image_ce: ^4.9.0
       collection: ^1.19.0
       cross_file: ^0.3.4+2
       dio: ^5.8.0+1
@@ -33,6 +33,8 @@ command:
       material_color_utilities: '>=0.11.0 <0.14.0'
       meta: ^1.15.0
       mime: ^2.0.0
+      path: ^1.9.0
+      path_provider: ^2.1.5
       plugin_platform_interface: ^2.1.8
       rxdart: ^0.28.0
       shimmer: ^3.0.0

--- a/packages/stream_core_flutter/CHANGELOG.md
+++ b/packages/stream_core_flutter/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added `isFloating` to the default `StreamButton` constructor — the floating (elevated) appearance was previously reachable only through `StreamButton.icon`. Labelled buttons now get the same treatment: elevation for every type, plus a `backgroundElevation1` fill for `outline` and `ghost`.
 - Added `StreamElevation` — the four elevation levels of the design system as logical pixels, for passing to `Material.elevation` or a component theme's `elevation` field. Like `StreamRadius` and `StreamSpacing` it is a theme primitive: reachable as `StreamTheme.elevation` or `context.streamElevation`, overridable per theme through the `StreamTheme` constructor, and lerped on theme transitions. `StreamElevation.none` is a fixed `0` rather than a themeable level, so "flat" cannot be redefined as elevated. `StreamAvatar` and `StreamButton` now resolve their elevations from it instead of hard-coded numbers; the rendered values are unchanged.
 - Added `chipStyle` to `StreamReactionsThemeData` for overriding the per-reaction chip appearance (background, size, etc.); it is merged over the default reaction chip style.
+- `StreamNetworkImage` now caches through a shared cache manager which, on IO platforms, is stored in its own app-scoped directory (isolated from the host app's image cache) with LRU eviction, while other platforms fall back to the library defaults.
 
 ### 🐛 Bug Fixes
 

--- a/packages/stream_core_flutter/check_barrels.yaml
+++ b/packages/stream_core_flutter/check_barrels.yaml
@@ -26,3 +26,4 @@ forbidden_src_imports:
 # internal to the package. Anything under these is excluded from coverage.
 internal_dirs:
   - lib/src/theme/primitives/internal
+  - lib/src/cache/internal

--- a/packages/stream_core_flutter/lib/src/cache/internal/stream_image_cache.dart
+++ b/packages/stream_core_flutter/lib/src/cache/internal/stream_image_cache.dart
@@ -1,0 +1,25 @@
+import 'package:cached_network_image_ce/cached_network_image.dart' show BaseCacheManager;
+
+import 'stream_image_cache_factory.dart' if (dart.library.io) 'stream_image_cache_factory_io.dart';
+
+/// Stream-owned shared image cache backing every `StreamNetworkImage`.
+///
+/// A single [BaseCacheManager] (from `cached_network_image_ce`) is shared by
+/// all network images so the whole SDK caches through one place. On native
+/// platforms it evicts least-recently-used entries first once the cache is
+/// full; on web it keeps the same size limit but falls back to the library's
+/// default eviction ordering. Cache size and stale period use the underlying
+/// library defaults.
+///
+/// This is an internal implementation detail of `StreamNetworkImage` and is
+/// not part of the package's public API.
+final class StreamImageCache {
+  StreamImageCache._();
+
+  /// The shared cache manager, created lazily on first access.
+  ///
+  /// Dart initializes `static final` fields lazily, so the underlying
+  /// `DefaultCacheManager` (which touches the temp dir / Hive) is only built
+  /// when the first image actually loads.
+  static final BaseCacheManager manager = createStreamCacheManager();
+}

--- a/packages/stream_core_flutter/lib/src/cache/internal/stream_image_cache_factory.dart
+++ b/packages/stream_core_flutter/lib/src/cache/internal/stream_image_cache_factory.dart
@@ -1,0 +1,22 @@
+import 'package:cached_network_image_ce/cached_network_image.dart';
+
+/// Builds the shared image cache manager for the current platform.
+///
+/// This is the default (non-IO) implementation, used on web and any platform
+/// where `DefaultCacheManager` does not accept a custom `CleanupStrategy` or
+/// `cacheDirectoryProvider`.
+///
+/// Unlike the IO variant, this returns the library's own shared
+/// [CachedNetworkImageProvider.defaultCacheManager] rather than a fresh
+/// `DefaultCacheManager()`. On web there is no cache directory to namespace, so
+/// every `DefaultCacheManager` opens the same fixed-name IndexedDB store — the
+/// isolation the IO variant achieves is impossible here. Constructing a second
+/// manager would only put two independent instances (each with its own Hive
+/// handle) on that one store; reusing the library default keeps web behaviour
+/// identical to a plain `CachedNetworkImage` and avoids that duplication. The
+/// cache keeps the library's default size limits and eviction ordering (TTL).
+///
+/// The IO implementation in `stream_image_cache_factory_io.dart` selects
+/// `LruCleanupStrategy` and an isolated directory; the correct file is chosen
+/// via a conditional import in `stream_image_cache.dart`.
+BaseCacheManager createStreamCacheManager() => CachedNetworkImageProvider.defaultCacheManager;

--- a/packages/stream_core_flutter/lib/src/cache/internal/stream_image_cache_factory_io.dart
+++ b/packages/stream_core_flutter/lib/src/cache/internal/stream_image_cache_factory_io.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:cached_network_image_ce/cached_network_image.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// Builds the shared image cache manager on IO platforms.
+///
+/// Uses [LruCleanupStrategy] so that, once the cache exceeds the library's
+/// default object limit, the least-recently-used entries are evicted first.
+///
+/// The manager's base directory is pinned to a dedicated `stream_image_cache`
+/// folder inside the app-scoped temporary directory ([getTemporaryDirectory]);
+/// the library then nests its own `cached_network_image_ce` folder under that,
+/// so files actually land at `<temp>/stream_image_cache/cached_network_image_ce`.
+/// A bare `DefaultCacheManager()` instead stores its files and Hive metadata box
+/// under `<temp>/cached_network_image_ce` — the same location the library's
+/// package-default manager (`CachedNetworkImageProvider.defaultCacheManager`)
+/// uses. Two managers sharing that directory keep separate, mutually-unaware
+/// metadata boxes, so each one's background orphan sweep can delete the other's
+/// cached files (see the warning in the library's own
+/// `default_cache_manager.dart`). Storing this manager under a dedicated
+/// sub-directory keeps it isolated from the package default — and from any
+/// other `cached_network_image_ce` manager that leaves the base temp directory
+/// untouched.
+///
+/// The base is resolved via `path_provider` rather than `Directory.systemTemp`
+/// so the cache lands in the platform's app-scoped temp location (which is not
+/// always where the raw OS temp root points on Android/desktop).
+///
+/// `cleanupStrategy` and `cacheDirectoryProvider` exist only on the IO
+/// `DefaultCacheManager`, which is why this variant is isolated behind a
+/// conditional import.
+BaseCacheManager createStreamCacheManager() {
+  // These named parameters exist only on the IO `DefaultCacheManager`. When the
+  // analyzer resolves the package's conditional export against the
+  // platform-agnostic (stub) variant it cannot see them, but this file is only
+  // ever compiled for IO targets, where they are valid. This is a permanent
+  // consequence of the conditional export, not a temporary workaround.
+  return DefaultCacheManager(
+    // ignore: undefined_named_parameter
+    cleanupStrategy: const LruCleanupStrategy(),
+    // ignore: undefined_named_parameter
+    cacheDirectoryProvider: () async {
+      final tempDir = await getTemporaryDirectory();
+      return Directory(p.join(tempDir.path, 'stream_image_cache'));
+    },
+  );
+}

--- a/packages/stream_core_flutter/lib/src/components/common/stream_network_image.dart
+++ b/packages/stream_core_flutter/lib/src/components/common/stream_network_image.dart
@@ -1,6 +1,7 @@
 import 'package:cached_network_image_ce/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
+import '../../cache/internal/stream_image_cache.dart';
 import '../../factory/stream_component_factory.dart';
 import '../../theme/stream_theme_extensions.dart';
 import '../badge/stream_retry_badge.dart';
@@ -124,7 +125,7 @@ class StreamNetworkImage extends StatelessWidget {
   /// This is intended for development and testing purposes only.
   @visibleForTesting
   static Future<bool> evictFromCache(String url, {String? cacheKey}) {
-    return CachedNetworkImage.evictFromCache(url, cacheKey: cacheKey);
+    return CachedNetworkImage.evictFromCache(url, cacheKey: cacheKey, cacheManager: StreamImageCache.manager);
   }
 
   @override
@@ -330,6 +331,7 @@ class _DefaultStreamNetworkImageState extends State<DefaultStreamNetworkImage> {
     return CachedNetworkImage(
       key: ValueKey(_retryKey),
       imageUrl: props.url,
+      cacheManager: StreamImageCache.manager,
       httpHeaders: props.httpHeaders,
       width: props.width,
       height: props.height,

--- a/packages/stream_core_flutter/pubspec.yaml
+++ b/packages/stream_core_flutter/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.38.1"
 
 dependencies:
-  cached_network_image_ce: ^4.6.3
+  cached_network_image_ce: ^4.9.0
   collection: ^1.19.0
   flutter:
     sdk: flutter
@@ -16,6 +16,8 @@ dependencies:
   flutter_svg: ^2.2.3
   markdown: ^7.3.0
   material_color_utilities: ">=0.11.0 <0.14.0"
+  path: ^1.9.0
+  path_provider: ^2.1.5
   shimmer: ^3.0.0
   stream_core: ^0.4.0
   svg_icon_widget: ^0.0.1+1

--- a/packages/stream_core_flutter/test/cache/internal/stream_image_cache_factory_io_test.dart
+++ b/packages/stream_core_flutter/test/cache/internal/stream_image_cache_factory_io_test.dart
@@ -1,0 +1,27 @@
+import 'package:cached_network_image_ce/cached_network_image.dart';
+import 'package:flutter_test/flutter_test.dart';
+// Imported directly (rather than through the `stream_image_cache.dart`
+// conditional import) so this test always compiles the IO factory against the
+// real IO `DefaultCacheManager`.
+import 'package:stream_core_flutter/src/cache/internal/stream_image_cache_factory_io.dart';
+
+void main() {
+  group('createStreamCacheManager (IO)', () {
+    // Signature-drift guard. `stream_image_cache_factory_io.dart` passes
+    // `cleanupStrategy` and `cacheDirectoryProvider`, which exist only on the IO
+    // `DefaultCacheManager`, behind `// ignore: undefined_named_parameter` — the
+    // analyzer resolves the package's conditional export against the stub variant
+    // and cannot see those parameters. That suppression means `melos run analyze`
+    // cannot catch a future `cached_network_image_ce` release that renames or
+    // removes either parameter. On the VM, however, this test compiles against
+    // the real IO constructor, so such a break fails the test suite here instead
+    // of shipping.
+    //
+    // Construction is filesystem-free: `DefaultCacheManager` only touches the
+    // temp dir / Hive box lazily on the first fetch, so this test needs no test
+    // binding and never writes to disk.
+    test('builds the shared cache manager on IO', () {
+      expect(createStreamCacheManager(), isA<BaseCacheManager>());
+    });
+  });
+}

--- a/packages/stream_core_flutter/test/components/common/stream_network_image_test.dart
+++ b/packages/stream_core_flutter/test/components/common/stream_network_image_test.dart
@@ -1,0 +1,39 @@
+import 'package:cached_network_image_ce/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stream_core_flutter/core.dart';
+
+Widget _withStreamTheme(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [StreamTheme()]),
+    home: Scaffold(body: Center(child: child)),
+  );
+}
+
+void main() {
+  group('StreamNetworkImage caching', () {
+    testWidgets('routes all images through one shared cache manager', (tester) async {
+      await tester.pumpWidget(
+        _withStreamTheme(
+          Column(
+            children: [
+              StreamNetworkImage('https://example.com/a.png'),
+              StreamNetworkImage('https://example.com/b.png'),
+            ],
+          ),
+        ),
+      );
+
+      final images = tester.widgetList<CachedNetworkImage>(find.byType(CachedNetworkImage)).toList();
+      expect(images, hasLength(2));
+
+      // A Stream-owned cache manager is wired in (not the package default,
+      // which would leave the widget's cacheManager null).
+      expect(images.first.cacheManager, isNotNull);
+
+      // Every StreamNetworkImage shares the SAME cache manager instance, so the
+      // whole SDK caches (and evicts) through one place.
+      expect(images.first.cacheManager, same(images.last.cacheManager));
+    });
+  });
+}


### PR DESCRIPTION
<!--Internal tickets have to be added by Stream devs-->
Linear: [FLU-598](https://linear.app/stream/issue/FLU-598/imagedisk-cache-configure-cachemanager-with-size-limit)
<!--Optional to add github issue which is solved by this PR-->
Github Issue: #

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Routes every `StreamNetworkImage` through a **single shared cache manager**
(`StreamImageCache.manager`) instead of the library's package-default one, so the
whole SDK caches images in one place that we control.

### What changed

- **`StreamImageCache`** — a lazily-created, process-wide `BaseCacheManager`
  (from `cached_network_image_ce`) shared by every `StreamNetworkImage`. Within
  this package that is `StreamAvatar` and `StreamEmoji` (both render through
  `StreamNetworkImage`); every downstream consumer inherits it too — e.g. in the
  chat SDK, message image attachments and the composer header preview.
- **Platform-specific factory** (conditional import):
  - **IO** (Android / iOS / macOS / desktop) — a `DefaultCacheManager` configured
    with `LruCleanupStrategy` and a dedicated `cacheDirectoryProvider` pinned to
    `<app-temp>/stream_image_cache/`. The library then nests its own
    `cached_network_image_ce/` folder under that.
  - **Web** — reuses the library's shared `CachedNetworkImageProvider.defaultCacheManager`
    (no filesystem to namespace, so per-instance isolation is impossible).
- **Dependency bumps** — `cached_network_image_ce` `^4.6.3 → ^4.9.0`, which
  provides the `cleanupStrategy` and `cacheDirectoryProvider` parameters on
  `DefaultCacheManager` that the IO factory relies on (LRU `CleanupStrategy` was
  introduced in 4.8.0). Plus `path` and `path_provider`. Mirrored in the
  workspace `melos.yaml`.
- **Barrel contract** — `lib/src/cache/internal` registered under `internal_dirs`
  in `check_barrels.yaml` (implementation-only, excluded from the public barrels).

### Benefits

- **Size-limited & self-evicting.** On IO the cache honours the library's object
  limit and evicts **least-recently-used** entries first once full, so image disk
  usage stays bounded — the core ask of FLU-598.
- **Isolated from the host app.** A bare `DefaultCacheManager()` (which many apps
  use directly) stores its files + Hive metadata under `<temp>/cached_network_image_ce`.
  Two managers sharing that directory keep separate, mutually-unaware metadata
  boxes, so each one's orphan sweep can delete the other's files. Nesting our
  manager under a dedicated `stream_image_cache/` sub-directory prevents that.
- **One cache for the whole SDK.** Avatars and attachments share a single store
  and a single eviction policy, and `evictFromCache` (used by the tap-to-retry
  path) targets that same manager.
- **No public API change.** `StreamNetworkImage`'s signature is unchanged;
  `StreamImageCache` is an internal detail.

### Shortcomings / limitations (intentional, documented here for review)

- **Web caching is unchanged and is *not* SDK-managed.** `CachedNetworkImage`
  defaults to `ImageRenderMethodForWeb.HtmlImage`, which renders via
  `ui_web.createImageCodecFromUrl(url)` — a direct browser fetch. On web the cache
  manager (and its IndexedDB stores) is **never consulted for rendering**; caching
  is the browser's HTTP cache. This is **pre-existing behaviour**, not a regression
  (both the old and new `cached_network_image_ce` default to `HtmlImage`, and we
  never set the render method). Consequence: web gets no size limit / LRU / offline
  guarantees from this cache, and `httpHeaders` are unsupported on web with
  `HtmlImage` (the library throws). Opting web into SDK-managed caching would mean
  passing `ImageRenderMethodForWeb.HttpGet`, which has its own trade-offs
  (Dart-side decode, memory, GIF/anim differences) — deliberately left out of scope.
- **Cache size and stale period use the library defaults** (~200 objects / 7-day
  stale) and are not yet consumer-configurable. A follow-up could expose a knob.
- **Eviction runs at manager init (≈ app launch), not continuously.** The library
  sweeps once when the manager first initialises, so within a single long-lived
  session the on-disk count can exceed the limit until the next launch. This is
  `cached_network_image_ce` behaviour, surfaced here for awareness.

### How this was tested

- **Unit:** `stream_network_image_test.dart` asserts all images route through the
  one shared manager; `stream_image_cache_factory_io_test.dart` is a signature-drift
  guard that compiles the IO factory against the real IO constructor on the VM.
- **Manual, via the `stream_chat_flutter` sample app** (local path override to this
  branch):
  - **Android & iOS** — loaded avatars + image attachments + a GIF, disabled
    connectivity, killed and relaunched: images still rendered from disk (proving
    cross-session disk cache + offline). Confirmed on-disk that the files land
    under `…/stream_image_cache/cached_network_image_ce/` (isolated dir) with the
    Hive metadata box.
  - **macOS** — confirmed the IO factory is selected and cached avatar files + the
    Hive box land in the same isolated `stream_image_cache/` dir under the app
    sandbox (desktop + sandbox path verification).
  - **Web (Chrome)** — confirmed the browser-cache behaviour described above (the
    SDK manager is instantiated but not used for rendering).

## Screenshots / Videos

<!-- Consider to add screenshots and/or videos to show the effect of the change -->

| Before | After |
| --- | --- |
| img | img |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved network image caching with one shared cache across image components.
  * Added app-scoped cache storage with automatic LRU eviction on supported platforms.
  * Preserved standard caching behavior on web and other platforms.

* **Bug Fixes**
  * Reduced duplicate cache managers and improved cache consistency for network images.

* **Tests**
  * Added coverage verifying shared cache usage and platform-specific cache manager creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->